### PR TITLE
[CI] Don't trigger docs builds on `labeled` events

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -13,7 +13,6 @@ on:
       - "Project.toml"
       - "CHANGELOG.md"
   pull_request:
-    types: [labeled, opened, reopened, synchronize]
     paths: *paths
 
 concurrency:
@@ -27,8 +26,6 @@ env:
 
 jobs:
   build-docs:
-    # Don't run the docs build if the trigger isn't a label event on a PR which isn't adding special label.
-    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'build all examples 🏗️' }}
     permissions:
       actions: write
       contents: write


### PR DESCRIPTION
In #297 we created a CI setup for triggering "larger" docs jobs with a dedicated label.  In that PR I added the triggering events for PRs `labeled`, `unlabeled`, and `edited`, in addition to the default ones (`opened`, `reopened`, and `synchronize`).  Of these, `unlabeled` and `edited` were definitely unnecessary, but `label` still means that adding _every_ label starts a new docs build job, which is very not ideal: opening a PR with multiple labels starts "# of labels + 1" docs build jobs, which is extremely wasteful (and expensive 💸), and also mostly completely useless: we care only about the dedicated label.  I tried to address all these shortcomings in #346 by removing the wrong/useless trigger events `edited` and `unlabeled`, and skipping `labeled` events when the special label isn't used.  While I think this is logically a good solution, in practice what happens when you open a PR with one or more labels (and none of them the special one) is that the status check of the PR is "skipped" because the last docs job (triggered by the `labeled` event) was skipped, while the job triggered by `opened` is running happily.

All in all, my feeling is that the `labeled` triggering event is problematic: either is starts unnecessary and wasteful jobs, or it (correctly) skips jobs overriding the CI status of the PR.  What I'm proposing here is to remove also the `labeled` triggering event and keep only the default triggers (opening/reopening a PR and pushing new commits), which means that ***to actually see a full docs build after applying the special label you must either close/reopen the PR, or push a new commit*** (of course also rebasing/merging on the target branch works as well). While this isn't the ideal setup I was imagining, I think this is a decent compromise between not spawning wasteful jobs and not getting misleading CI status checks in PRs.