### PR TITLE
Swap order of output of `materialize_momentum_and_velocities`

### DIFF
--- a/src/AtmosphereModels/AnelasticFormulations/anelastic_formulation.jl
+++ b/src/AtmosphereModels/AnelasticFormulations/anelastic_formulation.jl
@@ -167,5 +167,5 @@ function materialize_momentum_and_velocities(formulation::AnelasticFormulation, 
     w = ZFaceField(grid, boundary_conditions=velocity_bcs.w)
     velocities = (; u, v, w)
 
-    return velocities, momentum
+    return momentum, velocities
 end

--- a/src/AtmosphereModels/atmosphere_model.jl
+++ b/src/AtmosphereModels/atmosphere_model.jl
@@ -155,7 +155,7 @@ function AtmosphereModel(grid;
     # Materialize the full formulation with thermodynamic fields and pressure
     formulation = materialize_formulation(formulation, grid, boundary_conditions)
 
-    velocities, momentum = materialize_momentum_and_velocities(formulation, grid, boundary_conditions)
+    momentum, velocities = materialize_momentum_and_velocities(formulation, grid, boundary_conditions)
     microphysical_fields = materialize_microphysical_fields(microphysics, grid, boundary_conditions)
 
     tracers = NamedTuple(name => CenterField(grid, boundary_conditions=boundary_conditions[name]) for name in tracer_names)


### PR DESCRIPTION
This respects the name of the function itself.  Fix #324.