### PR TITLE
Resolve ambiguity about `Periodic` in Reactant tests

### DIFF
--- a/test/reactant_centered_compilation.jl
+++ b/test/reactant_centered_compilation.jl
@@ -9,6 +9,7 @@
 using Breeze
 using Oceananigans
 using Oceananigans.Architectures: ReactantState
+using Oceananigans.Grids: Periodic
 using Reactant
 using Reactant: @trace
 using Enzyme

--- a/test/reactant_weno_compilation.jl
+++ b/test/reactant_weno_compilation.jl
@@ -9,6 +9,7 @@
 using Breeze
 using Oceananigans
 using Oceananigans.Architectures: ReactantState
+using Oceananigans.Grids: Periodic
 using Reactant
 using Reactant: @trace
 using Enzyme


### PR DESCRIPTION
Reactant recently introduced a new exported symbol called `Periodic`, which conflicts with Oceananigans' symbol by the same name.  This is going to be resolved upstream in https://github.com/EnzymeAD/Reactant.jl/pull/2646, but it's generally more robust to use the explicit import style to avoid any ambiguity, and make intention clear and explicit.  CC @Pangoraw.