### PR TITLE
`sedimentation_speed` interface + effective sedimentation for total water

### DIFF
--- a/docs/src/appendix/notation.md
+++ b/docs/src/appendix/notation.md
@@ -58,6 +58,7 @@ The following table also uses a few conventions that suffuse the source code and
 | ``\mathbb{W}^{ci}``                 | `𝕎ᶜⁱ`  |                                     | Terminal velocity of cloud ice (scalar, positive downward)                     |
 | ``\mathbb{W}^r``                    | `𝕎ʳ`   |                                     | Terminal velocity of rain (scalar, positive downward)                          |
 | ``\mathbb{W}^s``                    | `𝕎ˢ`   |                                     | Terminal velocity of snow (scalar, positive downward)                          |
+| ``\mathbb{W}^t``                    | `𝕎ᵗ`   | `AM.bulk_sedimentation_velocities.ρqᵗ.w` | Effective total water sedimentation speed (mass-weighted average, positive downward) |
 | ``qᵛ⁺``                             | `qᵛ⁺`  |                                     | Saturation specific humidity over a surface                                    |
 | ``qᵛ⁺ˡ``                            | `qᵛ⁺ˡ` |                                     | Saturation specific humidity over a planar liquid surface                      |
 | ``qᵛ⁺ⁱ``                            | `qᵛ⁺ⁱ` |                                     | Saturation specific humidity over a planar ice surface                         |

--- a/docs/src/breeze.bib
+++ b/docs/src/breeze.bib
@@ -343,3 +343,12 @@
   year = {2019},
   doi = {10.5194/gmd-12-879-2019}
 }
+
+@article{Yatunin2025,
+  author = {Yatunin, Dennis and Byrne, Simon and Kawczynski, Charles and Kandala, Sriharsha and Bozzola, Gabriele and Sridhar, Akshay and Shen, Zhaoyi and Jaruga, Anna and Sloan, Julia and He, Jia and Huang, Daniel Zhengyu and Barra, Valeria and Knoth, Oswald and Ullrich, Paul and Schneider, Tapio},
+  title = {The {Climate Modeling Alliance} atmosphere dynamical core: Concepts, numerics, and scaling},
+  journal = {Journal of Advances in Modeling Earth Systems},
+  year = {2025},
+  note = {submitted},
+  doi = {10.22541/essoar.173940262.23304403/v1}
+}

--- a/docs/src/developer/microphysics/example.md
+++ b/docs/src/developer/microphysics/example.md
@@ -174,5 +174,5 @@ To implement a new microphysics scheme, we need to:
 9. **Implement `maybe_adjust_thermodynamic_state`** (trivial for non-equilibrium schemes)
 
 For schemes with sedimentation, you would also implement `sedimentation_speed` (returning positive
-sedimentation speed fields per tracer) and `total_water_sedimentation_speed_components` (returning
-`(speed_field, humidity_field)` pairs for the aggregate total water sedimentation velocity).
+sedimentation speed fields per tracer). The aggregate total water sedimentation velocity is
+computed generically from the per-tracer `sedimentation_speed` implementations.

--- a/docs/src/developer/microphysics/example.md
+++ b/docs/src/developer/microphysics/example.md
@@ -173,5 +173,6 @@ To implement a new microphysics scheme, we need to:
 8. **Implement `moisture_fractions`** to partition moisture
 9. **Implement `maybe_adjust_thermodynamic_state`** (trivial for non-equilibrium schemes)
 
-For schemes with sedimentation, you would also implement velocity fields and the
-`microphysical_velocities` function.
+For schemes with sedimentation, you would also implement `sedimentation_speed` (returning positive
+sedimentation speed fields per tracer) and `total_water_sedimentation_speed_components` (returning
+`(speed_field, humidity_field)` pairs for the aggregate total water sedimentation velocity).

