### PR TITLE
[CI] Remove manual upload of cache upon failure

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -78,7 +78,6 @@ jobs:
         run: |
           julia --compile=min -O0 -e 'using InteractiveUtils; versioninfo()'
       - uses: julia-actions/cache@v3
-        id: julia-cache
         with:
           # On self-hosted runners we use the prebuilt Docker container, which already
           # caches pkgimages and such, so we don't need to cache here most things.  Only
@@ -151,13 +150,3 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
         continue-on-error: true
-      - name: Save Julia depot cache on cancel or failure
-        id: julia-cache-save
-        # Avoid wasting time saving the cache on Windows, it takes long to both
-        # save it and fetch it back.
-        if: ${{ (runner.os != 'Windows') && (cancelled() || failure()) }}
-        uses: actions/cache/save@v5
-        with:
-          path: |
-            ${{ steps.julia-cache.outputs.cache-paths }}
-          key: ${{ steps.julia-cache.outputs.cache-key }}

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -97,7 +97,6 @@ jobs:
         with:
           version: "1.12.5"
       - uses: julia-actions/cache@v3
-        id: julia-cache
       - uses: actions/download-artifact@v8
         with:
           name: documentation-build
@@ -120,11 +119,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.BREEZEDOCUMENTATION_DOCUMENTER_KEY }}
-      - name: Save Julia depot cache on cancel or failure
-        id: julia-cache-save
-        if: cancelled() || failure()
-        uses: actions/cache/save@v5
-        with:
-          path: |
-            ${{ steps.julia-cache.outputs.cache-paths }}
-          key: ${{ steps.julia-cache.outputs.cache-key }}

--- a/.github/workflows/Validation.yml
+++ b/.github/workflows/Validation.yml
@@ -45,7 +45,6 @@ jobs:
         with:
           version: ${{ matrix.version }}
       - uses: julia-actions/cache@v3
-        id: julia-cache
       - name: Instantiate examples environment
         shell: julia --color=yes --project=examples {0}
         run: |
@@ -57,11 +56,3 @@ jobs:
           CI: "true"
         run: |
           julia --color=yes --project=examples examples/boussinesq_bomex.jl
-      - name: Save Julia depot cache on cancel or failure
-        id: julia-cache-save
-        if: cancelled() || failure()
-        uses: actions/cache/save@v5
-        with:
-          path: |
-            ${{ steps.julia-cache.outputs.cache-paths }}
-          key: ${{ steps.julia-cache.outputs.cache-key }}


### PR DESCRIPTION
Follow up to #559: `julia-actions/cache@v3` already automatically uploads the cache upon failure, so that'd conflict with the manual mechanism we had here, this PR removes that.  CC @navidcy.