### PR TITLE
Add `CUDA_Runtime_jll` and `Reactant_jll` to extras of test env

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -133,9 +133,8 @@ jobs:
           # means that we have to use the same preferences also for the tests environment,
           # because running the tests clears up the load path.  Let's copy the global
           # preference file to test directory (the global one will be ignored during the
-          # tests), and add `CUDA_Runtime_jll` to the env to make the preference effective.
-          cp /usr/local/share/julia/environments/breeze/LocalPreferences.toml test/.
-          julia --project=test --color=yes --check-bounds=${{ matrix.check-bounds }} -e 'using Pkg; Pkg.Registry.update(); Pkg.add("CUDA_Runtime_jll")'
+          # tests).
+          cp -v /usr/local/share/julia/environments/breeze/LocalPreferences.toml test/.
       - name: Run tests
         shell: bash
         run: |

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -43,3 +43,7 @@ Reactant = "0.2.210"
 SpecialFunctions = "2"
 Statistics = "<0.0.1, 1"
 Test = "<0.0.1, 1"
+
+[extras]
+CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"
+Reactant_jll = "0192cb87-2b54-54ad-80e0-3be72ad8a3c0"


### PR DESCRIPTION
This enables us to slightly simplify the CI test job on self-hosted runners: having these package in the extras section of the environment is sufficient for making the preferences set in the Docker image effective, without having to manually install packages.