### PR TITLE
[CI] Disable GPU support for Reactant until we actually start using it

### DIFF
--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -17,6 +17,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # Disable GPU support for Reactant until we actually use it.
+  REACTANT_GPU: 'none'
+
 jobs:
   run-benchmarks:
     name: "Run benchmarks"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,6 +25,10 @@ permissions:
   actions: write
   contents: read
 
+env:
+  # Disable GPU support for Reactant until we actually use it.
+  REACTANT_GPU: 'none'
+
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -23,6 +23,8 @@ concurrency:
 
 env:
   BREEZE_LABEL_BUILD_ALL_EXAMPLES: 'build all examples 🏗️'
+  # Disable GPU support for Reactant until we actually use it.
+  REACTANT_GPU: 'none'
 
 jobs:
   build-docs:


### PR DESCRIPTION
After #429 we're currently wasting time (and storage) downloading large GPU artifact for not actually using it at all.