### PR TITLE
Builds draft version of docs when the PR is a draft

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -20,6 +20,12 @@ on:
       - "src/**"
       - "Project.toml"
       - "CHANGELOG.md"
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - converted_to_draft
+      - ready_for_review
   release:
 
 concurrency:
@@ -49,6 +55,13 @@ jobs:
         run: |
           using Pkg
           Pkg.instantiate()
+      - name: Set environment variables
+        run: |
+          BREEZE_DOCS_DRAFT=false
+          if [[ ${{ (github.event_name == 'pull_request') && github.event.pull_request.draft }} == 'true' ]]; then
+              BREEZE_DOCS_DRAFT=true
+          fi
+          echo "BREEZE_DOCS_DRAFT=${BREEZE_DOCS_DRAFT}" | tee "${GITHUB_ENV}"
       - name: Build documentation
         run:
           julia --color=yes --project=docs docs/make.jl

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,6 +7,9 @@ using CairoMakie
 CairoMakie.activate!(type = "svg")
 set_theme!(Theme(linewidth = 3))
 
+# Whether to build a draft version of the docs.
+draft = get(ENV, "BREEZE_DOCS_DRAFT", "false") == "true"
+
 DocMeta.setdocmeta!(Breeze, :DocTestSetup, :(using Breeze); recursive=true)
 
 bib_filepath = joinpath(@__DIR__, "src", "breeze.bib")
@@ -16,7 +19,7 @@ examples_src_dir = joinpath(@__DIR__, "..", "examples")
 literated_dir = joinpath(@__DIR__, "src", "literated")
 mkpath(literated_dir)
 
-example_scripts = [
+example_scripts = draft ? [] : [
     "thermal_bubble.jl",
 ]
 
@@ -27,7 +30,7 @@ for script_file in example_scripts
                       execute = true)
 end
 
-example_pages = Any[
+example_pages = draft ? [] : [
     "Thermal bubble" => "literated/thermal_bubble.md",
 ]
 
@@ -52,5 +55,5 @@ makedocs(
         "API" => "api.md",
         "Contributors guide" => "contributing.md",
     ],
-    draft = false,
+    draft = draft,
 )

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -63,7 +63,7 @@ Pkg.test("Breeze"; test_args=`doctests`)
     Pkg.test("Breeze"; test_args=`--list`)
     ```
 
-### GPU tests
+### Tests on GPU
 
 When running the tests, if a CUDA GPU is detected, they automatically use the [`GPU` Oceananigans architecture](https://clima.github.io/OceananigansDocumentation/stable/appendix/library/#Oceananigans.Architectures.GPU), otherwise they run on [`CPU`](https://clima.github.io/OceananigansDocumentation/stable/appendix/library/#Oceananigans.Architectures.CPU).
 To temporarily disable the automatic detection of the GPU and forcibly run the tests on CPU you can set the environment variable `CUDA_VISIBLE_DEVICES=-1`.
@@ -104,8 +104,10 @@ julia --project=docs/ docs/make.jl
 ```
 
 to build the documentation.
-If you want to quickly build a draft copy of the documentation (i.e. without running all the examples or running the doctests), modify the [call to the `makedocs`](https://github.com/NumericalEarth/Breeze.jl/blob/cdf8bd25c83f24cbd4f26c8c600d20ef9740e9c7/docs/make.jl#L14-L34) function in `docs/make.jl` to set the keyword argument `draft=true` and run again the `docs/make.jl` script.
-When you submit a pull request to `Breeze.jl`, if the documentation building job is successfull a copy of the build will be uploaded as an artifact, which you can retrieve by looking at the summary page of the documentation job.
+
+When you submit a pull request to `Breeze.jl`, if the documentation building job is successfull a copy of the build will be uploaded as an artifact, which you can retrieve from the summary page of the documentation job.
+
+### Displaying the documentation
 
 To view the documentation you can open the generated HTML files in the `docs/build` directory, but you need an HTTP server to be able to move around the website and follow internal links.
 The [`LiveServer`](https://github.com/JuliaDocs/LiveServer.jl) package provides a simple HTTP server implementation, which also automatically reloads the pages when they are modified on disk:
@@ -116,4 +118,26 @@ Pkg.activate("live-server"; shared=true)
 Pkg.add("LiveServer") # this is necessary only the first time, to install LiveServer
 using LiveSever: serve
 serve(; dir="docs/build")
+```
+
+### Draft documentation
+
+If you want to quickly build a draft copy of the documentation (i.e. without running the doctests or all the examples, which can be very time-consuming), set the environment variable `BREEZE_DOCS_DRAFT=true` and run again the `docs/make.jl` script:
+
+```sh
+export BREEZE_DOCS_DRAFT=true
+julia --project=docs/ docs/make.jl
+```
+
+or start julia with
+
+```
+julia --project=docs/
+```
+
+and then inside it
+
+```julia
+ENV["BREEZE_DOCS_DRAFT"] = "true"
+include("docs/make.jl")
 ```


### PR DESCRIPTION
So we don't need to manually edit https://github.com/NumericalEarth/Breeze.jl/blob/c0ad90fb5af6c8900cba3548562e947ee6ccb01b/docs/src/index.md?plain=1#L29 anymore 🙂 Also, see https://github.com/NumericalEarth/Breeze.jl/issues/90#issuecomment-3506732252.

I'm happy to elaborate the conditions under which the full/draft documentation is built (for example if you want to use labels to control that), but this is a start, then we can iterate over as necessary.

Opening the PR as a draft to demonstrate the functionality.