### PR TITLE
[CI] Do not error out when cleaning up docs if previews don't exist

### DIFF
--- a/.github/workflows/DocPreviewsCleanup.yml
+++ b/.github/workflows/DocPreviewsCleanup.yml
@@ -25,9 +25,12 @@ jobs:
           ref: gh-pages
       - name: Delete preview and history + push changes
         run: |
-          git config user.name "Documenter.jl"
-          git config user.email "documenter@juliadocs.github.io"
-          git rm -rf previews/*
-          git commit -m "delete previews directory"
-          git branch gh-pages-new $(echo "delete history" | git commit-tree HEAD^{tree})
-          git push --force origin gh-pages-new:gh-pages
+          preview_directory=previews/PR${{ github.event.number }}
+          if [[ -d "${preview_directory}" ]]; then
+            git config user.name "${{github.actor}}"
+            git config user.email "${{github.actor_id}}+${{github.actor}}@users.noreply.github.com"
+            git rm -rf "${preview_directory}"
+            git commit -m 'Cleanup docs for PR #${{ github.event.number }}'
+            git branch gh-pages-new $(echo "Delete history" | git commit-tree HEAD^{tree})
+            git push --force origin gh-pages-new:gh-pages
+          fi


### PR DESCRIPTION
It's a bit annoying to see jobs failing for no reason: https://github.com/NumericalEarth/Breeze.jl/actions/workflows/DocPreviewsCleanup.yml.