### PR TITLE
Add EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# EditorConfig: https://editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+# * Unix-style newlines,
+# * final newline ending every file,
+# * trim extra whitespace at end of lines or file
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# 4-space indentation
+[*.{jl,md,sh}]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
Let's start this experiment here before moving to Oceananigans: [EditorConfig](https://editorconfig.org/)  is an editor configuration format understood by several editor and IDEs, either [by default](https://editorconfig.org/#pre-installed) or [by installing a simple plugin](https://editorconfig.org/#download).

The configuration I added here satisfies the by far most common issues detected by the new whitespace check workflow, so that if you enable EditorConfig with your editor/IDE (if supported!), then you should hopefully never again have problems with the check.