### PR TITLE
Change kernel launching to `:xyz` to support further Reactant integration

### DIFF
--- a/src/AtmosphereModels/update_atmosphere_model_state.jl
+++ b/src/AtmosphereModels/update_atmosphere_model_state.jl
@@ -79,6 +79,7 @@ function compute_velocities!(model::AtmosphereModel)
 
     #TODO: Better support OffsetStaticSize in KernalAbstractions
     # For now, just use :xyz instead of KernelParameters
+    # See: https://github.com/NumericalEarth/Breeze.jl/issues/433
 
     # TX, TY, TZ = topology(grid)
     # Nx, Ny, Nz = size(grid)


### PR DESCRIPTION
See https://github.com/NumericalEarth/Breeze.jl/issues/433. Launching `compute_velocities!` with `:xyz` rather than `KernelParameters` works around this bug.

Note that Reactant integration tests are blocked via some upstream issues. 