### PR TITLE
Fix moist static energy expression in the dycore docs

### DIFF
--- a/docs/src/dycore_equations_algorithms.md
+++ b/docs/src/dycore_equations_algorithms.md
@@ -88,7 +88,7 @@ where ``c^{p m}`` is the mixture heat capacity, ``T`` is temperature, ``g`` is g
 and 
 ``\mathscr{L}^i_r`` is the latent heat of deposition (vapor to ice) at the energy reference temperature,
 
-According to [Pauluis2008](@citet) the moist static energy obeys 
+According to [Pauluis2008](@citet), the moist static energy obeys 
 
 ```math
 \partial_t(ρᵣ e) + \boldsymbol{\nabla \cdot}\, (ρᵣ e \boldsymbol{u}) = ρᵣ w b + S_e ,


### PR DESCRIPTION
This PR fixes the expression for moist static energy in the docs.

Note the docs leave much to be desired. Several terms (eg source terms) are undefined. It should also define an equation for tracers --- moisture density is just one tracer. We should write the expression for moist static energy directly, not energy density with the \rho in front. Etc.

The docs are a draft so please improve if desired!

Closes #210 