### PR TITLE
[docs] Move code for running Literate examples to its own script

### DIFF
--- a/docs/literate.jl
+++ b/docs/literate.jl
@@ -1,0 +1,33 @@
+using Literate
+using CairoMakie
+
+CairoMakie.activate!(type = "png")
+set_theme!(Theme(linewidth = 3))
+
+script_path = ARGS[1]
+literated_dir = ARGS[2]
+
+# We'll append the following postamble to the literate examples, to include
+# information about the computing environment used to run them.
+example_postamble = """
+
+# ---
+
+# ### Julia version and environment information
+#
+# This example was executed with the following version of Julia:
+
+using InteractiveUtils: versioninfo
+versioninfo()
+
+# These were the top-level packages installed in the environment:
+
+import Pkg
+Pkg.status()
+"""
+
+@time basename(script_path) Literate.markdown(script_path, literated_dir;
+                                              flavor = Literate.DocumenterFlavor(),
+                                              preprocess = content -> content * example_postamble,
+                                              execute = true,
+                                              )


### PR DESCRIPTION
No change of functionality, just making things simpler and neater (when there's an error in a literate example at the moment we get the large-ish inlined `literate_code` as part of the error message, which is just noise).  Also, this makes it easier to run the individual literate examples from outside of the `docs/make.jl` script.