### PR TITLE
Make MoistAirBuoyancy a concrete type + adapt for MoistAirBuoyancy utilities

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -5,4 +5,4 @@ Oceananigans = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
 
 [compat]
 Documenter = "1"
-CairoMakie = "0.13, 0.14, 0.15"
+CairoMakie = "0.13, 0.14"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -5,3 +5,4 @@ Oceananigans = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
 
 [compat]
 Documenter = "1"
+CairoMakie = "0.13, 0.14, 0.15"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,8 @@
 using Breeze
 using Documenter
 
+using Breeze.AtmosphereModels
+
 DocMeta.setdocmeta!(Breeze, :DocTestSetup, :(using Breeze); recursive=true)
 
 makedocs(sitename="Breeze",

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,8 +1,27 @@
 # API Documentation
 
+```@autodocs
+Modules = [Breeze]
+Private = false
+```
+
 ## Thermodynamics
 
-```@docs
-Breeze.AtmosphereThermodynamics
-Breeze.Thermodynamics.saturation_vapor_pressure
+```@autodocs
+Modules = [Breeze.Thermodynamics]
+Private = false
+```
+
+## MoistAirBuoyancies
+
+```@autodocs
+Modules = [Breeze.MoistAirBuoyancies]
+Private = false
+```
+
+## AtmosphereModels
+
+```@autodocs
+Modules = [Breeze.AtmosphereModels]
+Private = false
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -63,7 +63,7 @@ Tₛ = reference_constants.reference_potential_temperature # K
 qᵢ(x, z) = 0 # 1e-2 + 1e-5 * rand()
 set!(model, θ=θᵢ, q=qᵢ)
 
-simulation = Simulation(model, Δt=10, stop_time=20)#hours)
+simulation = Simulation(model, Δt=10, stop_time=2hours)
 conjure_time_step_wizard!(simulation, cfl=0.7)
 
 run!(simulation)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -11,12 +11,12 @@ Under the hood, Breeze's abstractions, design, and finite volume engine are base
 
 Breeze provides two ways to simulate atmospheric flows:
 
-* A `MoistAirBuoyancy` that can be used with Oceananigans' `NonhydrostaticModel` to simulate atmospheric flows with the Boussinesq approximation.
-* A prototype `AtmosphereModel`, which uses the anelastic approximation following [Pauluis 2008](https://journals.ametsoc.org/view/journals/atsc/65/8/2007jas2475.1.xml).
+* A [`MoistAirBuoyancy`](@ref) that can be used with Oceananigans' `NonhydrostaticModel` to simulate atmospheric flows with the Boussinesq approximation.
+* A prototype [`AtmosphereModel`](@ref Breeze.AtmosphereModels.AtmosphereModel) that uses the anelastic approximation following [Pauluis (2008)](https://journals.ametsoc.org/view/journals/atsc/65/8/200s7jas2475.1.xml).
 
 ## Installation
 
-To use Breeze, install directly from github:
+To use Breeze, install directly from GitHub:
 
 ```julia
 using Pkg
@@ -29,7 +29,7 @@ A basic free convection simulation:
 
 ```@setup intro
 using CairoMakie
-CairoMakie.activate!(type = "png")
+CairoMakie.activate!(type = "svg")
 ```
 
 ```@example intro
@@ -57,13 +57,13 @@ model = NonhydrostaticModel(; grid, advection, buoyancy,
                             tracers = (:θ, :q),
                             boundary_conditions = (θ=θ_bcs, q=q_bcs))
 
-Δθ = 5 # K
+Δθ = 5 # ᵒK
 Tₛ = reference_constants.reference_potential_temperature # K
 θᵢ(x, z) = Tₛ + Δθ * z / grid.Lz + 1e-2 * Δθ * randn()
 qᵢ(x, z) = 0 # 1e-2 + 1e-5 * rand()
 set!(model, θ=θᵢ, q=qᵢ)
 
-simulation = Simulation(model, Δt=10, stop_time=2hours)
+simulation = Simulation(model, Δt=10, stop_time=20)#hours)
 conjure_time_step_wizard!(simulation, cfl=0.7)
 
 run!(simulation)

--- a/src/AtmosphereModels/AtmosphereModels.jl
+++ b/src/AtmosphereModels/AtmosphereModels.jl
@@ -1,5 +1,7 @@
 module AtmosphereModels
 
+export AtmosphereModel
+
 include("atmosphere_model.jl")
 include("anelastic_formulation.jl")
 include("saturation_adjustment.jl")

--- a/src/AtmosphereModels/atmosphere_model.jl
+++ b/src/AtmosphereModels/atmosphere_model.jl
@@ -66,6 +66,23 @@ function default_formulation(grid, thermo)
     return AnelasticFormulation(grid, constants, thermo)
 end
 
+"""
+    AtmosphereModel(grid;
+                    clock = Clock(grid),
+                    thermodynamics = AtmosphereThermodynamics(eltype(grid)),
+                    formulation = default_formulation(grid, thermodynamics),
+                    absolute_humidity = DefaultValue(),
+                    tracers = tuple(),
+                    coriolis = nothing,
+                    boundary_conditions = NamedTuple(),
+                    forcing = NamedTuple(),
+                    advection = WENO(order=5),
+                    microphysics = WarmPhaseSaturationAdjustment(),
+                    timestepper = :RungeKutta3)
+
+Return an AtmosphereModel that uses the anelastic approximation following
+[Pauluis (2008)](https://journals.ametsoc.org/view/journals/atsc/65/8/200s7jas2475.1.xml).
+"""
 function AtmosphereModel(grid;
                          clock = Clock(grid),
                          thermodynamics = AtmosphereThermodynamics(eltype(grid)),

--- a/src/MoistAirBuoyancies.jl
+++ b/src/MoistAirBuoyancies.jl
@@ -10,6 +10,8 @@ using Oceananigans
 using Oceananigans: AbstractModel
 using Oceananigans.Grids: AbstractGrid
 
+using Adapt
+
 import Oceananigans.BuoyancyFormulations: AbstractBuoyancyFormulation,
                                           buoyancy_perturbationᶜᶜᶜ,
                                           required_tracers
@@ -110,6 +112,10 @@ struct SaturationKernel{T, P}
     temperature :: T
 end
 
+Adapt.adapt_structure(to, sk::SaturationKernel) =
+    SaturationKernel(adapt(to, sk.phase_transition),
+                     adapt(to, sk.temperature))
+
 @inline function (kernel::SaturationKernel)(i, j, k, grid, buoyancy)
     T = kernel.temperature
     return saturation_specific_humidity(i, j, k, grid, buoyancy, T, kernel.phase_transition)
@@ -132,6 +138,8 @@ end
 struct CondensateKernel{T}
     temperature :: T
 end
+
+Adapt.adapt_structure(to, ck::CondensateKernel) = CondensateKernel(adapt(to, ck.temperature))
 
 @inline function condensate_specific_humidity(i, j, k, grid, mb::MoistAirBuoyancy, T, q)
     z = Oceananigans.Grids.znode(i, j, k, grid, c, c, c)

--- a/src/MoistAirBuoyancies.jl
+++ b/src/MoistAirBuoyancies.jl
@@ -34,6 +34,13 @@ struct MoistAirBuoyancy{FT, AT} <: AbstractBuoyancyFormulation{Nothing}
     thermodynamics :: AT
 end
 
+"""
+    MoistAirBuoyancy(FT=Oceananigans.defaults.FloatType;
+                     thermodynamics = AtmosphereThermodynamics(FT),
+                     reference_constants = ReferenceConstants{FT}(101325, 290))
+
+Return a MoistAirBuoyancy.
+"""
 function MoistAirBuoyancy(FT=Oceananigans.defaults.FloatType;
                           thermodynamics = AtmosphereThermodynamics(FT),
                           reference_constants = ReferenceConstants{FT}(101325, 290))
@@ -47,7 +54,7 @@ reference_density(z, mb::MoistAirBuoyancy) = reference_density(z, mb.reference_c
 base_density(mb::MoistAirBuoyancy) = base_density(mb.reference_constants, mb.thermodynamics)
 
 #####
-##### 
+#####
 #####
 
 const c = Center()
@@ -189,7 +196,7 @@ condensate_specific_humidity(T, state::HeightReferenceThermodynamicState, ref, t
     T₁ = Π * state.θ
     qˡ₁ = condensate_specific_humidity(T₁, state, ref, thermo)
     qˡ₁ <= 0 && return T₁
-    
+
     # If we made it this far, we have condensation
     r₁ = saturation_adjustment_residual(T₁, Π, qˡ₁, state, thermo)
 
@@ -202,7 +209,7 @@ condensate_specific_humidity(T, state::HeightReferenceThermodynamicState, ref, t
     # Saturation adjustment
     R = sqrt(max(T₂, T₁))
     ϵ = convert(FT, 1e-4)
-    δ = ϵ * R 
+    δ = ϵ * R
     iter = 0
 
     while abs(r₂ - r₁) > δ

--- a/src/MoistAirBuoyancies.jl
+++ b/src/MoistAirBuoyancies.jl
@@ -27,16 +27,17 @@ import ..Thermodynamics:
     saturation_specific_humidity,
     condensate_specific_humidity
 
-struct MoistAirBuoyancy{FT} <: AbstractBuoyancyFormulation{Nothing}
-    thermodynamics :: AtmosphereThermodynamics{FT}
+struct MoistAirBuoyancy{FT, AT} <: AbstractBuoyancyFormulation{Nothing}
     reference_constants :: ReferenceConstants{FT}
+    thermodynamics :: AT
 end
 
 function MoistAirBuoyancy(FT=Oceananigans.defaults.FloatType;
-                           thermodynamics = AtmosphereThermodynamics(FT),
-                           reference_constants = ReferenceConstants{FT}(101325, 290))
+                          thermodynamics = AtmosphereThermodynamics(FT),
+                          reference_constants = ReferenceConstants{FT}(101325, 290))
 
-    return MoistAirBuoyancy{FT}(thermodynamics, reference_constants)
+    AT = typeof(thermodynamics)
+    return MoistAirBuoyancy{FT, AT}(reference_constants, thermodynamics)
 end
 
 required_tracers(::MoistAirBuoyancy) = (:θ, :q)


### PR DESCRIPTION
Resolves #17 by making `MoistAirBuoyancy` a concrete type and by adding `adapt_structure` for `CondensateKernel` and `SaturationKernel`, which are used for diagnostics in the bomex example. Also makes a few cosmetic improvements.