--- a/ext/BreezeCloudMicrophysicsExt/BreezeCloudMicrophysicsExt.jl
+++ b/ext/BreezeCloudMicrophysicsExt/BreezeCloudMicrophysicsExt.jl
@@ -55,7 +55,7 @@ using DocStringExtensions: TYPEDSIGNATURES
 
 using Oceananigans: Center, Face, Field
 using Oceananigans.AbstractOperations: KernelFunctionOperation
-using Oceananigans.Fields: ZeroField, ZFaceField
+using Oceananigans.Fields: ZFaceField
 using Oceananigans.BoundaryConditions: FieldBoundaryConditions, BoundaryCondition, Open
 using Adapt: Adapt, adapt
 

--- a/ext/BreezeCloudMicrophysicsExt/one_moment_helpers.jl
+++ b/ext/BreezeCloudMicrophysicsExt/one_moment_helpers.jl
@@ -67,7 +67,7 @@ the rate at which rain mass leaves the domain through the bottom boundary.
 Units: kg/m²/s (positive = downward, out of domain)
 
 Note: The returned value is positive when rain is falling out of the domain
-(the terminal velocity `wʳ` is negative, and we flip the sign).
+(the fall speed `wʳ` is stored as a positive magnitude).
 """
 function AtmosphereModels.surface_precipitation_flux(model, microphysics::OneMomentCloudMicrophysics)
     grid = model.grid
@@ -89,12 +89,12 @@ Adapt.adapt_structure(to, k::SurfacePrecipitationFluxKernel) =
 
 @inline function (kernel::SurfacePrecipitationFluxKernel)(i, j, k_idx, grid)
     # Flux at bottom face (k=1), ignore k_idx since this is a 2D field
-    # wʳ < 0 (downward), so -wʳ * ρqʳ > 0 represents flux out of domain
+    # wʳ > 0 (fall speed magnitude), so wʳ * ρqʳ > 0 represents flux out of domain
     @inbounds wʳ = kernel.terminal_velocity[i, j, 1]
     @inbounds ρqʳ = kernel.rain_density[i, j, 1]
 
     # Return positive flux for rain leaving domain (downward)
-    return -wʳ * ρqʳ
+    return wʳ * ρqʳ
 end
 
 #####

--- a/ext/BreezeCloudMicrophysicsExt/one_moment_microphysics.jl
+++ b/ext/BreezeCloudMicrophysicsExt/one_moment_microphysics.jl
@@ -178,9 +178,6 @@ const OMCM = OneMomentCloudMicrophysics
 # Rain sedimentation speed: stored as positive magnitude in microphysical fields
 @inline AM.sedimentation_speed(bμp::OMCM, μ, ::Val{:ρqʳ}) = μ.wʳ
 
-# Total water sedimentation speed components for computing aggregate sedimentation velocity
-AM.total_water_sedimentation_speed_components(bμp::OMCM, μ) = ((μ.wʳ, μ.qʳ),)
-
 # ImpenetrableBoundaryCondition alias
 const IBC = BoundaryCondition{<:Open, Nothing}
 

--- a/ext/BreezeCloudMicrophysicsExt/two_moment_helpers.jl
+++ b/ext/BreezeCloudMicrophysicsExt/two_moment_helpers.jl
@@ -70,7 +70,7 @@ the rate at which rain mass leaves the domain through the bottom boundary.
 Units: kg/m²/s (positive = downward, out of domain)
 
 Note: The returned value is positive when rain is falling out of the domain
-(the terminal velocity `wʳ` is negative, and we flip the sign).
+(the fall speed `wʳ` is stored as a positive magnitude).
 """
 function AtmosphereModels.surface_precipitation_flux(model, microphysics::TwoMomentCloudMicrophysics)
     grid = model.grid
@@ -92,12 +92,12 @@ Adapt.adapt_structure(to, k::TwoMomentSurfacePrecipitationFluxKernel) =
 
 @inline function (kernel::TwoMomentSurfacePrecipitationFluxKernel)(i, j, k_idx, grid)
     # Flux at bottom face (k=1), ignore k_idx since this is a 2D field
