### PR TITLE
[CI] Reduce number of parallel jobs on macOS back to 2

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -109,7 +109,7 @@ jobs:
           if [[ ${{ runner.os }} == "macOS" ]]; then
               # Encourage ParallelTestRunner to use multiple jobs on macOS, rather
               # than the single one it'd use by default.
-              TEST_ARGS+=(--jobs=3)
+              TEST_ARGS+=(--jobs=2)
               # ...but also set a more conservative limit to memory usage before
               # reciclying a worker, to avoid out-of-memory issues.
               JULIA_TEST_MAXRSS_MB=2500


### PR DESCRIPTION
Partial revert of #514.  This didn't seem to help too much, in some bad cases (especially with Julia v1.12) it seemed to have caused slowdowns due to memory constraints (see https://github.com/JuliaTesting/ParallelTestRunner.jl/issues/124)