### PR TITLE
Fix dependabot setup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,10 +15,7 @@ updates:
     labels:
       - "dependencies 🖇️"
     cooldown:
-      default-days: 5
-      semver-major-days: 30
-      semver-minor-days: 7
-      semver-patch-days: 3
+      default-days: 15
   - package-ecosystem: "julia"
     # Location of Julia projects
     directories:


### PR DESCRIPTION
`github-actions` ecosystem doesn't support semver.