### PR TITLE
Replace DefaultStabilityFunction with FittedStabilityFunction (Li et al. 2010)

### DIFF
--- a/docs/src/breeze.bib
+++ b/docs/src/breeze.bib
@@ -411,6 +411,16 @@
   doi = {10.1175/JAS-D-18-0357.1}
 }
 
+@article{Li2010,
+  author = {Li, Yubin and Gao, Zhiqiu and Lenschow, Donald H. and Chen, Fei},
+  title = {An improved approach for parameterizing surface-layer turbulent transfer coefficients in numerical models},
+  journal = {Boundary-Layer Meteorology},
+  volume = {137},
+  pages = {153--165},
+  year = {2010},
+  doi = {10.1007/s10546-010-9523-y}
+}
+
 @article{LargeYeager2009,
   author = {Large, William G. and Yeager, Stephen G.},
   title = {The global climatology of an interannually varying air--sea flux data set},

--- a/examples/prescribed_sea_surface_temperature.jl
+++ b/examples/prescribed_sea_surface_temperature.jl
@@ -117,27 +117,30 @@ scalar_advection = WENO(order=5)
 # and are further modified by atmospheric stability using the bulk Richardson number,
 #
 # ```math
-# Ri = \frac{g}{\overline{θ_v}} \frac{h \, (θ_v - θ_{v0})}{U_h^2}
+# Riᴮ = \frac{g}{\overline{θ_v}} \frac{h \, (θ_v - θ_{v0})}{U_h^2}
 # ```
 #
 # where ``h`` is the measurement height (first cell center), ``θ_v`` and ``θ_{v0}``
 # are virtual potential temperatures at the measurement height and surface, and
 # ``U_h`` is the wind speed at height ``h``.
-# The stability-corrected transfer coefficient is then
+#
+# The default stability correction uses [`FittedStabilityFunction`](@ref), which maps
+# ``Riᴮ`` to the Monin-Obukhov stability parameter ``ζ = z/L`` via the non-iterative
+# regression of [Li2010](@citet), then evaluates integrated MOST stability functions
+# ``Ψᴰ(ζ)`` and ``Ψᵀ(ζ)`` (Hogström 1996 for unstable, Beljaars & Holtslag 1991 for
+# stable conditions). The stability-corrected transfer coefficients are
 #
 # ```math
-# C^{Ri}_h(U_h, Ri) = C^N_{10}(U_h) \left[\frac{\ln(10/\ell)}{\ln(h/\ell)}\right]^2 ψ(Ri)
+# Cᴰ = Cᴰ_N \left[\frac{α}{α - Ψᴰ}\right]^2, \quad
+# Cᵀ = Cᵀ_N \frac{α}{α - Ψᴰ} \frac{β_h}{β_h - Ψᵀ}
 # ```
 #
-# where ``\ell`` is the roughness length and ``ψ`` is a stability function.
-# The default stability function enhances transfer in unstable conditions
-# (``Ri < 0``, ``ψ = \sqrt{1 - 16 \, Ri}``) and reduces it in stable
-# conditions (``Ri ≥ 0``, ``ψ = 1 / (1 + 10 \, Ri)``).
+# where ``α = \ln(h/ℓ)`` and ``β_h = \ln(h/ℓ_h)`` with roughness lengths ``ℓ``
+# (momentum) and ``ℓ_h`` (scalar). This provides structurally correct and different
+# corrections for momentum and scalar transfer.
 #
 # In unstable conditions (over warm and wet surfaces), exchange is enhanced.
 # In stable conditions (cold and dry surfaces), exchange is reduced.
-# This captures the physical reality that
-# turbulent mixing is stronger when the surface is warmer than the air above it.
 #
 # We create polynomial coefficients for each flux type. The default coefficients
 # come from [LargeYeager2009](@citet) observational fits:
@@ -190,7 +193,10 @@ using Breeze.BoundaryConditions: neutral_coefficient_10m, bulk_richardson_number
 
 h = grid.Lz / grid.Nz / 2  # first cell center height
 U_min = 0.1
-ψ = DefaultStabilityFunction()
+ℓ = coef.roughness_length
+sf = coef.stability_function
+α = log(h / ℓ)
+β = log(ℓ / sf.scalar_roughness_length)
 
 ΔT_line = 10  # K, temperature difference for stability lines
 T_warm = θ₀ + ΔT / 2      # warm SST in this simulation
@@ -198,12 +204,12 @@ T_cold = θ₀ - ΔT / 2      # cold SST in this simulation
 T_unstable = θ₀ + ΔT_line  # strongly unstable
 T_stable   = θ₀ - ΔT_line  # strongly stable
 
-U_range = range(0.5, 25, length=200)
+U_range = range(3, 25, length=200)
 Cᴰ_neutral  = [neutral_coefficient_10m(default_neutral_drag_polynomial, U, U_min) for U in U_range]
-Cᴰ_unstable = [Cᴰ * ψ(bulk_richardson_number(h, θ₀, T_unstable, U, U_min)) for (Cᴰ, U) in zip(Cᴰ_neutral, U_range)]
-Cᴰ_stable   = [Cᴰ * ψ(bulk_richardson_number(h, θ₀, T_stable,   U, U_min)) for (Cᴰ, U) in zip(Cᴰ_neutral, U_range)]
-Cᴰ_sim_warm = [Cᴰ * ψ(bulk_richardson_number(h, θ₀, T_warm, U, U_min)) for (Cᴰ, U) in zip(Cᴰ_neutral, U_range)]
-Cᴰ_sim_cold = [Cᴰ * ψ(bulk_richardson_number(h, θ₀, T_cold, U, U_min)) for (Cᴰ, U) in zip(Cᴰ_neutral, U_range)]
+Cᴰ_unstable = [Cᴰ * sf(bulk_richardson_number(h, θ₀, T_unstable, U, U_min), α, β) for (Cᴰ, U) in zip(Cᴰ_neutral, U_range)]
+Cᴰ_stable   = [Cᴰ * sf(bulk_richardson_number(h, θ₀, T_stable,   U, U_min), α, β) for (Cᴰ, U) in zip(Cᴰ_neutral, U_range)]
+Cᴰ_sim_warm = [Cᴰ * sf(bulk_richardson_number(h, θ₀, T_warm, U, U_min), α, β) for (Cᴰ, U) in zip(Cᴰ_neutral, U_range)]
+Cᴰ_sim_cold = [Cᴰ * sf(bulk_richardson_number(h, θ₀, T_cold, U, U_min), α, β) for (Cᴰ, U) in zip(Cᴰ_neutral, U_range)]
 
 fig = Figure(size=(1100, 400))
 

--- a/src/BoundaryConditions/polynomial_bulk_coefficient.jl
+++ b/src/BoundaryConditions/polynomial_bulk_coefficient.jl
@@ -9,47 +9,343 @@ const default_neutral_drag_polynomial            = (0.142, 0.076, 2.7)
 const default_neutral_sensible_heat_polynomial   = (0.128, 0.068, 2.43)
 const default_neutral_latent_heat_polynomial     = (0.120, 0.070, 2.55)
 
+#####
+##### StabilityFunctionParameters: Ψ function constants
+#####
+
 """
-    DefaultStabilityFunction()
+    StabilityFunctionParameters(FT = Oceananigans.defaults.FloatType;
+        γᴰ = 19.3, γᵀ = 11.6, a = 1, b = 2/3, c = 5, d = 0.35)
 
-Stability correction factor based on the bulk Richardson number ``Ri``.
+Parameters for the integrated Monin-Obukhov stability functions ``Ψ^D(ζ)``
+and ``Ψ^T(ζ)``.
 
-For unstable conditions (``Ri < 0``):
-```math
-ψ = √(1 - 16 \\, Ri)
-```
+Note: we use superscript D (drag/momentum) and T (temperature/scalar) to match the
+transfer coefficient notation ``Cᴰ``, ``Cᵀ`` established in `notation.md`.
+In the literature these are commonly written ``Ψ_m`` and ``Ψ_h``.
 
-For stable conditions (``Ri ≥ 0``):
-```math
-ψ = 1 / (1 + 10 \\, Ri)
-```
+For unstable conditions (``ζ < 0``), uses Hogström (1996):
+- ``φ^D = (1 - γ^D ζ)^{-1/4}``
+- ``φ^T = 0.95(1 - γ^T ζ)^{-1/2}``
 
-Multiplies the neutral transfer coefficient so that unstable conditions
-enhance transfer (``ψ > 1``) and stable conditions reduce it (``ψ < 1``).
+For stable conditions (``ζ ≥ 0``), uses Beljaars & Holtslag (1991):
+- ``Ψ^D = -(a ζ + b (ζ - c/d) e^{-dζ} + bc/d)``
+- ``Ψ^T = -((1 + 2aζ/3)^{3/2} + b (ζ - c/d) e^{-dζ} + bc/d - 1)``
+
+# References
+
+* Hogström, U. (1996). Review of some basic characteristics of the atmospheric
+  surface layer. Boundary-Layer Meteorology, 78, 215-246.
+* Beljaars, A. C. M., & Holtslag, A. A. M. (1991). Flux parameterization over
+  land surfaces for atmospheric models. Journal of Applied Meteorology, 30, 327-341.
 """
-struct DefaultStabilityFunction end
-
-@inline function (::DefaultStabilityFunction)(Riᵦ)
-    Ψ⁻ = sqrt(max(1 - 16 * Riᵦ, 0))  # unstable branch
-    Ψ⁺ = 1 / (1 + 10 * max(Riᵦ, 0))  # stable branch
-    return ifelse(Riᵦ < 0, Ψ⁻, Ψ⁺)
+struct StabilityFunctionParameters{FT}
+    γᴰ :: FT
+    γᵀ :: FT
+    a :: FT
+    b :: FT
+    c :: FT
+    d :: FT
 end
 
-Base.summary(::DefaultStabilityFunction) = "ψ(Ri) = √(1-16Ri) unstable, 1/(1+10Ri) stable"
-
-function Base.show(io::IO, ::DefaultStabilityFunction)
-    println(io, "DefaultStabilityFunction")
-    println(io, "├── Ri < 0 (unstable): ψ = √(1 - 16 Ri)")
-    print(io,   "└── Ri ≥ 0 (stable):   ψ = 1 / (1 + 10 Ri)")
+function StabilityFunctionParameters(FT = Oceananigans.defaults.FloatType;
+                                     γᴰ = 19.3,
+                                     γᵀ = 11.6,
+                                     a = 1,
+                                     b = 2/3,
+                                     c = 5,
+                                     d = 0.35)
+    return StabilityFunctionParameters{FT}(FT(γᴰ), FT(γᵀ), FT(a), FT(b), FT(c), FT(d))
 end
 
-const default_stability_function = DefaultStabilityFunction()
+#####
+##### RichardsonNumberMapping: Li et al. (2010) regression coefficients
+#####
+
+"""
+    RichardsonNumberMapping(FT = Oceananigans.defaults.FloatType; kwargs...)
+
+Regression coefficients for the non-iterative mapping from bulk Richardson number
+``Riᴮ`` to the Monin-Obukhov stability parameter ``ζ = z/L``, following
+Li et al. (2010).
+
+The superscripts u, w, s denote unstable, weakly stable, and strongly stable
+regimes respectively. Subscript indices follow the original paper.
+
+Three regimes:
+- **Unstable** (``Riᴮ <`` `stable_unstable_transition`): Eq. 12
+- **Weakly stable** (`stable_unstable_transition` ``≤ Riᴮ ≤`` `strongly_stable_transition`): Eq. 14
+- **Strongly stable** (``Riᴮ >`` `strongly_stable_transition`): Eq. 16
+
+# References
+
+* Li, Y., Gao, Z., Lenschow, D. H., & Chen, F. (2010). An improved approach for
+  parameterizing surface-layer turbulent transfer coefficients in numerical models.
+  Boundary-Layer Meteorology, 137, 153-165.
+"""
+struct RichardsonNumberMapping{FT}
+    # Regime thresholds
+    stable_unstable_transition :: FT
+    strongly_stable_transition :: FT
+
+    # Unstable regime (Eq. 12)
+    aᵘ₁₁ :: FT
+    bᵘ₁₁ :: FT
+    bᵘ₁₂ :: FT
+    aᵘ₂₁ :: FT
+    aᵘ₂₂ :: FT
+    bᵘ₃₁ :: FT
+    bᵘ₃₂ :: FT
+    bᵘ₃₃ :: FT
+
+    # Weakly stable regime (Eq. 14)
+    aʷ₁₁ :: FT
+    aʷ₁₂ :: FT
+    aʷ₂₁ :: FT
+    aʷ₂₂ :: FT
+    bʷ₁₁ :: FT
+    bʷ₁₂ :: FT
+    bʷ₂₁ :: FT
+    bʷ₂₂ :: FT
+
+    # Strongly stable regime (Eq. 16)
+    aˢ₁₁ :: FT
+    aˢ₂₁ :: FT
+    bˢ₁₁ :: FT
+    bˢ₂₁ :: FT
+    bˢ₂₂ :: FT
+end
+
+function RichardsonNumberMapping(FT = Oceananigans.defaults.FloatType;
+                                 stable_unstable_transition = 0,
+                                 strongly_stable_transition = 0.2,
+                                 aᵘ₁₁ =  0.0450, bᵘ₁₁ =  0.0030, bᵘ₁₂ =  0.0059,
+                                 aᵘ₂₁ = -0.0828, aᵘ₂₂ =  0.8845,
+                                 bᵘ₃₁ =  0.1739, bᵘ₃₂ = -0.9213, bᵘ₃₃ = -0.1057,
+                                 aʷ₁₁ =  0.5738, aʷ₁₂ = -0.4399,
+                                 aʷ₂₁ = -4.901,  aʷ₂₂ = 52.50,
+                                 bʷ₁₁ = -0.0539, bʷ₁₂ =  1.540,
+                                 bʷ₂₁ = -0.6690, bʷ₂₂ = -3.282,
+                                 aˢ₁₁ =  0.7529, aˢ₂₁ = 14.94,
+                                 bˢ₁₁ =  0.1569, bˢ₂₁ = -0.3091, bˢ₂₂ = -1.303)
+    return RichardsonNumberMapping{FT}(
+        FT(stable_unstable_transition), FT(strongly_stable_transition),
+        FT(aᵘ₁₁), FT(bᵘ₁₁), FT(bᵘ₁₂), FT(aᵘ₂₁), FT(aᵘ₂₂), FT(bᵘ₃₁), FT(bᵘ₃₂), FT(bᵘ₃₃),
+        FT(aʷ₁₁), FT(aʷ₁₂), FT(aʷ₂₁), FT(aʷ₂₂), FT(bʷ₁₁), FT(bʷ₁₂), FT(bʷ₂₁), FT(bʷ₂₂),
+        FT(aˢ₁₁), FT(aˢ₂₁), FT(bˢ₁₁), FT(bˢ₂₁), FT(bˢ₂₂))
+end
+
+#####
+##### FittedStabilityFunction
+#####
+
+"""
+    FittedStabilityFunction(scalar_roughness_length;
+        richardson_number_mapping = RichardsonNumberMapping(...),
+        stability_function_parameters = StabilityFunctionParameters(...))
+
+Stability correction based on Monin-Obukhov similarity theory using the
+Li et al. (2010) analytical mapping from bulk Richardson number to the
+stability parameter ``ζ = z/L``.
+
+Uses Hogström (1996) integrated stability functions for unstable conditions and
+Beljaars & Holtslag (1991) for stable conditions.
+
+Applies structurally correct (and different) corrections for momentum vs scalar transfer:
+- Momentum: ``Cᴰ = Cᴰ_N [α / (α - Ψᴰ)]²``
+- Scalar:   ``Cᵀ = Cᵀ_N [α / (α - Ψᴰ)] [β_h / (β_h - Ψᵀ)]``
+
+where ``α = \\ln(z/ℓ)``, ``β_h = \\ln(z/ℓ_h)``.
+
+`FittedStabilityFunction` is callable: `sf(Riᴮ, α, β)` returns the momentum
+stability correction factor, and `sf(Riᴮ, α, β, Val(:scalar))` returns the
+scalar correction factor.
+
+# Arguments
+- `scalar_roughness_length`: Roughness length for heat/moisture ``ℓ_h`` (m).
+
+# Keyword Arguments
+- `richardson_number_mapping`: [`RichardsonNumberMapping`](@ref) coefficients (default: Li et al. 2010).
+- `stability_function_parameters`: [`StabilityFunctionParameters`](@ref) (default: Hogström 1996 / Beljaars & Holtslag 1991).
+
+# References
+
+* Li, Y., Gao, Z., Lenschow, D. H., & Chen, F. (2010). An improved approach for
+  parameterizing surface-layer turbulent transfer coefficients in numerical models.
+  Boundary-Layer Meteorology, 137, 153-165.
+* Hogström, U. (1996). Review of some basic characteristics of the atmospheric surface layer.
+  Boundary-Layer Meteorology, 78, 215-246.
+* Beljaars, A. C. M., & Holtslag, A. A. M. (1991). Flux parameterization over land surfaces
+  for atmospheric models. Journal of Applied Meteorology, 30, 327-341.
+"""
+struct FittedStabilityFunction{FT, RM, SP}
+    scalar_roughness_length :: FT
+    richardson_number_mapping :: RM
+    stability_function_parameters :: SP
+end
+
+function FittedStabilityFunction(scalar_roughness_length;
+    richardson_number_mapping = RichardsonNumberMapping(typeof(scalar_roughness_length)),
+    stability_function_parameters = StabilityFunctionParameters(typeof(scalar_roughness_length)))
+    return FittedStabilityFunction(scalar_roughness_length,
+                                   richardson_number_mapping,
+                                   stability_function_parameters)
+end
+
+Base.summary(::FittedStabilityFunction) = "FittedStabilityFunction (Li et al. 2010)"
+
+function Base.show(io::IO, sf::FittedStabilityFunction)
+    println(io, "FittedStabilityFunction (Li et al. 2010)")
+    println(io, "├── scalar_roughness_length: ", sf.scalar_roughness_length, " m")
+    println(io, "├── Riᴮ → ζ mapping: Li et al. (2010)")
+    println(io, "├── Unstable Ψᴰ, Ψᵀ: Hogström (1996)")
+    print(io,   "└── Stable Ψᴰ, Ψᵀ: Beljaars & Holtslag (1991)")
+end
+
+# Callable interface: compute stability correction factor
+@inline function (sf::FittedStabilityFunction)(Riᴮ, α, β, transfer_type=Val(:momentum))
+    ζ = bulk_to_flux_richardson_number(Riᴮ, α, β, sf.richardson_number_mapping)
+    Ψᴰ = integrated_stability_momentum(ζ, sf.stability_function_parameters)
+    Ψᵀ = integrated_stability_scalar(ζ, sf.stability_function_parameters)
+    return stability_correction_factor(α, β, Ψᴰ, Ψᵀ, transfer_type)
+end
+
+#####
+##### Li et al. (2010) bulk Richardson number to flux Richardson number mapping
+#####
+
+"""
+$(TYPEDSIGNATURES)
+
+Map bulk Richardson number ``Riᴮ`` to the Monin-Obukhov stability parameter
+``ζ = z/L`` using the regression equations of Li et al. (2010).
+
+# Arguments
+- `Riᴮ`: Bulk Richardson number
+- `α`: ``\\ln(z / ℓ)``
+- `β`: ``\\ln(ℓ / ℓ_h)``
+- `mapping`: [`RichardsonNumberMapping`](@ref) with regression coefficients
+"""
+@inline function bulk_to_flux_richardson_number(Riᴮ, α, β, mapping)
+    ζ⁻ = unstable_bulk_to_flux_richardson_number(Riᴮ, α, β, mapping)
+    ζʷ = weakly_stable_bulk_to_flux_richardson_number(Riᴮ, α, β, mapping)
+    ζˢ = strongly_stable_bulk_to_flux_richardson_number(Riᴮ, α, β, mapping)
+    return ifelse(Riᴮ < mapping.stable_unstable_transition,
+                  ζ⁻,
+                  ifelse(Riᴮ ≤ mapping.strongly_stable_transition, ζʷ, ζˢ))
+end
+
+# Unstable regime (Riᴮ < 0), Li et al. (2010) Eq. 12
+@inline function unstable_bulk_to_flux_richardson_number(Riᴮ, α, β, mapping)
+    A = mapping.aᵘ₁₁ * α
+    B = (mapping.bᵘ₁₁ * β + mapping.bᵘ₁₂) * α^2 +
+        (mapping.aᵘ₂₁ * β + mapping.aᵘ₂₂) * α +
+        (mapping.bᵘ₃₁ * β^2 + mapping.bᵘ₃₂ * β + mapping.bᵘ₃₃)
+    return A * Riᴮ^2 + B * Riᴮ
+end
+
+# Weakly stable regime (0 ≤ Riᴮ ≤ Ri*), Li et al. (2010) Eq. 14
+@inline function weakly_stable_bulk_to_flux_richardson_number(Riᴮ, α, β, mapping)
+    A = (mapping.aʷ₁₁ * β + mapping.aʷ₁₂) * α + (mapping.aʷ₂₁ * β + mapping.aʷ₂₂)
+    B = (mapping.bʷ₁₁ * β + mapping.bʷ₁₂) * α + (mapping.bʷ₂₁ * β + mapping.bʷ₂₂)
+    return A * Riᴮ^2 + B * Riᴮ
+end
+
+# Strongly stable regime (Riᴮ > Ri*), Li et al. (2010) Eq. 16
+@inline function strongly_stable_bulk_to_flux_richardson_number(Riᴮ, α, β, mapping)
+    return (mapping.aˢ₁₁ * α + mapping.aˢ₂₁) * Riᴮ +
+            mapping.bˢ₁₁ * α + mapping.bˢ₂₁ * β + mapping.bˢ₂₂
+end
+
+#####
+##### Integrated MOST stability functions
+#####
+
+"""
+$(TYPEDSIGNATURES)
+
+Integrated stability function for momentum ``Ψᴰ(ζ)``.
+
+Note: ``Ψᴰ`` corresponds to ``Ψ_m`` in the literature.
+"""
+@inline function integrated_stability_momentum(ζ, params)
+    FT = typeof(ζ)
+    Ψ⁻ = unstable_Ψᴰ(ζ, params)
+    Ψ⁺ = stable_Ψᴰ(ζ, params)
+    return ifelse(ζ < zero(FT), Ψ⁻, Ψ⁺)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Integrated stability function for scalars (heat, moisture) ``Ψᵀ(ζ)``.
+
+Note: ``Ψᵀ`` corresponds to ``Ψ_h`` in the literature.
+"""
+@inline function integrated_stability_scalar(ζ, params)
+    FT = typeof(ζ)
+    Ψ⁻ = unstable_Ψᵀ(ζ, params)
+    Ψ⁺ = stable_Ψᵀ(ζ, params)
+    return ifelse(ζ < zero(FT), Ψ⁻, Ψ⁺)
+end
+
+# Hogström (1996) unstable Ψᴰ: φᴰ = (1 - γᴰ ζ)^{-1/4}
+@inline function unstable_Ψᴰ(ζ, params)
+    FT = typeof(ζ)
+    x = sqrt(sqrt(max(1 - params.γᴰ * ζ, zero(FT))))
+    return 2 * log((1 + x) / 2) + log((1 + x^2) / 2) - 2 * atan(x) + FT(π) / 2
+end
+
+# Hogström (1996) unstable Ψᵀ: φᵀ = 0.95(1 - γᵀ ζ)^{-1/2}
+@inline function unstable_Ψᵀ(ζ, params)
+    FT = typeof(ζ)
+    y = sqrt(max(1 - params.γᵀ * ζ, zero(FT)))
+    return 2 * log((1 + y) / 2)
+end
+
+# Beljaars & Holtslag (1991) stable Ψᴰ
+@inline function stable_Ψᴰ(ζ, params)
+    (; a, b, c, d) = params
+    return -(a * ζ + b * (ζ - c / d) * exp(-d * ζ) + b * c / d)
+end
+
+# Beljaars & Holtslag (1991) stable Ψᵀ
+@inline function stable_Ψᵀ(ζ, params)
+    FT = typeof(ζ)
+    (; a, b, c, d) = params
+    x = max(1 + 2 * a / 3 * ζ, zero(FT))
+    return -(x * sqrt(x) + b * (ζ - c / d) * exp(-d * ζ) + b * c / d - 1)
+end
+
+#####
+##### Stability correction factors for momentum and scalar transfer
+#####
+
+@inline function stability_correction_factor(α, β, Ψᴰ, Ψᵀ, ::Val{:momentum})
+    denominator_D = max(α - Ψᴰ, α / 10)
+    return (α / denominator_D)^2
+end
+
+@inline function stability_correction_factor(α, β, Ψᴰ, Ψᵀ, ::Val{:scalar})
+    βh = α + β
+    denominator_D = max(α - Ψᴰ, α / 10)
+    denominator_T = max(βh - Ψᵀ, βh / 10)
+    return (α / denominator_D) * (βh / denominator_T)
+end
+
+# Default to momentum when transfer_type is not set
+@inline stability_correction_factor(α, β, Ψᴰ, Ψᵀ, ::Nothing) =
+    stability_correction_factor(α, β, Ψᴰ, Ψᵀ, Val(:momentum))
+
+#####
+##### PolynomialCoefficient struct
+#####
 
 """
     PolynomialCoefficient(;
         polynomial = nothing,
         roughness_length = 1.5e-4,
-        stability_function = DefaultStabilityFunction(),
+        stability_function = FittedStabilityFunction(roughness_length / 7.3),
         surface = PlanarLiquidSurface()
     )
 
@@ -63,10 +359,7 @@ C^N_{10}(U_h) = (a_0 + a_1 U_h + a_2 / U_h) × 10^{-3}
 where ``U_h`` is the wind speed at measurement height ``h``.
 
 The coefficient is adjusted for measurement height using logarithmic profile theory,
-and when a `stability_function` is provided, further modified by the bulk Richardson number:
-```math
-Ri = \\frac{g}{\\overline{θ_v}} \\frac{h \\, (θ_v - θ_{v0})}{U_h^2}
-```
+and stability correction is applied based on the bulk Richardson number.
 
 When `polynomial` is `nothing`, the appropriate Large & Yeager (2009) polynomial
 will be automatically selected based on the boundary condition type:
@@ -77,10 +370,13 @@ will be automatically selected based on the boundary condition type:
 # Keyword Arguments
 - `polynomial`: Tuple `(a₀, a₁, a₂)` for the polynomial. If `nothing`, the polynomial
   is automatically selected by the boundary condition constructor.
-- `roughness_length`: Surface roughness ℓ in meters (default: 1.5e-4, typical for ocean)
+- `roughness_length`: Surface roughness `ℓ` in meters (default: 1.5e-4, typical for ocean)
 - `minimum_wind_speed`: Minimum wind speed to avoid singularity in a₂/U term (default: 0.1 m/s)
-- `stability_function`: Callable `ψ(Ri)` that computes stability correction factor from bulk Richardson number.
-  Set to `nothing` to disable stability correction. Default is `DefaultStabilityFunction()`.
+- `stability_function`: Stability correction strategy.
+  Default is [`FittedStabilityFunction`](@ref) using Li et al. (2010) ``Riᴮ → ζ`` mapping
+  with Hogström (1996) / Beljaars & Holtslag (1991) MOST stability functions.
+  The scalar roughness length defaults to `roughness_length / 7.3` (typical ocean value).
+  Use `nothing` to disable stability correction.
 - `surface`: Surface type for computing saturation specific humidity in the stability correction.
   Default is `PlanarLiquidSurface()`. Use `PlanarIceSurface()` for ice surfaces.
 
@@ -101,7 +397,7 @@ PolynomialCoefficient{Float64}
 ├── roughness_length: 0.00015 m
 ├── minimum_wind_speed: 0.1 m/s
 ├── surface: PlanarLiquidSurface
-└── stability_function: ψ(Ri) = √(1-16Ri) unstable, 1/(1+10Ri) stable
+└── stability_function: FittedStabilityFunction (Li et al. 2010)
 ```
 
 ```jldoctest
@@ -116,7 +412,7 @@ PolynomialCoefficient{Float64}
 ├── roughness_length: 0.00015 m
 ├── minimum_wind_speed: 0.1 m/s
 ├── surface: PlanarLiquidSurface
-└── stability_function: ψ(Ri) = √(1-16Ri) unstable, 1/(1+10Ri) stable
+└── stability_function: FittedStabilityFunction (Li et al. 2010)
 ```
 
 ```jldoctest
@@ -137,8 +433,9 @@ PolynomialCoefficient{Float64}
 # References
 
 * Large, W., & Yeager, S. G. (2009). The global climatology of an interannually varying air–sea flux data set. Climate dynamics, 33(2), 341-364.
+* Li, Y., Gao, Z., Lenschow, D. H., & Chen, F. (2010). An improved approach for parameterizing surface-layer turbulent transfer coefficients in numerical models. Boundary-Layer Meteorology, 137, 153-165.
 """
-struct PolynomialCoefficient{FT, C, SF, S, θᵛ, P, TC}
+struct PolynomialCoefficient{FT, C, SF, S, θᵛ, P, TC, TT}
     polynomial :: C
     roughness_length :: FT
     minimum_wind_speed :: FT
@@ -147,22 +444,25 @@ struct PolynomialCoefficient{FT, C, SF, S, θᵛ, P, TC}
     virtual_potential_temperature :: θᵛ
     surface_pressure :: P
     thermodynamic_constants :: TC
+    transfer_type :: TT
 end
 
 # Constructor with sensible defaults
-function PolynomialCoefficient(FT = Float64;
+function PolynomialCoefficient(FT = Oceananigans.defaults.FloatType;
                                polynomial = nothing,
                                roughness_length = 1.5e-4,
                                minimum_wind_speed = 0.1,
-                               stability_function = DefaultStabilityFunction(),
-                               surface = PlanarLiquidSurface())
+                               stability_function = FittedStabilityFunction(FT(roughness_length / 7.3)),
+                               surface = PlanarLiquidSurface(),
+                               transfer_type = nothing)
 
     return PolynomialCoefficient(polynomial,
                                  FT(roughness_length),
                                  FT(minimum_wind_speed),
                                  stability_function,
                                  surface,
-                                 nothing, nothing, nothing)
+                                 nothing, nothing, nothing,
+                                 transfer_type)
 end
 
 Adapt.adapt_structure(to, coef::PolynomialCoefficient) =
@@ -173,7 +473,8 @@ Adapt.adapt_structure(to, coef::PolynomialCoefficient) =
                           coef.surface,
                           Adapt.adapt(to, coef.virtual_potential_temperature),
                           Adapt.adapt(to, coef.surface_pressure),
-                          Adapt.adapt(to, coef.thermodynamic_constants))
+                          Adapt.adapt(to, coef.thermodynamic_constants),
+                          coef.transfer_type)
 
 function Base.show(io::IO, coef::PolynomialCoefficient{FT}) where FT
     println(io, "PolynomialCoefficient{$FT}")
@@ -209,14 +510,14 @@ Wind speed is clamped to `U_min` to avoid singularity in the a₂/U term.
 end
 
 #####
-##### Bulk Richardson number and stability correction
+##### Bulk Richardson number
 #####
 
 """
 $(TYPEDSIGNATURES)
 
 Compute bulk Richardson number:
-Ri = (g/θ̄ᵥ) × h × (θᵥ - θᵥ₀) / U²
+Riᴮ = (g/θ̄ᵥ) × h × (θᵥ - θᵥ₀) / U²
 
 Wind speed is clamped to `U_min` to avoid singularity.
 
@@ -292,26 +593,36 @@ Returns the transfer coefficient (dimensionless).
     # C(h) = C₁₀ × [ln(10/ℓ) / ln(h/ℓ)]²
     h = znode(i, j, 1, grid, Center(), Center(), Center())
     ℓ = coef.roughness_length
-    Cʰ = C¹⁰ * (log(10 / ℓ) / log(h / ℓ))^2
+    α = log(h / ℓ)
+    Cʰ = C¹⁰ * (log(10 / ℓ) / α)^2
 
     # Apply stability correction
-    return stability_corrected_coefficient(i, j, grid, coef, Cʰ, U, T₀)
+    return stability_corrected_coefficient(i, j, grid, coef, Cʰ, h, α, U, T₀)
 end
 
 # No stability correction (stability_function = nothing)
-@inline stability_corrected_coefficient(i, j, grid, ::PolynomialCoefficient{<:Any, <:Any, Nothing}, Cʰ, U, T₀) = Cʰ
+@inline stability_corrected_coefficient(i, j, grid,
+    ::PolynomialCoefficient{<:Any, <:Any, Nothing}, Cʰ, h, α, U, T₀) = Cʰ
 
-# Stability correction with a function — uses stored VPT and surface pressure
-@inline function stability_corrected_coefficient(i, j, grid, coef::PolynomialCoefficient, Cʰ, U, T₀)
-    h = znode(i, j, 1, grid, Center(), Center(), Center())
+# FittedStabilityFunction correction (Li et al. 2010 mapping + MOST Ψ functions)
+@inline function stability_corrected_coefficient(i, j, grid,
+    coef::PolynomialCoefficient{<:Any, <:Any, <:FittedStabilityFunction}, Cʰ, h, α, U, T₀)
+
+    sf = coef.stability_function
+    ℓ = coef.roughness_length
+    ℓh = sf.scalar_roughness_length
+    β = log(ℓ / ℓh)
+
     θᵥ = @inbounds coef.virtual_potential_temperature[i, j, 1]
     θᵥ₀ = surface_virtual_potential_temperature(T₀, coef.surface_pressure, coef.thermodynamic_constants, coef.surface)
-    Riᵦ = bulk_richardson_number(h, θᵥ, θᵥ₀, U, coef.minimum_wind_speed)
-    return Cʰ * coef.stability_function(Riᵦ)
+    Riᴮ = bulk_richardson_number(h, θᵥ, θᵥ₀, U, coef.minimum_wind_speed)
+
+    return Cʰ * sf(Riᴮ, α, β, coef.transfer_type)
 end
 
 #####
 ##### Bulk coefficient evaluation
+#####
 #####
 ##### Unified interface for evaluating bulk transfer coefficients. Dispatches
 ##### on the coefficient type: constant Number returns directly, callable
@@ -330,14 +641,15 @@ end
 ##### Default polynomial filling
 #####
 
-# Helper: fill in a default polynomial for a PolynomialCoefficient that has `nothing`
-fill_polynomial(coef::PolynomialCoefficient, polynomial) =
+# Helper: fill in a default polynomial and transfer type for a PolynomialCoefficient
+fill_polynomial(coef::PolynomialCoefficient, polynomial, transfer_type) =
     PolynomialCoefficient(polynomial,
                           coef.roughness_length,
                           coef.minimum_wind_speed,
                           coef.stability_function,
                           coef.surface,
-                          nothing, nothing, nothing)
+                          nothing, nothing, nothing,
+                          transfer_type)
 
 # Type alias for PolynomialCoefficient with no polynomial set
 const NothingPolynomialCoefficient = PolynomialCoefficient{<:Any, Nothing}

