### PR TITLE
Revert "[CI] Set `benchmark-data-dir-path` for pull requests"

### DIFF
--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -187,7 +187,7 @@ jobs:
           name: Breeze.jl Benchmarks
           tool: "customBiggerIsBetter"
           output-file-path: "github-action-benchmark.json"
-          benchmark-data-dir-path: ${{ github.event_name == 'push' && '.' || format('previews/PR{0}', github.event.number) }}
+          benchmark-data-dir-path: "."
           gh-repository: "github.com/NumericalEarth/BreezeBenchmarks"
           github-token: ${{ github.event.pull_request.head.repo.fork && github.token || steps.generate_token.outputs.token }}
           comment-always: false


### PR DESCRIPTION
Reverts NumericalEarth/Breeze.jl#528. This didn't do what I hoped.