### PR TITLE
Always reset `Float64` as default float type at the end

### DIFF
--- a/test/all_sky_radiative_transfer.jl
+++ b/test/all_sky_radiative_transfer.jl
@@ -10,7 +10,7 @@ using ClimaComms
 using NCDatasets
 using RRTMGP
 
-@testset "All-sky full-spectrum RadiativeTransferModel [$FT]" for FT in (Float64, Float32)
+@testset "All-sky full-spectrum RadiativeTransferModel [$FT]" for FT in (Float32, Float64)
 
     @testset "Constructor argument errors" begin
         Oceananigans.defaults.FloatType = FT
@@ -120,7 +120,7 @@ using RRTMGP
         @test (lw_up_diff > 0) || (sw_dn_diff > 0)
     end
 
-    @testset "Custom effective radius models [$FT]" for FT in (Float64, Float32)
+    @testset "Custom effective radius models [$FT]" for FT in (Float32, Float64)
         Oceananigans.defaults.FloatType = FT
         topology = (Flat, Flat, Bounded)
         grid = RectilinearGrid(default_arch; size=8, x=0, y=45, z=(0, 10kilometers), topology)


### PR DESCRIPTION
This should fix a [test failure](https://github.com/NumericalEarth/Breeze.jl/actions/runs/20637097998/job/59263647419?pr=241) seen in #241: note how [`doctests` was run on job 7](https://github.com/NumericalEarth/Breeze.jl/actions/runs/20637097998/job/59263647419?pr=241#step:8:279), [same as the `all_sky_radiative_transfer` test](https://github.com/NumericalEarth/Breeze.jl/actions/runs/20637097998/job/59263647419?pr=241#step:8:271)