### PR TITLE
[CI] Start julia process for running tests with `--check-bounds=yes`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -106,7 +106,7 @@ jobs:
               # We use earlyoom only on the GPU machines
               earlyoom -m 3 -s 100 -r 300 --prefer 'julia' &
           fi
-          julia --project --color=yes -e 'using Pkg; Pkg.test(; coverage=true, julia_args=["--check-bounds=yes", "--compiled-modules=yes", "--depwarn=yes"], test_args=`${{ env.runtest_test_args }}`, force_latest_compatible_version=false, allow_reresolve=true)'
+          julia --project --color=yes --check-bounds=yes -e 'using Pkg; Pkg.test(; coverage=true, julia_args=["--check-bounds=yes", "--compiled-modules=yes", "--depwarn=yes"], test_args=`${{ env.runtest_test_args }}`, force_latest_compatible_version=false, allow_reresolve=true)'
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v5
         with:


### PR DESCRIPTION
This should avoid precompiling the `CUDA_Runtime_jll` on the GPU jobs using the Docker image, because that one doesn't have cached that package for `--check-bounds=auto`