### PR TITLE
[CI] Fix Julia version to v1.12.2 in all jobs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,7 +41,7 @@ jobs:
       matrix:
         version:
           - "min"
-          - "1.12"
+          - "1.12.2"
         os:
           - ubuntu-latest
           - macOS-latest
@@ -52,7 +52,7 @@ jobs:
           - version: "min"
             os: windows-latest
         include:
-          - version: "1.12"
+          - version: "1.12.2"
             os: nvidia-gpu-t4
             arch: "default"
     steps:

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2
         with:
-          version: "1.12"
+          version: "1.12.2"
       - uses: julia-actions/cache@v2
         id: julia-cache
       - name: Instantiate docs environment
@@ -90,7 +90,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2
         with:
-          version: "1.12"
+          version: "1.12.2"
       - uses: julia-actions/cache@v2
         id: julia-cache
       - uses: actions/download-artifact@v7

--- a/.github/workflows/Validation.yml
+++ b/.github/workflows/Validation.yml
@@ -44,7 +44,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - "1.12"
+          - "1.12.2"
         os:
           - ubuntu-latest
     steps:


### PR DESCRIPTION
There seems to be an issue with Julia v1.12.3 causing all documentation jobs to fail with
```
ERROR: LoadError: AssertionError: normpath(entry.path) == normpath(path)
Stacktrace:
  [1] write_env(env::Pkg.Types.EnvCache; update_undo::Bool, skip_writing_project::Bool)
    @ Pkg.Types /opt/actions-runner/_work/_tool/julia/1.12.3/x64/share/julia/stdlib/v1.12/Pkg/src/Types.jl:1292
  [2] write_env
    @ /opt/actions-runner/_work/_tool/julia/1.12.3/x64/share/julia/stdlib/v1.12/Pkg/src/Types.jl:1283 [inlined]
  [3] up(ctx::Pkg.Types.Context, pkgs::Vector{PackageSpec}, level::UpgradeLevel; skip_writing_project::Bool, preserve::Nothing)
    @ Pkg.Operations /opt/actions-runner/_work/_tool/julia/1.12.3/x64/share/julia/stdlib/v1.12/Pkg/src/Operations.jl:1986
  [4] up
    @ /opt/actions-runner/_work/_tool/julia/1.12.3/x64/share/julia/stdlib/v1.12/Pkg/src/Operations.jl:1957 [inlined]
  [5] up(ctx::Pkg.Types.Context, pkgs::Vector{PackageSpec}; level::UpgradeLevel, mode::PackageMode, preserve::Nothing, update_registry::Bool, skip_writing_project::Bool, kwargs::@Kwargs{})
    @ Pkg.API /opt/actions-runner/_work/_tool/julia/1.12.3/x64/share/julia/stdlib/v1.12/Pkg/src/API.jl:416
  [6] up
    @ /opt/actions-runner/_work/_tool/julia/1.12.3/x64/share/julia/stdlib/v1.12/Pkg/src/API.jl:386 [inlined]
  [7] up
    @ /opt/actions-runner/_work/_tool/julia/1.12.3/x64/share/julia/stdlib/v1.12/Pkg/src/API.jl:174 [inlined]
  [8] instantiate(ctx::Pkg.Types.Context; manifest::Nothing, update_registry::Bool, verbose::Bool, platform::Base.BinaryPlatforms.Platform, allow_build::Bool, allow_autoprecomp::Bool, workspace::Bool, julia_version_strict::Bool, kwargs::@Kwargs{})
    @ Pkg.API /opt/actions-runner/_work/_tool/julia/1.12.3/x64/share/julia/stdlib/v1.12/Pkg/src/API.jl:1270
  [9] instantiate
    @ /opt/actions-runner/_work/_tool/julia/1.12.3/x64/share/julia/stdlib/v1.12/Pkg/src/API.jl:1243 [inlined]
 [10] instantiate(; kwargs::@Kwargs{})
    @ Pkg.API /opt/actions-runner/_work/_tool/julia/1.12.3/x64/share/julia/stdlib/v1.12/Pkg/src/API.jl:1242
 [11] top-level scope
    @ /opt/actions-runner/_work/_temp/20f2febf-3f15-4533-a6d6-d0b85a76b882:2
 [12] include(mod::Module, _path::String)
    @ Base ./Base.jl:306
 [13] exec_options(opts::Base.JLOptions)
    @ Base ./client.jl:317
 [14] _start()
    @ Base ./client.jl:550
```
Fixing to v1.12.2 fixes that.  I'd suggest merging this somewhat urgently