-    # wʳ < 0 (downward), so -wʳ * ρqʳ > 0 represents flux out of domain
+    # wʳ > 0 (fall speed magnitude), so wʳ * ρqʳ > 0 represents flux out of domain
     @inbounds wʳ = kernel.terminal_velocity[i, j, 1]
     @inbounds ρqʳ = kernel.rain_density[i, j, 1]
 
     # Return positive flux for rain leaving domain (downward)
-    return -wʳ * ρqʳ
+    return wʳ * ρqʳ
 end
 
 #####

--- a/ext/BreezeCloudMicrophysicsExt/two_moment_microphysics.jl
+++ b/ext/BreezeCloudMicrophysicsExt/two_moment_microphysics.jl
@@ -379,10 +379,6 @@ end
 # Rain number: use number-weighted sedimentation speed
 @inline AtmosphereModels.sedimentation_speed(bμp::WPNE2M, μ, ::Val{:ρnʳ}) = μ.wʳₙ
 
-# Total water sedimentation speed components for computing aggregate sedimentation velocity
-# In 2M, both cloud liquid and rain contribute to total water sedimentation
-AtmosphereModels.total_water_sedimentation_speed_components(bμp::WPNE2M, μ) = ((μ.wᶜˡ, μ.qᶜˡ), (μ.wʳ, μ.qʳ))
-
 #####
 ##### Microphysical tendencies
 #####

--- a/ext/BreezeCloudMicrophysicsExt/zero_moment_microphysics.jl
+++ b/ext/BreezeCloudMicrophysicsExt/zero_moment_microphysics.jl
@@ -19,7 +19,7 @@ AtmosphereModels.materialize_microphysical_fields(bμp::ZMCM, grid, bcs) = mater
 @inline AtmosphereModels.update_microphysical_fields!(μ, i, j, k, grid, bμp::ZMCM, ρ, 𝒰, constants) = update_microphysical_fields!(μ, i, j, k, grid, bμp.cloud_formation, ρ, 𝒰, constants)
 @inline AtmosphereModels.grid_moisture_fractions(i, j, k, grid, bμp::ZMCM, ρ, qᵗ, μ) = grid_moisture_fractions(i, j, k, grid, bμp.cloud_formation, ρ, qᵗ, μ)
 @inline AtmosphereModels.grid_microphysical_tendency(i, j, k, grid, bμp::ZMCM, args...) = zero(grid)
-@inline AtmosphereModels.microphysical_velocities(bμp::ZMCM, μ, name) = nothing
+@inline AtmosphereModels.sedimentation_speed(bμp::ZMCM, μ, name) = nothing
 
 @inline function AtmosphereModels.maybe_adjust_thermodynamic_state(𝒰₀, bμp::ZMCM, qᵗ, constants)
     # Initialize moisture state from total moisture qᵗ (not from stale microphysical fields)

--- a/src/AtmosphereModels/AtmosphereModels.jl
+++ b/src/AtmosphereModels/AtmosphereModels.jl
@@ -38,7 +38,6 @@ export
     NegatedField,
     materialize_bulk_sedimentation_velocities,
     update_bulk_sedimentation_velocities!,
-    total_water_sedimentation_speed_components,
 
     # Interface functions (extended by BoundaryConditions and Forcings)
     regularize_atmosphere_model_boundary_conditions,

--- a/src/AtmosphereModels/AtmosphereModels.jl
+++ b/src/AtmosphereModels/AtmosphereModels.jl
@@ -33,6 +33,12 @@ export
     grid_microphysical_tendency,
     update_microphysical_fields!,
     update_microphysical_auxiliaries!,
+    sedimentation_speed,
+    microphysical_velocities,
+    NegatedField,
+    materialize_bulk_sedimentation_velocities,
+    update_bulk_sedimentation_velocities!,
+    total_water_sedimentation_speed_components,
 
     # Interface functions (extended by BoundaryConditions and Forcings)
     regularize_atmosphere_model_boundary_conditions,
