### PR TITLE
[CI] Try using three parallel jobs instead of two for macOS tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -99,9 +99,10 @@ jobs:
               TEST_ARGS+=(--jobs=3)
               # ...but also set a more conservative limit to memory usage before
               # reciclying a worker, to avoid out-of-memory issues.
-              echo "JULIA_TEST_MAXRSS_MB=2500" | tee "${GITHUB_ENV}"
+              JULIA_TEST_MAXRSS_MB=2500
+              echo "JULIA_TEST_MAXRSS_MB=${JULIA_TEST_MAXRSS_MB}" | tee -a "${GITHUB_ENV}"
           fi
-          echo "runtest_test_args=${TEST_ARGS[@]}" | tee "${GITHUB_ENV}"
+          echo "runtest_test_args=${TEST_ARGS[@]}" | tee -a "${GITHUB_ENV}"
       - name: Prepare test environment
         if: ${{ startsWith(matrix.os, 'aws-linux-nvidia-gpu-') }}
         shell: bash


### PR DESCRIPTION
If this works, we should hopefully get a good speedup in the macOS tests, but I don't know how this will go, because [on the macOS runners we only have 7 GB of memory](https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories), so 3 parallel workers each using a little bit more than 2 GB of memory (which is what we typically have at the end of the tests) will be dangerously close to the limit.