### PR TITLE
[docs] Include private `Microphysics` docstrings

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -133,6 +133,13 @@ Modules = [Breeze.AtmosphereModels.Diagnostics]
 Public = false
 ```
 
+### Microphysics
+
+```@autodocs
+Modules = [Breeze.Microphysics]
+Public = false
+```
+
 ### Forcings
 
 ```@autodocs


### PR DESCRIPTION
Taken out of #241, needed also for #300, at this point it's better to have the change in a separate PR easier to merge.