--- a/src/Breeze.jl
+++ b/src/Breeze.jl
@@ -81,7 +81,7 @@ export
     BulkSensibleHeatFlux,
     BulkVaporFlux,
     PolynomialCoefficient,
-    DefaultStabilityFunction,
+    FittedStabilityFunction,
     default_neutral_drag_polynomial,
     default_neutral_sensible_heat_polynomial,
     default_neutral_latent_heat_polynomial,

--- a/test/polynomial_bulk_coefficients.jl
+++ b/test/polynomial_bulk_coefficients.jl
@@ -2,19 +2,36 @@ using Test
 using Breeze
 using Breeze.BoundaryConditions
 using Breeze.BoundaryConditions: PolynomialCoefficient,
-                                 DefaultStabilityFunction,
+                                 FittedStabilityFunction,
+                                 StabilityFunctionParameters,
+                                 RichardsonNumberMapping,
                                  neutral_coefficient_10m,
-                                 bulk_richardson_number
+                                 bulk_richardson_number,
+                                 bulk_to_flux_richardson_number,
+                                 integrated_stability_momentum,
+                                 integrated_stability_scalar,
+                                 stability_correction_factor
 using Oceananigans
 using Oceananigans.BoundaryConditions: BoundaryCondition
 
 @testset "PolynomialCoefficient" begin
     @testset "Constructor and defaults" begin
