### PR TITLE
[CI] Run GPU tests using Julia v1.12

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,7 +52,7 @@ jobs:
           - version: "min"
             os: windows-latest
         include:
-          - version: "min"
+          - version: "1.12"
             os: nvidia-gpu-t4
             arch: "default"
     steps:


### PR DESCRIPTION
Julia v1.12 is now the recommended (and tested) version across the Oceananigans ecosystem, and these tests should also quite a bit faster in the newer version compared to v1.10.