### PR TITLE
Silence Oceananigans warnings during `turbulence_closures` tests

### DIFF
--- a/test/turbulence_closures.jl
+++ b/test/turbulence_closures.jl
@@ -18,7 +18,7 @@ test_thermodynamics = (:StaticEnergy, :LiquidIcePotentialTemperature)
 
     for closure in closures
         @testset let closure=closure
-            model = AtmosphereModel(grid; closure)
+            model = @test_logs match_mode=:any AtmosphereModel(grid; closure)
             time_step!(model, 1)
             @test true
         end
@@ -34,7 +34,7 @@ test_thermodynamics = (:StaticEnergy, :LiquidIcePotentialTemperature)
 
         @testset "Implicit diffusion solver with ScalarDiffusivity [$thermodynamics, $(FT), $(typeof(disc))]" for disc in discretizations
             closure = ScalarDiffusivity(disc, ν=1, κ=1)
-            model = AtmosphereModel(grid; closure, tracers=:ρc)
+            model = @test_logs match_mode=:any AtmosphereModel(grid; closure, tracers=:ρc)
             # Set uniform specific energy for no diffusion
             θ₀ = model.formulation.reference_state.potential_temperature
             cᵖᵈ = model.thermodynamic_constants.dry_air.heat_capacity


### PR DESCRIPTION
This silences warnings like
```
┌ Warning: Implicit-explicit time-stepping with RungeKutta3TimeStepper is not tested.
│  implicit_solver: Oceananigans.Solvers.BatchedTridiagonalSolver{Oceananigans.TurbulenceClosures.VerticallyImplicitDiffusionLowerDiagonal, Oceananigans.TurbulenceClosures.VerticallyImplicitDiffusionDiagonal, Oceananigans.TurbulenceClosures.VerticallyImplicitDiffusionUpperDiagonal, Array{Float32, 3}, Oceananigans.Grids.RectilinearGrid{Float32, Oceananigans.Grids.Periodic, Oceananigans.Grids.Periodic, Oceananigans.Grids.Bounded, Oceananigans.Grids.StaticVerticalDiscretization{OffsetArrays.OffsetVector{Float32, StepRangeLen{Float32, Float64, Float64, Int64}}, OffsetArrays.OffsetVector{Float32, StepRangeLen{Float32, Float64, Float64, Int64}}, Float32, Float32}, Float32, Float32, OffsetArrays.OffsetVector{Float32, StepRangeLen{Float32, Float64, Float64, Int64}}, OffsetArrays.OffsetVector{Float32, StepRangeLen{Float32, Float64, Float64, Int64}}, Oceananigans.Architectures.CPU}, Nothing, Oceananigans.Grids.ZDirection}
└ @ Oceananigans.TimeSteppers ~/.julia/packages/Oceananigans/cQglC/src/TimeSteppers/runge_kutta_3.jl:67
```
These warnings annoy me quite a bit, and short of fixing them in Oceananigans, these only pollute the test log.

What I don't like about this solution is:
* these warnings are upstream in Oceananigans, not this package, so if anything changes there we get a test failure here.  Of course given the tight relation between Oceananigans and Breeze, this should be easy to resolve quickly, but still not great to tie Breeze's tests to Oceananigans' internals
* this is silencing _all_ warnings on that line.  In case there were other warnings, they'd be hidden too.  However the warnings are issues only for some closures or discretizations, I don't know how to capture a warning only under certain conditions (apart from duplicating the `AtmosphereModel` calls)