### PR TITLE
Fix quick-start figure in Docs

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -86,5 +86,5 @@ conjure_time_step_wizard!(simulation, cfl=0.7)
 
 run!(simulation)
 
-heatmap(model.temperature, colormap=:thermal)
+heatmap(PotentialTemperature(model), colormap=:thermal)
 ```


### PR DESCRIPTION
Add thermodynamics option to AnelasticFormulation after #305 rendered LiquidIcePotentialTemperature the default.

Closes https://github.com/NumericalEarth/Breeze.jl/issues/341