### PR TITLE
[test] Make all `Simulation`s quiet

### DIFF
--- a/test/atmosphere_model_construction.jl
+++ b/test/atmosphere_model_construction.jl
@@ -9,7 +9,7 @@ using Test
 function run_nan_checker_test(arch; erroring)
     grid = RectilinearGrid(arch, size=(4, 2, 1), extent=(1, 1, 1))
     model = AtmosphereModel(grid)
-    simulation = Simulation(model, Δt=1, stop_iteration=2)
+    simulation = Simulation(model, Δt=1, stop_iteration=2, verbose=false)
     @allowscalar model.momentum.ρu[1, 1, 1] = NaN
     erroring && erroring_NaNChecker!(simulation)
 

--- a/test/kinematic_driver.jl
+++ b/test/kinematic_driver.jl
@@ -102,7 +102,7 @@ end
     set!(model, θ=300, qᵗ=0, w=w₀, c=(x, y, z) -> c_exact(x, y, z, 0))
 
     stop_time = 50
-    simulation = Simulation(model; Δt=1, stop_time)
+    simulation = Simulation(model; Δt=1, stop_time, verbose=false)
     run!(simulation)
 
     c_truth = CenterField(grid)

--- a/test/parcel_dynamics.jl
+++ b/test/parcel_dynamics.jl
@@ -344,7 +344,7 @@ using Oceananigans: interpolate
     e_initial = model.dynamics.state.ℰ
 
     # Run simulation for 20 minutes (parcel rises 1200 m at 1 m/s)
-    simulation = Simulation(model; Δt=1.0, stop_time=20minutes)
+    simulation = Simulation(model; Δt=1.0, stop_time=20minutes, verbose=false)
     run!(simulation)
 
     z_final = model.dynamics.state.z
@@ -392,7 +392,7 @@ end
     e_initial = model.dynamics.state.ℰ
 
     # Run simulation for 15 minutes
-    simulation = Simulation(model; Δt=1.0, stop_time=15minutes)
+    simulation = Simulation(model; Δt=1.0, stop_time=15minutes, verbose=false)
     run!(simulation)
 
     qᵗ_final = model.dynamics.state.qᵗ
@@ -446,7 +446,7 @@ OneMomentCloudMicrophysics = BreezeCloudMicrophysicsExt.OneMomentCloudMicrophysi
     @test haskey(μ, :ρqʳ)
 
     # Time step should work
-    simulation = Simulation(model; Δt=1.0, stop_time=5minutes)
+    simulation = Simulation(model; Δt=1.0, stop_time=5minutes, verbose=false)
     run!(simulation)
 
     @test model.dynamics.state.z ≈ 300.0 atol=1.0  # 5 min at 1 m/s = 300m
@@ -478,7 +478,7 @@ end
     @test model.dynamics.state.μ.ρqʳ ≈ 0.0
 
     # Run long enough for condensation to occur (above LCL)
-    simulation = Simulation(model; Δt=1.0, stop_time=60minutes)
+    simulation = Simulation(model; Δt=1.0, stop_time=60minutes, verbose=false)
     run!(simulation)
 
     # After rising through LCL, cloud liquid should form
@@ -509,7 +509,7 @@ end
          z = 0, w = 1)
 
     # Run long enough for cloud formation and autoconversion
-    simulation = Simulation(model; Δt=1.0, stop_time=120minutes)
+    simulation = Simulation(model; Δt=1.0, stop_time=120minutes, verbose=false)
     run!(simulation)
 
     # Extract final microphysical state
@@ -568,7 +568,7 @@ TwoMomentCloudMicrophysics = BreezeCloudMicrophysicsExt.TwoMomentCloudMicrophysi
     @test haskey(μ, :ρnʳ)
 
     # Time step should work
-    simulation = Simulation(model; Δt=1.0, stop_time=5minutes)
+    simulation = Simulation(model; Δt=1.0, stop_time=5minutes, verbose=false)
     run!(simulation)
 
     @test model.dynamics.state.z ≈ 300.0 atol=1.0  # 5 min at 1 m/s = 300m
@@ -600,7 +600,7 @@ end
     model.dynamics.state.μ = (; ρqᶜˡ=0.0, ρnᶜˡ=1.2 * nᶜˡ₀, ρqʳ=0.0, ρnʳ=0.0)
 
     # Run long enough for condensation to occur (above LCL)
-    simulation = Simulation(model; Δt=1.0, stop_time=60minutes)
+    simulation = Simulation(model; Δt=1.0, stop_time=60minutes, verbose=false)
     run!(simulation)
 
     # After rising through LCL, cloud liquid should form
@@ -637,7 +637,7 @@ end
     model.dynamics.state.μ = (; ρqᶜˡ=0.0, ρnᶜˡ=1.2 * nᶜˡ₀, ρqʳ=0.0, ρnʳ=0.0)
 
     # Run long enough for cloud formation and autoconversion
-    simulation = Simulation(model; Δt=1.0, stop_time=120minutes)
+    simulation = Simulation(model; Δt=1.0, stop_time=120minutes, verbose=false)
     run!(simulation)
 
     # Extract final microphysical state


### PR DESCRIPTION
Ref: https://github.com/NumericalEarth/Breeze.jl/pull/468#discussion_r2802049057.  Simulations in `test/cloud_microphysics_2M.jl` were already quiet, yay!