### PR TITLE
[CI] Run tests with -O0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,7 +29,7 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 90
+    timeout-minutes: 60
     container:
       image: ${{ (startsWith(matrix.os, 'aws-linux-nvidia-gpu-') && format('ghcr.io/numericalearth/breeze-docker-images:test-julia_{0}', matrix.version) ) || '' }}
       options: --gpus=all


### PR DESCRIPTION
@simone-silvestri would love this:

* macOS tests with Julia v1.10 on `main`: timeout after 90 minutes
* [macOS tests with Julia v1.10 with `-O0`](https://github.com/NumericalEarth/Breeze.jl/actions/runs/21780247582/job/62843122760#step:7:485): finish in 9m05.9s 😂

There's some modest speedup also for tests with Julia v1.12, but a lot smaller compared to v1.10, where the speed up is in the range of 10x.

As an upside, we can now reduce the timeout of the test job 😄