### PR TITLE
Increase relative humidity in cloud kelvin helmholtz

### DIFF
--- a/examples/cloudy_kelvin_helmholtz.jl
+++ b/examples/cloudy_kelvin_helmholtz.jl
@@ -100,12 +100,14 @@ uᵇ(z) = U₀ + ΔU * (1 + tanh((z - z₀) / Δzu)) / 2
 
 δθ = 0.01
 δu = 1e-3
+δℋ = 0.05
 
 ϵ() = rand() - 1/2
 θᵢ(x, z) = θᵇ(z) + δθ * ϵ()
 uᵢ(x, z) = uᵇ(z) + δu * ϵ()
+ℋᵢ(x, z) = ℋᵇ(x, z) + δℋ * ϵ()
 
-set!(model; u=uᵢ, θ=θᵢ, ℋ=ℋᵇ)
+set!(model; u=uᵢ, θ=θᵢ, ℋ=ℋᵢ)
 
 # ## The Kelvin-Helmholtz instability
 #


### PR DESCRIPTION
On `main` there is no instability (because the relative humidity peak is 1.0); this PR tries to fix the example so it goes unstable again within the duration of the simulation.