### PR TITLE
Set some grouping for Julia dependencies in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,13 @@ updates:
       - dependency-name: "Breeze"
     labels:
       - "dependencies 🖇️"
+    groups:
+      julia-major-updates:
+        update-types:
+          - "major"
+      julia-minor-updates:
+        update-types:
+          - "minor"
+      julia-patch-updates:
+        update-types:
+          - "patch"


### PR DESCRIPTION
This isn't really what I'd like because it groups together different packages, I'd much prefer https://github.com/dependabot/dependabot-core/issues/13284 to be addressed (grouping same package, across directories), but let's see how it goes in the long term.