### PR TITLE
[CI] Increase timeout for test jobs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,7 +29,7 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 90
     container:
       image: ${{ (startsWith(matrix.os, 'aws-linux-nvidia-gpu-') && 'ghcr.io/numericalearth/breeze-docker-images:test' ) || '' }}
       options: --gpus=all


### PR DESCRIPTION
Recent changes tipped jobs with Julia v1.11 over the current timeout.  On the other hand, tests in v1.12 finish in 10-15 minutes 🫠