### PR TITLE
Tweak computation of discrete buoyancy

### DIFF
--- a/examples/random_decay.jl
+++ b/examples/random_decay.jl
@@ -1,0 +1,55 @@
+using Breeze
+using Printf
+
+Nx = Ny = Nz = 16
+x = y = z = (0, 10_000)
+grid = RectilinearGrid(size = (Nx, Ny, Nz); x, y, z)
+
+microphysics = SaturationAdjustment(equilibrium=WarmPhaseEquilibrium())
+model = AtmosphereModel(grid; microphysics, advection = WENO(order=5), tracers = tuple(:ρc))
+
+θ₀ = model.formulation.reference_state.potential_temperature
+θᵢ(x, y, z) = θ₀ + 1e-2 * rand()
+ρqᵗᵢ(x, y, z) = 2e-2 * rand()
+ρcᵢ(x, y, z) = rand()
+set!(model, θ=θᵢ, ρqᵗ=ρqᵗᵢ, ρc=ρcᵢ)
+
+simulation = Simulation(model; Δt=10, stop_iteration=100)
+
+ρE = Field(Integral(model.energy_density))
+ρQᵗ = Field(Integral(model.moisture_density))
+ρC = Field(Integral(model.tracers.ρc))
+
+ρE₀ = first(ρE)
+ρQᵗ₀ = first(ρQᵗ)
+ρC₀ = first(ρC)
+
+function progress(sim)
+    compute!(ρE)
+    compute!(ρQᵗ)
+    compute!(ρC)
+
+    δρE  = (first(ρE) - ρE₀) / ρE₀
+    δρQᵗ = (first(ρQᵗ) - ρQᵗ₀) / ρQᵗ₀
+    δρC  = (first(ρC) - ρC₀) / ρC₀
+
+    msg = @sprintf("Iter: %d, t: %s, δ∫ρe: %.2e, δ∫ρqᵗ: %.2e, δ∫ρc: %.2e",
+                    iteration(sim), prettytime(sim), δρE, δρQᵗ, δρC)
+
+    @info msg
+
+    return nothing
+end
+
+add_callback!(simulation, progress, IterationInterval(1))
+run!(simulation)
+
+compute!(ρE)
+compute!(ρQᵗ)
+compute!(ρC)
+
+δρE  = (first(ρE) - ρE₀) / ρE₀
+δρQᵗ = (first(ρQᵗ) - ρQᵗ₀) / ρQᵗ₀
+δρC  = (first(ρC) - ρC₀) / ρC₀
+
+@show δρE, δρQᵗ, δρC

--- a/src/AtmosphereModels/anelastic_formulation.jl
+++ b/src/AtmosphereModels/anelastic_formulation.jl
@@ -80,6 +80,20 @@ function diagnose_thermodynamic_state(i, j, k, grid, formulation::AnelasticFormu
     return MoistStaticEnergyState(e, q, z, pᵣ)
 end
 
+@inline function density(i, j, k, grid, formulation, temperature, specific_moisture, thermo)
+    @inbounds begin
+        qᵗ = specific_moisture[i, j, k]
+        pᵣ = formulation.reference_state.pressure[i, j, k]
+        T = temperature[i, j, k]
+    end
+
+    # TODO: fix this assumption of non-condensed state by invoking the microphysics model
+    q = MoistureMassFractions(qᵗ)
+    Rᵐ = mixture_gas_constant(q, thermo)
+
+    return pᵣ / (Rᵐ * T)
+end
+
 @inline function specific_volume(i, j, k, grid, formulation, temperature, specific_moisture, thermo)
     @inbounds begin
         qᵗ = specific_moisture[i, j, k]

--- a/src/AtmosphereModels/dynamics_kernel_functions.jl
+++ b/src/AtmosphereModels/dynamics_kernel_functions.jl
@@ -22,11 +22,31 @@ Oceananigans `qᶜ` is the kinematic tracer flux.
 ##### Some key functions
 #####
 
+@inline function ρ_bᶜᶜᶜ(i, j, k, grid, reference_density, buoyancy, formulation, T, q, thermo)
+    b = buoyancy(i, j, k, grid, formulation, T, q, thermo)
+    ρᵣ = @inbounds reference_density[i, j, k]
+    return ρᵣ * b
+end
+
+@inline ρ_bᶜᶜᶠ(i, j, k, grid, ρ, T, q, formulation, thermo) = ℑzᵃᵃᶠ(i, j, k, grid, ρ_bᶜᶜᶜ, ρ, buoyancy, formulation, T, q, thermo)
+
+#=
+@inline function ρ_bᶜᶜᶠ(i, j, k, grid, ρ, T, q, formulation, thermo)
+    ρᶜᶜᶠ = ℑzᵃᵃᶠ(i, j, k, grid, density, formulation, T, q, thermo)
+    ρᵣ = ℑzᵃᵃᶠ(i, j, k, grid, formulation.reference_state.density)
+    g = thermo.gravitational_acceleration     
+    bᶜᶜᶠ = - g * (ρᶜᶜᶠ - ρᵣ) / ρᶜᶜᶠ
+    return ρᶜᶜᶠ * bᶜᶜᶠ
+end
+=#
+
+#=
 @inline function ρ_bᶜᶜᶠ(i, j, k, grid, ρ, T, q, formulation, thermo)
     ρᶜᶜᶠ = ℑzᵃᵃᶠ(i, j, k, grid, ρ)
     bᶜᶜᶠ = ℑzᵃᵃᶠ(i, j, k, grid, buoyancy, formulation, T, q, thermo)
     return ρᶜᶜᶠ * bᶜᶜᶠ
 end
+=#
 
 @inline function ρ_w_bᶜᶜᶠ(i, j, k, grid, w, ρ, T, q, formulation, thermo)
     ρ_b = ρ_bᶜᶜᶠ(i, j, k, grid, ρ, T, q, formulation, thermo)


### PR DESCRIPTION
This PR tweaks how discrete buoyancy is computed.

Note, we still make an approximation in computing buoyancy re: moisture. I'll look into fixing this in this PR.

@kaiyuan-cheng this PR also has a `random_decay.jl` script that evaluates conservation of energy density, moisture density, and an arbitrary tracer. Both moisture density and tracer density seem to be well-conserved. Energy density is conserved to within a 1/100th %. Not sure if that is success or not (its small but far from machine precision). 