### PR TITLE
[benchmark] Use a slightly larger small grid

### DIFF
--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -37,7 +37,7 @@ jobs:
         include:
           - dynamics: 'anelastic'
             microphysics: 'nothing'
-            grid: '128^3, 512x512x256, 768x768x256'
+            grid: '256x256x128, 512x512x256, 768x768x256'
             advection: 'WENO5, WENO9'
           - dynamics: 'compressible_splitexplicit'
             microphysics: 'nothing'


### PR DESCRIPTION
The 128^3 grid is _very_ small, it finishes running the whole timestepping loop in about a second, and very small glitches during the benchmarks cause frequent false positive performance alerts.  By using a slightly larger grid, hopefully we'll have more stable numbers.