@@ -62,7 +68,8 @@ using DocStringExtensions: TYPEDSIGNATURES, TYPEDEF, TYPEDFIELDS
 using Adapt: Adapt, adapt
 using KernelAbstractions: @kernel, @index
 
-using Oceananigans: Oceananigans, CenterField, fields
+using Oceananigans: Oceananigans, Center, Face, CenterField, fields
+using Oceananigans.Fields: ZeroField, ZFaceField
 using Oceananigans.BoundaryConditions: FieldBoundaryConditions, regularize_field_boundary_conditions, fill_halo_regions!
 using Oceananigans.ImmersedBoundaries: mask_immersed_field!
 using Oceananigans.Operators: Δzᶜᶜᶜ, ℑzᵃᵃᶠ

--- a/src/AtmosphereModels/atmosphere_model.jl
+++ b/src/AtmosphereModels/atmosphere_model.jl
@@ -27,7 +27,7 @@ function validate_tracers(tracers::Tuple)
 end
 
 mutable struct AtmosphereModel{Dyn, Frm, Arc, Tst, Grd, Clk, Thm, Mom, Moi, Mfr, Buy,
-                               Tmp, Sol, Vel, Trc, Adv, Cor, Frc, Mic, Cnd, Cls, Cfs, Rad} <: AbstractModel{Tst, Arc}
+                               Tmp, Sol, Vel, Trc, Adv, Cor, Frc, Mic, Cnd, Fvl, Cls, Cfs, Rad} <: AbstractModel{Tst, Arc}
     architecture :: Arc
     grid :: Grd
     clock :: Clk
