### PR TITLE
[test] Make all `Simulation`s quiet -- take 2

### DIFF
--- a/test/cloud_microphysics_2M.jl
+++ b/test/cloud_microphysics_2M.jl
@@ -305,7 +305,7 @@ end
     @test model.dynamics.state.μ.ρnᶜˡ == 0
 
     # Run parcel simulation until it becomes supersaturated
-    simulation = Simulation(model; Δt=1.0, stop_iteration=500)
+    simulation = Simulation(model; Δt=1.0, stop_iteration=500, verbose=false)
     run!(simulation)
 
     # After rising, parcel should have some cloud droplets from activation


### PR DESCRIPTION
I thought I had somehow missed this in #472, but this was actually introduced in #420, which was merged after #472.