### PR TITLE
Remove Breeze compat from `benchmarking` environment

### DIFF
--- a/benchmarking/Project.toml
+++ b/benchmarking/Project.toml
@@ -20,7 +20,6 @@ Breeze = {path = ".."}
 
 [compat]
 ArgParse = "1"
-Breeze = "0.3"
 CUDA = "5"
 CloudMicrophysics = "0.31.4"
 Dates = "<0.0.1, 1"


### PR DESCRIPTION
#539 broke instantiating the entire environment with Julia v1.12 (and hence all the tests) because the workspaces are resolved all together (by design).  Setting the compat bound for the main package is not necessary, so we can simply remove it.