### PR TITLE
[CI] Remove JLD2 files before publishing docs

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -91,6 +91,11 @@ jobs:
         with:
           name: documentation-build
           path: docs/build
+      - name: Remove extra files
+        # There may be JLD2 files generated during execution of Literate
+        # examples, we don't need them on the website.
+        run:
+          rm -fv docs/build/literated/*.jld2
       - name: Instantiate docs environment
         shell: julia --color=yes {0}
         run: |


### PR DESCRIPTION
These can be very heavy (40+ MB, the rest of the website is ~0.5 MB), and are useless for the purpose of the website.