### PR TITLE
Add `modules=[Breeze]` argument to `makedocs` to actually run doctests

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,7 +9,7 @@ set_theme!(Theme(linewidth = 3))
 
 DocMeta.setdocmeta!(Breeze, :DocTestSetup, :(using Breeze); recursive=true)
 
-bib_filepath = joinpath(dirname(@__FILE__), "src", "breeze.bib")
+bib_filepath = joinpath(@__DIR__, "src", "breeze.bib")
 bib = CitationBibliography(bib_filepath, style=:authoryear)
 
 examples_src_dir = joinpath(@__DIR__, "..", "examples")


### PR DESCRIPTION
I was getting mad wondering why doctests were not being run.  This is quite important because at https://github.com/NumericalEarth/Breeze.jl/blob/b7e48d87a357ad53f51c75ccf2752fc34e8eb6b0/test/doctests.jl#L7 we skip the doctests in the manual only.  Alternatively we should set `manual=true` in the regular CI jobs.