### PR TITLE
Fix definition of virtual potential temperature

### DIFF
--- a/src/AtmosphereModels/Diagnostics/potential_temperatures.jl
+++ b/src/AtmosphereModels/Diagnostics/potential_temperatures.jl
@@ -202,7 +202,7 @@ Field(θᵛ)
 ├── operand: KernelFunctionOperation at (Center, Center, Center)
 ├── status: time=0.0
 └── data: 3×3×14 OffsetArray(::Array{Float64, 3}, 0:2, 0:2, -2:11) with eltype Float64 with indices 0:2×0:2×-2:11
-    └── max=304.824, min=304.824, mean=304.824
+    └── max=301.824, min=301.824, mean=301.824
 ```
 
 # References


### PR DESCRIPTION
As discussed on #436 -- thank you @mmr0 !

Here is an explanation repeated from there:

The virtual temperature is defined as

$$ p = \rho R^d T^v $$

So, given the ideal gas law for the mixture $p = \rho R^m T$, it's easy to see that

$$ T^v = \frac{R^m}{R^d} T $$

Then we note that $R^m = q^d R^d + q^v R^v$, and since $q^d = 1 - q^t = 1 - q^v - q^l - q^i$, we have

$$ R^m = R^d \left ( 1 + \delta^v q^v - q^l - q^i \right ) $$

where $\delta^v = \frac{R^v}{R^d} - 1$. So finally

$$ T^v = T \left ( q^d + \frac{R^v}{R^d} \right ) = T \left ( 1 + \delta q^v - q^l - q^i \right ) $$

The virtual potential temperature is defined analogously.
