### PR TITLE
Restrict `potential_temperature_tendency` to potential temperature formulation

### DIFF
--- a/src/PotentialTemperatureFormulations/potential_temperature_tendency.jl
+++ b/src/PotentialTemperatureFormulations/potential_temperature_tendency.jl
@@ -68,7 +68,7 @@ end
                                                 ρe_forcing,
                                                 advection,
                                                 dynamics,
-                                                formulation,
+                                                formulation::LiquidIcePotentialTemperatureFormulation,
                                                 constants,
                                                 specific_moisture,
                                                 velocities,


### PR DESCRIPTION
This prevents the compiler from thinking that it could be called with a static energy formulation, too.

Confirmed that this fixes the first error reported in #511.