### PR TITLE
Fix typo in reference pressure

### DIFF
--- a/examples/bomex.jl
+++ b/examples/bomex.jl
@@ -168,7 +168,7 @@ model = NonhydrostaticModel(; grid, advection, buoyancy, coriolis, closure,
 # of Siebesma et al 2003, 3rd paragraph
 θϵ = 0.1
 qϵ = 2.5e-5
-θᵢ(x, y, z) = θ_bomex(z) + θϵ * randn() - 3
+θᵢ(x, y, z) = θ_bomex(z) + θϵ * randn()
 qᵢ(x, y, z) = q_bomex(z) + qϵ * randn()
 uᵢ(x, y, z) = u_bomex(z)
 set!(model, θ=θᵢ, q=qᵢ, u=uᵢ)

--- a/examples/bomex.jl
+++ b/examples/bomex.jl
@@ -13,8 +13,8 @@ using CloudMicrophysics.Microphysics0M: remove_precipitation
 
 # Siebesma et al (2003) resolution!
 # DOI: https://doi.org/10.1175/1520-0469(2003)60<1201:ALESIS>2.0.CO;2
-Nx = Ny = 64
-Nz = 75
+Nx = Ny = 32
+Nz = 40
 
 Lx = 6400
 Ly = 6400
@@ -245,14 +245,23 @@ add_callback!(simulation, progress, IterationInterval(10))
 # Sʳ = ForcingOperation(:q, model)
 # outputs = merge(model.velocities, model.tracers, (; T, qˡ, qᵛ★, Sʳ))
 outputs = merge(model.velocities, model.tracers, (; T, qˡ, qᵛ★))
+averaged_outputs = NamedTuple(name => Average(outputs[name], dims=(1, 2)) for name in keys(outputs))
 
 filename = string("bomex_", Nx, "_", Ny, "_", Nz, ".jld2")
+averages_filename = string("bomex_averages", Nx, "_", Ny, "_", Nz, ".jld2")
 
 ow = JLD2Writer(model, outputs; filename,
                 schedule = TimeInterval(1minutes),
                 overwrite_existing = true)
 
 simulation.output_writers[:jld2] = ow
+
+averages_ow = JLD2Writer(model, averaged_outputs;
+                         filename = averages_filename,
+                     .   schedule = TimeInterval(1minutes),
+                         overwrite_existing = true)
+
+simulation.output_writers[:avg] = averages_ow
 
 @info "Running BOMEX on grid: \n $grid \n and using model: \n $model"
 run!(simulation)

--- a/src/MoistAirBuoyancies.jl
+++ b/src/MoistAirBuoyancies.jl
@@ -103,14 +103,18 @@ const c = Center()
     q = @inbounds tracers.q[i, j, k]
     𝒰 = HeightReferenceThermodynamicState(θ, q, z)
 
-    ρ₀ = base_density(mb.reference_constants, mb.thermodynamics)
-    αʳ = reference_specific_volume(z, mb.reference_constants, mb.thermodynamics)
-    g = mb.thermodynamics.gravitational_acceleration
-
     # Perform saturation adjustment
     α = specific_volume(𝒰, mb.reference_constants, mb.thermodynamics)
 
-    return ρ₀ * g * (α - αʳ)
+    # Compute reference specific volume
+    αʳ = reference_specific_volume(z, mb.reference_constants, mb.thermodynamics)
+    g = mb.thermodynamics.gravitational_acceleration
+
+    # Formulation in terms of base density:
+    # ρ₀ = base_density(mb.reference_constants, mb.thermodynamics)
+    # return ρ₀ * g * (α - αʳ)
+
+    return g * (α - αʳ) / αʳ
 end
 
 @inline ∂z_b(i, j, k, grid, mb::MoistAirBuoyancy, tracers) =
@@ -289,8 +293,9 @@ end
     cᵖᵐ = mixture_heat_capacity(state.q, thermo)
     inv_ϰᵐ = Rᵐ / cᵖᵐ
     pᵣ = reference_pressure(state.z, ref, thermo)
-    p₀ = ref.base_pressure
-    return (pᵣ / p₀)^inv_ϰᵐ
+    FT = eltype(pᵣ)
+    pₑ₀ = convert(FT, 1e5)
+    return (pᵣ / pₑ₀)^inv_ϰᵐ
 end
 
 #####

--- a/src/Thermodynamics/atmosphere_thermodynamics.jl
+++ b/src/Thermodynamics/atmosphere_thermodynamics.jl
@@ -304,9 +304,9 @@ end
 @inline function reference_pressure(z, ref, thermo)
     cᵖᵈ = thermo.dry_air.heat_capacity
     Rᵈ = dry_air_gas_constant(thermo)
-    ϰᵈ⁻¹ = Rᵈ / cᵖᵈ
+    inv_ϰᵈ = Rᵈ / cᵖᵈ
     g = thermo.gravitational_acceleration
-    return ref.p₀ * (1 - g * z / (cᵖᵈ * ref.θ))^ϰᵈ⁻¹
+    return ref.p₀ * (1 - g * z / (cᵖᵈ * ref.θ))^inv_ϰᵈ
 end
 
 @inline function saturation_specific_humidity(T, z, ref::ReferenceState, thermo, phase_transition)
@@ -319,7 +319,9 @@ end
     cᵖᵐ = mixture_heat_capacity(state.q, thermo)
     inv_ϰᵐ = Rᵐ / cᵖᵐ
     pᵣ = reference_pressure(state.z, ref, thermo)
-    return (pᵣ / 1e5)^inv_ϰᵐ
+    FT = eltype(pᵣ)
+    pₑ₀ = convert(FT, 1e5) # hard-coded for now
+    return (pᵣ / pₑ₀)^inv_ϰᵐ
 end
 
 condensate_specific_humidity(T, state, ref, thermo) =

--- a/src/Thermodynamics/atmosphere_thermodynamics.jl
+++ b/src/Thermodynamics/atmosphere_thermodynamics.jl
@@ -318,9 +318,11 @@ end
     Rᵐ = mixture_gas_constant(state.q, thermo)
     cᵖᵐ = mixture_heat_capacity(state.q, thermo)
     inv_ϰᵐ = Rᵐ / cᵖᵐ
+
     pᵣ = reference_pressure(state.z, ref, thermo)
     FT = eltype(pᵣ)
-    pₑ₀ = convert(FT, 1e5) # hard-coded for now
+    pₑ₀ = convert(FT, 1e5) # "exner surface reference pressure" -- hard-coded for now
+
     return (pᵣ / pₑ₀)^inv_ϰᵐ
 end
 

--- a/src/Thermodynamics/reference_states.jl
+++ b/src/Thermodynamics/reference_states.jl
@@ -52,7 +52,7 @@ end
     g = thermo.gravitational_acceleration
     θᵣ = ref.reference_potential_temperature
     p₀ = ref.base_pressure
-    return p₀ * (1 - g * z / (cᵖᵈ * θᵣ))^(Rᵈ / cᵖᵈ)
+    return p₀ * (1 - g * z / (cᵖᵈ * θᵣ))^(cᵖᵈ / Rᵈ)
 end
 
 @inline function saturation_specific_humidity(T, z, ref::ReferenceConstants, thermo, phase_transition)


### PR DESCRIPTION
The bug fix in https://github.com/NumericalEarth/Breeze.jl/pull/23/commits/133f008ed1b7584d27e9c5f34e4b672f7bb9ef54 fixes the bomex example, producing (at half resolution here, running on my laptop):

https://github.com/user-attachments/assets/e4111772-a8bf-4944-8941-0d578838b5ff