### PR TITLE
Avoid boxing of `advection` inside `AtmosphereModel`

### DIFF
--- a/src/AtmosphereModels/atmosphere_model.jl
+++ b/src/AtmosphereModels/atmosphere_model.jl
@@ -244,7 +244,7 @@ function AtmosphereModel(grid;
     scalar_advection_tuple = with_tracers(scalar_names, scalar_advection, default_generator, with_velocities=false)
     momentum_advection_tuple = (; momentum = momentum_advection)
     advection = merge(momentum_advection_tuple, scalar_advection_tuple)
-    advection_tuple = NamedTuple(name => adapt_advection_order(scheme, grid) for (name, scheme) in pairs(advection))
+    materialized_advection = NamedTuple(name => adapt_advection_order(scheme, grid) for (name, scheme) in pairs(advection))
 
     model = AtmosphereModel(arch,
                             grid,
@@ -260,7 +260,7 @@ function AtmosphereModel(grid;
                             velocities,
                             tracers,
                             nothing, # buoyancy, temporary solution for compatibility with Oceananigans.TurbulenceClosures
-                            advection_tuple,
+                            materialized_advection,
                             coriolis,
                             forcing,
                             microphysics,


### PR DESCRIPTION
This was first observed in #504.  The pattern
```julia
variable = # some expression involving `variable`
```
is the prototype of what can cause a `Core.Box`, especially when the right-hand side involves iteration/generator expressions, like in this case.  The usual solution is to just use a different variable name, to avoid confusion.

It's interesting that this never caused an actual `Core.Box` before but only failed in #504 for the first time, I guess this was a fragile situation where we've always been very lucky so far that the compiler was able to avoid boxing `advection`: I presume because the new `advection` value was just inlined in `AtmosphereModel` constructor right after it, but with the seemingly unrelated changes in #504 to this function this simplification wasn't possible anymore, thus causing the test failure.  I guess another approach in #504 would have been to move the new `advection` definition after the newly introduced `if` condition, to keep it close to the `AtmosphereModel` constructor, but again, this is all a bit fragile that I believe a more stable solution is needed to avoid problems again in the future, which is what this PR is proposing.

This was detected thanks to JETLS.