-        # Test default constructor
+        # Test default constructor — uses FittedStabilityFunction
         coef = PolynomialCoefficient()
         @test coef.polynomial === nothing
         @test coef.roughness_length == 1.5e-4
-        @test coef.stability_function isa DefaultStabilityFunction
+        @test coef.stability_function isa FittedStabilityFunction
+        @test coef.stability_function.scalar_roughness_length ≈ 1.5e-4 / 7.3
+
+        # Scalar roughness length follows roughness_length / 7.3
+        coef_custom_rl = PolynomialCoefficient(roughness_length = 1e-3)
+        @test coef_custom_rl.stability_function.scalar_roughness_length ≈ 1e-3 / 7.3
+
+        # FittedStabilityFunction embeds parameter structs
+        sf = coef.stability_function
+        @test sf.richardson_number_mapping isa RichardsonNumberMapping
+        @test sf.stability_function_parameters isa StabilityFunctionParameters
+        @test sf.richardson_number_mapping.strongly_stable_transition ≈ 0.2
 
         # Test explicit coefficients
         drag_coef = PolynomialCoefficient(polynomial = (0.142, 0.076, 2.7))
@@ -26,7 +43,7 @@ using Oceananigans.BoundaryConditions: BoundaryCondition
         moisture_coef = PolynomialCoefficient(polynomial = (0.120, 0.070, 2.55))
         @test moisture_coef.polynomial == (0.120, 0.070, 2.55)
 
