### PR TITLE
Fix `prettysummary` import in CloudMicrophysics extension

### DIFF
--- a/ext/BreezeCloudMicrophysicsExt.jl
+++ b/ext/BreezeCloudMicrophysicsExt.jl
@@ -207,7 +207,7 @@ computed in `update_microphysical_fields!`.
 ##### show methods
 #####
 
-import Oceananigans.Utils: prettysummary
+import Oceananigans.Grids: prettysummary
 
 function prettysummary(cl::CloudLiquid)
     return string("CloudLiquid(",


### PR DESCRIPTION
I'm a bit confused by why this doesn't trigger an error systematically (@ericphanson ideas?), but this has been failing in some jobs on `main` (e.g. https://github.com/NumericalEarth/Breeze.jl/actions/runs/19600740942/job/56131898424#step:6:756) and also locally for me (but I'm using julia v1.12 on macOS, same combination as the job linked above).

Honestly, I'm tempted by fixing this upstream in Oceananigans, it feels like `prettysummary` should really have been defined in `Utils`, not `Grids.`