### PR TITLE
Bump version from 0.2.0 to 0.2.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Breeze"
 uuid = "660aa2fb-d4c8-4359-a52c-9c057bc511da"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["NumericalEarth organization (github.com/NumericalEarth) and lovely contributors"]
 
 [deps]


### PR DESCRIPTION
This is to get a Zenodo record that I just enabled.