### PR TITLE
[dependabot] Group all Julia PRs together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,12 +28,7 @@ updates:
     labels:
       - "dependencies 🖇️"
     groups:
-      julia-major-updates:
-        update-types:
-          - "major"
-      julia-minor-updates:
-        update-types:
-          - "minor"
-      julia-patch-updates:
-        update-types:
-          - "patch"
+      # Group all Julia package updates into a single PR
+      all-julia-packages:
+        patterns:
+          - "*"


### PR DESCRIPTION
This is still not I want, but grouping by version number types doesn't seem to be working either, so let's see if "grouping all" at least works as advertised.