### PR TITLE
[CI] Further reduce memory limit for macOS CI jobs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -112,7 +112,7 @@ jobs:
               TEST_ARGS+=(--jobs=2)
               # ...but also set a more conservative limit to memory usage before
               # reciclying a worker, to avoid trashing memory or out-of-memory errors.
-              JULIA_TEST_MAXRSS_MB=1900
+              JULIA_TEST_MAXRSS_MB=1800
               echo "JULIA_TEST_MAXRSS_MB=${JULIA_TEST_MAXRSS_MB}" | tee -a "${GITHUB_ENV}"
           fi
           echo "runtest_test_args=${TEST_ARGS[@]}" | tee -a "${GITHUB_ENV}"


### PR DESCRIPTION
Let's see if this helps, together with #601 