### PR TITLE
[docs] Don't actually save unused figures in Literate examples

### DIFF
--- a/examples/bomex.jl
+++ b/examples/bomex.jl
@@ -359,7 +359,7 @@ text!(axuv, -8.5, 2200, text="solid: u\ndashed: v", fontsize=12)
 
 fig[0, :] = Label(fig, "BOMEX: Mean profile evolution (Siebesma et al., 2003)", fontsize=18, tellwidth=false)
 
-save("bomex_profiles.png", fig)
+save("bomex_profiles.png", fig) #src
 fig
 
 # The simulation shows the development of a cloudy boundary layer with:

--- a/examples/rico.jl
+++ b/examples/rico.jl
@@ -380,7 +380,7 @@ text!(axuw, 0.01, 2500, text="solid: uw\ndashed: vw", fontsize=14)
 
 fig[0, :] = Label(fig, "RICO: Horizontally-averaged profiles", fontsize=18, tellwidth=false)
 
-save("rico_profiles.png", fig)
+save("rico_profiles.png", fig) #src
 fig
 
 # The simulation shows the development of a cloudy, precipitating boundary layer with:

--- a/examples/supercell.jl
+++ b/examples/supercell.jl
@@ -153,7 +153,7 @@ ax_rh = Axis(fig_thermo[1, 2],
              title = "Relative Humidity Profile")
 lines!(ax_rh, RH_profile, collect(z_plot), linewidth = 2, color = :blue)
 
-save("supercell_thermo_profiles.png", fig_thermo)
+save("supercell_thermo_profiles.png", fig_thermo) #src
 fig_thermo
 
 # Zonal wind profile with linear shear below ``z_s`` and smooth transition (Equation 15-16):
@@ -188,7 +188,7 @@ lines!(ax_wind, u_profile, collect(z_plot), label = "u (zonal)", linewidth = 2)
 lines!(ax_wind, v_profile, collect(z_plot), label = "v (meridional)", linewidth = 2, linestyle = :dash)
 axislegend(ax_wind, position = :rb)
 
-save("supercell_wind_profile.png", fig_wind)
+save("supercell_wind_profile.png", fig_wind) #src
 fig_wind
 
 # ## Warm bubble initial perturbation
@@ -232,7 +232,7 @@ hm = heatmap!(ax_bubble, collect(x_slice) ./ 1000, collect(z_slice), θ_pert_sli
               colormap = :thermal, colorrange = (0, Δθ))
 Colorbar(fig_bubble[1, 2], hm, label = "θ' (K)")
 
-save("supercell_warm_bubble.png", fig_bubble)
+save("supercell_warm_bubble.png", fig_bubble) #src
 fig_bubble
 
 # ## Model initialization
@@ -315,12 +315,12 @@ function progress(sim)
 
     ρe = Breeze.AtmosphereModels.static_energy_density(sim.model)
     ρemean = mean(ρe)
-    
+
     msg = @sprintf("Iter: %d, t: %s, Δt: %s, mean(ρe): %.6e J/kg, max|u|: %.5f m/s, max w: %.5f m/s, min w: %.5f m/s",
                    iteration(sim), prettytime(sim), prettytime(sim.Δt), ρemean,
                    maximum(abs, u), maximum(w), minimum(w))
     @info msg
-    
+
     msg *= @sprintf(", max(qᵛ): %.5e, max(qᶜˡ): %.5e, max(qᶜⁱ): %.5e",
                     maximum(qᵛ), maximum(qᶜˡ), maximum(qᶜⁱ))
     @info msg
@@ -360,7 +360,8 @@ ax = Axis(fig[1, 1],
           xticks = 0:900:maximum(times))
 lines!(ax, times, max_w)
 
-save("max_w_timeseries.png", fig)
+save("max_w_timeseries.png", fig) #src
+fig
 
 # ## Animation: horizontal slices at 5 km
 #


### PR DESCRIPTION
By `save`-ing figures when running Literate examples, we store on the website figures which aren't actually used at all, which becomes a waste of space in the long run (see [Oceananigans experience](https://github.com/CliMA/Oceananigans.jl/issues/5027)).  Inspired by https://github.com/NumericalEarth/Breeze.jl/pull/334#discussion_r2652766036.