@@ -47,6 +47,7 @@ mutable struct AtmosphereModel{Dyn, Frm, Arc, Tst, Grd, Clk, Thm, Mom, Moi, Mfr,
     forcing :: Frc
     microphysics :: Mic
     microphysical_fields :: Cnd
+    bulk_sedimentation_velocities :: Fvl
     timestepper :: Tst
     closure :: Cls
     closure_fields :: Cfs
@@ -177,6 +178,7 @@ function AtmosphereModel(grid;
         velocities = materialize_velocities(velocities, grid)
     end
     microphysical_fields = materialize_microphysical_fields(microphysics, grid, regularized_boundary_conditions)
+    bulk_sedimentation_velocities = materialize_bulk_sedimentation_velocities(microphysics, microphysical_fields, grid)
 
     tracers = NamedTuple(name => CenterField(grid, boundary_conditions=regularized_boundary_conditions[name]) for name in tracer_names)
 
@@ -241,6 +243,7 @@ function AtmosphereModel(grid;
                             forcing,
                             microphysics,
                             microphysical_fields,
+                            bulk_sedimentation_velocities,
                             timestepper,
                             closure,
                             closure_fields,

--- a/src/AtmosphereModels/dynamics_kernel_functions.jl
+++ b/src/AtmosphereModels/dynamics_kernel_functions.jl
@@ -10,9 +10,9 @@ using Oceananigans.Utils: sum_of_velocities
 @inline c_div_ρU(i, j, k, grid, args...) = zero(grid)
 
 # Use precomputed bulk sedimentation velocity when provided, otherwise call microphysical_velocities
-@inline _sedimentation_velocity(::Nothing, microphysics, microphysical_fields, name) =
+@inline get_sedimentation_velocity(::Nothing, microphysics, microphysical_fields, name) =
     microphysical_velocities(microphysics, microphysical_fields, name)
-@inline _sedimentation_velocity(Uˢ, microphysics, microphysical_fields, name) = Uˢ
+@inline get_sedimentation_velocity(Uˢ, microphysics, microphysical_fields, name) = Uˢ
 
 """
     ∇_dot_Jᶜ(i, j, k, grid, ρ, closure::AbstractTurbulenceClosure, closure_fields,
@@ -134,7 +134,7 @@ end
                                  clock,
                                  model_fields)
 
-    Uᵖ = _sedimentation_velocity(Uˢ, microphysics, microphysical_fields, name)
+    Uᵖ = get_sedimentation_velocity(Uˢ, microphysics, microphysical_fields, name)
     Uᵗ = sum_of_velocities(velocities, Uᵖ)
     ρ_field = dynamics_density(dynamics)
     @inbounds ρ = ρ_field[i, j, k]

--- a/src/AtmosphereModels/update_atmosphere_model_state.jl
+++ b/src/AtmosphereModels/update_atmosphere_model_state.jl
@@ -13,6 +13,8 @@ function TimeSteppers.update_state!(model::AtmosphereModel, callbacks=[]; comput
 
     fill_halo_regions!(prognostic_fields(model), model.clock, fields(model), async=true)
     compute_auxiliary_variables!(model)
+    update_bulk_sedimentation_velocities!(model.bulk_sedimentation_velocities, model.microphysics,
+                                         model.microphysical_fields, model.specific_moisture)
     update_radiation!(model.radiation, model)
     compute_forcings!(model)
     microphysics_model_update!(model.microphysics, model)
@@ -255,6 +257,9 @@ end
     @inbounds temperature[i, j, k] = T
 end
 
+bulk_sedimentation_velocity(::Nothing, name) = nothing
+bulk_sedimentation_velocity(velocities, name) = get(velocities, name, nothing)
+
 function compute_tendencies!(model::AtmosphereModel)
     grid = model.grid
     arch = grid.architecture
@@ -291,8 +296,11 @@ function compute_tendencies!(model::AtmosphereModel)
     ##### Moisture density tendency
     #####
 
+    Uᵗ = bulk_sedimentation_velocity(model.bulk_sedimentation_velocities, :ρqᵗ)
+
     ρq_args = (
         model.specific_moisture,
+        Uᵗ,
         Val(2),
         Val(:ρqᵗ),
         model.forcing.ρqᵗ,
@@ -315,6 +323,7 @@ function compute_tendencies!(model::AtmosphereModel)
 
         scalar_args = (
             ρc,
+            nothing, # Uˢ (hydrometeor velocities are handled by microphysical_velocities)
             Val(i + 2),
             Val(name),
             model.forcing[name],

--- a/src/Microphysics/dcmip2016_kessler.jl
+++ b/src/Microphysics/dcmip2016_kessler.jl
@@ -265,7 +265,7 @@ Return `nothing`.
 
 Rain sedimentation is handled internally by the kernel rather than through the advection interface.
 """
-@inline AtmosphereModels.microphysical_velocities(::DCMIP2016KM, μ, name) = nothing
+@inline AtmosphereModels.sedimentation_speed(::DCMIP2016KM, μ, name) = nothing
 
 """
 $(TYPEDSIGNATURES)

--- a/src/Microphysics/saturation_adjustment.jl
+++ b/src/Microphysics/saturation_adjustment.jl
@@ -52,7 +52,7 @@ function SaturationAdjustment(FT::DataType=Oceananigans.defaults.FloatType;
     return SaturationAdjustment(tolerance, maxiter, equilibrium)
 end
 
-@inline AtmosphereModels.microphysical_velocities(::SaturationAdjustment, μ, name) = nothing
+@inline AtmosphereModels.sedimentation_speed(::SaturationAdjustment, μ, name) = nothing
 
 # SaturationAdjustment operates through the thermodynamic state adjustment pathway,
 # so no explicit model update is needed.


### PR DESCRIPTION
This PR implements a "sedimentation interface" for microphysics schemes to specify the sedimentation speed of hydrometeors. The intent is to produce a system that automatically computes the effective sedimentation speed of aggregate quantities: total liquid fraction $q^l$, total ice fraction $q^i$ (both diagnostic quantities, possibly not stored), and finally total water fraction $q^t$ (which is required to consistently advect total moisture density as well as density).