-        # Test custom coefficients
+        # Test custom coefficients with no stability
         custom_coef = PolynomialCoefficient(
             polynomial = (1.0, 0.5, 0.1),
             roughness_length = 1e-3,
@@ -36,6 +53,34 @@ using Oceananigans.BoundaryConditions: BoundaryCondition
         @test isnothing(custom_coef.stability_function)
     end
 
+    @testset "Parameter structs" begin
+        # Default RichardsonNumberMapping has Li et al. (2010) values
+        mapping = RichardsonNumberMapping()
+        @test mapping.stable_unstable_transition ≈ 0.0
+        @test mapping.strongly_stable_transition ≈ 0.2
+        @test mapping.aᵘ₁₁ ≈ 0.0450
+        @test mapping.aᵘ₂₂ ≈ 0.8845
+        @test mapping.aˢ₁₁ ≈ 0.7529
+
+        # Custom thresholds
+        mapping_custom = RichardsonNumberMapping(strongly_stable_transition = 0.3)
+        @test mapping_custom.strongly_stable_transition ≈ 0.3
+
+        # Default StabilityFunctionParameters
+        params = StabilityFunctionParameters()
+        @test params.γᴰ ≈ 19.3
+        @test params.γᵀ ≈ 11.6
+        @test params.a ≈ 1.0
+        @test params.b ≈ 2/3
+        @test params.c ≈ 5.0
+        @test params.d ≈ 0.35
+
+        # Custom parameters
+        params_custom = StabilityFunctionParameters(γᴰ = 16.0, γᵀ = 12.0)
+        @test params_custom.γᴰ ≈ 16.0
+        @test params_custom.γᵀ ≈ 12.0
+    end
+
     @testset "Neutral coefficient computation" begin
         # Test Large & Yeager form at U = 10 m/s
         coeffs = (0.142, 0.076, 2.7)  # Large & Yeager (2009) drag coefficients
@@ -43,7 +88,7 @@ using Oceananigans.BoundaryConditions: BoundaryCondition
         U_min = 0.1
         C = neutral_coefficient_10m(coeffs, U, U_min)
 
-        # C_D = (0.142 + 0.076*10 + 2.7/10) × 10⁻³
+        # Cᴰ = (0.142 + 0.076*10 + 2.7/10) × 10⁻³
         #     = (0.142 + 0.76 + 0.27) × 10⁻³
         #     = 1.172 × 10⁻³
         @test C ≈ 1.172e-3 atol=1e-6
@@ -51,13 +96,13 @@ using Oceananigans.BoundaryConditions: BoundaryCondition
         # Test at low wind speed
         U_low = 1.0
         C_low = neutral_coefficient_10m(coeffs, U_low, U_min)
-        # C_D = (0.142 + 0.076*1 + 2.7/1) × 10⁻³ = 2.918 × 10⁻³
+        # Cᴰ = (0.142 + 0.076*1 + 2.7/1) × 10⁻³ = 2.918 × 10⁻³
         @test C_low ≈ 2.918e-3 atol=1e-6
 
         # Test at high wind speed
         U_high = 20.0
         C_high = neutral_coefficient_10m(coeffs, U_high, U_min)
-        # C_D = (0.142 + 0.076*20 + 2.7/20) × 10⁻³
+        # Cᴰ = (0.142 + 0.076*20 + 2.7/20) × 10⁻³
         #     = (0.142 + 1.52 + 0.135) × 10⁻³ = 1.797 × 10⁻³
         @test C_high ≈ 1.797e-3 atol=1e-6
     end
@@ -83,21 +128,125 @@ using Oceananigans.BoundaryConditions: BoundaryCondition
         @test Ri_stable > 0
     end
 
-    @testset "Stability functions" begin
-        # Unstable conditions (Ri < 0) enhance transfer
-        Ri_unstable = -0.1
-        ψ_unstable = DefaultStabilityFunction()(Ri_unstable)
-        @test ψ_unstable > 1.0
+    @testset "Li et al. (2010) Riᴮ → ζ mapping" begin
+        α = log(1e4)  # z/ℓ = 10⁴
+        β = log(7.3)  # ℓ/ℓh = 7.3
+        mapping = RichardsonNumberMapping()
 
-        # Neutral conditions (Ri = 0) don't modify coefficient
-        Ri_neutral = 0.0
-        ψ_neutral = DefaultStabilityFunction()(Ri_neutral)
-        @test ψ_neutral ≈ 1.0
+        # Neutral: Riᴮ = 0 gives ζ = 0
+        @test bulk_to_flux_richardson_number(0.0, α, β, mapping) ≈ 0.0 atol=1e-10
 
-        # Stable conditions (Ri > 0) reduce transfer
-        Ri_stable = 0.1
-        ψ_stable = DefaultStabilityFunction()(Ri_stable)
-        @test ψ_stable < 1.0
+        # Unstable: Riᴮ < 0 gives ζ < 0
+        @test bulk_to_flux_richardson_number(-0.5, α, β, mapping) < 0
+        @test bulk_to_flux_richardson_number(-1.0, α, β, mapping) < 0
+
+        # Stable: Riᴮ > 0 gives ζ > 0
+        @test bulk_to_flux_richardson_number(0.1, α, β, mapping) > 0
+        @test bulk_to_flux_richardson_number(0.5, α, β, mapping) > 0
+
+        # Monotonicity: more unstable → more negative ζ
+        @test bulk_to_flux_richardson_number(-1.0, α, β, mapping) < bulk_to_flux_richardson_number(-0.5, α, β, mapping)
+
+        # Monotonicity: more stable → more positive ζ
+        @test bulk_to_flux_richardson_number(0.5, α, β, mapping) > bulk_to_flux_richardson_number(0.1, α, β, mapping)
+
+        # Test with β = 0 (ℓ = ℓh)
+        β0 = 0.0
+        @test bulk_to_flux_richardson_number(0.0, α, β0, mapping) ≈ 0.0 atol=1e-10
+        @test bulk_to_flux_richardson_number(-1.0, α, β0, mapping) < 0
+        @test bulk_to_flux_richardson_number(0.5, α, β0, mapping) > 0
+
+        # Test across regime boundaries
+        ζ_weakly = bulk_to_flux_richardson_number(0.19, α, β, mapping)
+        ζ_strongly = bulk_to_flux_richardson_number(0.21, α, β, mapping)
+        @test ζ_weakly > 0
+        @test ζ_strongly > 0
+    end
+
+    @testset "Integrated stability functions Ψᴰ and Ψᵀ" begin
+        params = StabilityFunctionParameters()
+
+        # At ζ = 0, both Ψᴰ and Ψᵀ should be 0 (continuity)
+        @test integrated_stability_momentum(0.0, params) ≈ 0.0 atol=1e-10
+        @test integrated_stability_scalar(0.0, params) ≈ 0.0 atol=1e-10
+
+        # Unstable (ζ < 0): Ψ > 0
+        @test integrated_stability_momentum(-1.0, params) > 0
+        @test integrated_stability_scalar(-1.0, params) > 0
+
+        # Stable (ζ > 0): Ψ < 0
+        @test integrated_stability_momentum(1.0, params) < 0
+        @test integrated_stability_scalar(1.0, params) < 0
+
+        # Monotonicity: more unstable → larger positive Ψ
+        @test integrated_stability_momentum(-2.0, params) > integrated_stability_momentum(-1.0, params)
+        @test integrated_stability_scalar(-2.0, params) > integrated_stability_scalar(-1.0, params)
+
+        # Monotonicity: more stable → more negative Ψ
+        @test integrated_stability_momentum(2.0, params) < integrated_stability_momentum(1.0, params)
+        @test integrated_stability_scalar(2.0, params) < integrated_stability_scalar(1.0, params)
+
+        # Known reference values (computed from Hogström/Beljaars-Holtslag formulas)
+        @test integrated_stability_momentum(-1.0, params) ≈ 1.215 atol=0.01
+        @test integrated_stability_scalar(-1.0, params) ≈ 1.644 atol=0.01
+        @test integrated_stability_momentum(1.0, params) ≈ -4.282 atol=0.01
+        @test integrated_stability_scalar(1.0, params) ≈ -4.434 atol=0.01
+    end
+
+    @testset "Stability correction factors" begin
+        α = 10.0
+        β = 2.0
+
+        # Neutral (Ψᴰ = Ψᵀ = 0): factor = 1
+        @test stability_correction_factor(α, β, 0.0, 0.0, Val(:momentum)) ≈ 1.0
+        @test stability_correction_factor(α, β, 0.0, 0.0, Val(:scalar)) ≈ 1.0
+
+        # Unstable (positive Ψ): factor > 1
+        @test stability_correction_factor(α, β, 1.0, 1.0, Val(:momentum)) > 1.0
+        @test stability_correction_factor(α, β, 1.0, 1.0, Val(:scalar)) > 1.0
+
+        # Stable (negative Ψ): factor < 1
+        @test stability_correction_factor(α, β, -2.0, -2.0, Val(:momentum)) < 1.0
+        @test stability_correction_factor(α, β, -2.0, -2.0, Val(:scalar)) < 1.0
+
+        # Exact momentum correction: [α/(α - Ψᴰ)]²
+        Ψᴰ = 1.5
+        expected_momentum = (α / (α - Ψᴰ))^2
+        @test stability_correction_factor(α, β, Ψᴰ, 0.0, Val(:momentum)) ≈ expected_momentum
+
+        # Exact scalar correction: [α/(α - Ψᴰ)] × [βh/(βh - Ψᵀ)]
+        Ψᵀ = 1.0
+        βh = α + β
+        expected_scalar = (α / (α - Ψᴰ)) * (βh / (βh - Ψᵀ))
+        @test stability_correction_factor(α, β, Ψᴰ, Ψᵀ, Val(:scalar)) ≈ expected_scalar
+
+        # Momentum and scalar corrections differ
+        f_m = stability_correction_factor(α, β, 1.0, 1.0, Val(:momentum))
+        f_h = stability_correction_factor(α, β, 1.0, 1.0, Val(:scalar))
+        @test f_m != f_h
+
+        # Nothing transfer_type defaults to momentum
+        @test stability_correction_factor(α, β, Ψᴰ, 0.0, nothing) ≈ expected_momentum
+    end
+
+    @testset "FittedStabilityFunction callable interface" begin
+        sf = FittedStabilityFunction(1.5e-4 / 7.3)
+        α = log(1e4)
+        β = log(7.3)
+
+        # Neutral: correction factor ≈ 1
+        @test sf(0.0, α, β) ≈ 1.0 atol=1e-10
+
+        # Unstable: correction factor > 1
+        @test sf(-0.1, α, β) > 1.0
+
+        # Stable: correction factor < 1
+        @test sf(0.1, α, β) < 1.0
+
+        # Scalar correction differs from momentum
+        f_m = sf(-0.1, α, β, Val(:momentum))
+        f_s = sf(-0.1, α, β, Val(:scalar))
+        @test f_m != f_s
     end
 
     @testset "Callable interface" begin
@@ -115,25 +264,26 @@ using Oceananigans.BoundaryConditions: BoundaryCondition
         @test C isa Number
         @test C > 0
 
-        # Test with stability correction — need a VPT field
+        # Test with FittedStabilityFunction — need a VPT field
         θᵥ_field = CenterField(grid)
         set!(θᵥ_field, 288.0)  # cooler than surface → unstable
 
-        coef_stable = PolynomialCoefficient(
+        coef_fitted = PolynomialCoefficient(
             (0.142, 0.076, 2.7),     # polynomial
-            coef.roughness_length,
-            coef.minimum_wind_speed,
-            DefaultStabilityFunction(),
-            Breeze.PlanarLiquidSurface(),  # surface
-            θᵥ_field,                # virtual_potential_temperature
-            1e5,                     # surface_pressure
-            Breeze.Thermodynamics.ThermodynamicConstants()
+            1.5e-4,                   # roughness_length
+            0.1,                      # minimum_wind_speed
+            FittedStabilityFunction(1.5e-4 / 7.3),
+            Breeze.PlanarLiquidSurface(),
+            θᵥ_field,
+            1e5,
+            Breeze.Thermodynamics.ThermodynamicConstants(),
+            Val(:momentum)
         )
-        C_stable = coef_stable(1, 1, grid, U, T₀)
-        @test C_stable isa Number
-        @test C_stable > 0
-        # Unstable conditions (θᵥ < θᵥ₀) should enhance transfer
-        @test C_stable > C
+        C_fitted = coef_fitted(1, 1, grid, U, T₀)
+        @test C_fitted isa Number
+        @test C_fitted > 0
+        # Unstable conditions should enhance transfer
+        @test C_fitted > C
     end
 
     @testset "Integration with BulkDrag" begin
@@ -146,6 +296,7 @@ using Oceananigans.BoundaryConditions: BoundaryCondition
         @test bc.condition.coefficient.polynomial == (0.142, 0.076, 2.7)
         @test bc.condition.gustiness == 0.5
         @test bc.condition.surface_temperature === SST
+        @test bc.condition.coefficient.transfer_type === Val(:momentum)
     end
 
     @testset "Integration with BulkSensibleHeatFlux" begin
@@ -156,6 +307,7 @@ using Oceananigans.BoundaryConditions: BoundaryCondition
         @test bc isa BoundaryCondition
         # Coefficient should have been materialized with sensible heat coefficients
         @test bc.condition.coefficient.polynomial == (0.128, 0.068, 2.43)
+        @test bc.condition.coefficient.transfer_type === Val(:scalar)
     end
 
     @testset "Integration with BulkVaporFlux" begin
@@ -166,5 +318,6 @@ using Oceananigans.BoundaryConditions: BoundaryCondition
         @test bc isa BoundaryCondition
         # Coefficient should have been materialized with latent heat coefficients
         @test bc.condition.coefficient.polynomial == (0.120, 0.070, 2.55)
+        @test bc.condition.coefficient.transfer_type === Val(:scalar)
     end
 end


### PR DESCRIPTION
## Summary

- Replace `DefaultStabilityFunction` with `FittedStabilityFunction` using the Li et al. (2010) non-iterative mapping from bulk Richardson number to the Monin-Obukhov stability parameter ζ = z/L
- Add configurable parameter structs (`RichardsonNumberMapping`, `StabilityFunctionParameters`) so all fitting coefficients and stability function constants are stored in types rather than hard-coded
- Apply structurally correct corrections: momentum uses `[α/(α-Ψ_m)]²`, scalar uses `[α/(α-Ψ_m)][β_h/(β_h-Ψ_h)]`, with dispatch via `transfer_type` field on `PolynomialCoefficient`
- Fix notation to use `Cᴰ`, `Cᵀ` (superscripts) per `notation.md` conventions

### New types
- `FittedStabilityFunction` — top-level stability correction, callable as `sf(Riᵦ, α, β)` or `sf(Riᵦ, α, β, Val(:scalar))`
- `RichardsonNumberMapping` — Li et al. (2010) regression coefficients and regime thresholds (default: Table 1 values)
- `StabilityFunctionParameters` — Hogström (1996) unstable + Beljaars & Holtslag (1991) stable Ψ function constants

## Test plan

- [x] All 1374 tests pass (including doctests)
- [x] New tests for `RichardsonNumberMapping` and `StabilityFunctionParameters` constructors and defaults
- [x] Tests for `FittedStabilityFunction` callable interface (neutral, unstable, stable, momentum vs scalar)
- [x] Tests for Ri_B → ζ mapping (signs, monotonicity, regime boundaries)
- [x] Tests for integrated stability functions (continuity at ζ=0, signs, monotonicity, known reference values)
- [x] Integration tests with `BulkDrag`, `BulkSensibleHeatFlux`, `BulkVaporFlux`

🤖 Generated with [Claude Code](https://claude.com/claude-code)