### PR TITLE
Fix physics bugs found by Bug Crawl (#625)

### DIFF
--- a/src/AtmosphereModels/Diagnostics/dewpoint_temperature.jl
+++ b/src/AtmosphereModels/Diagnostics/dewpoint_temperature.jl
@@ -76,7 +76,7 @@ T⁺_field = Field(T⁺)
 ├── operand: KernelFunctionOperation at (Center, Center, Center)
 ├── status: time=0.0
 └── data: 3×3×14 OffsetArray(::Array{Float64, 3}, 0:2, 0:2, -2:11) with eltype Float64 with indices 0:2×0:2×-2:11
-    └── max=289.062, min=287.475, mean=288.27
+    └── max=289.056, min=287.474, mean=288.266
 ```
 """
 function DewpointTemperature(model; tolerance=1e-4, maxiter=10)

--- a/src/AtmosphereModels/Diagnostics/potential_temperatures.jl
+++ b/src/AtmosphereModels/Diagnostics/potential_temperatures.jl
@@ -416,7 +416,7 @@ Field(θᵉ)
 ├── operand: KernelFunctionOperation at (Center, Center, Center)
 ├── status: time=0.0
 └── data: 3×3×14 OffsetArray(::Array{Float64, 3}, 0:2, 0:2, -2:11) with eltype Float64 with indices 0:2×0:2×-2:11
-    └── max=326.162, min=325.849, mean=326.005
+    └── max=326.162, min=325.851, mean=326.006
 ```
 
 # References
@@ -498,7 +498,7 @@ Field(θᵇ)
 ├── operand: KernelFunctionOperation at (Center, Center, Center)
 ├── status: time=0.0
 └── data: 3×3×14 OffsetArray(::Array{Float64, 3}, 0:2, 0:2, -2:11) with eltype Float64 with indices 0:2×0:2×-2:11
-    └── max=326.162, min=325.849, mean=326.005
+    └── max=326.162, min=325.851, mean=326.006
 ```
 
 # References

--- a/src/AtmosphereModels/Diagnostics/saturation_specific_humidity.jl
+++ b/src/AtmosphereModels/Diagnostics/saturation_specific_humidity.jl
@@ -94,8 +94,9 @@ end
     pᵛ⁺ = saturation_vapor_pressure(T, constants, surface)
     Rᵈ = dry_air_gas_constant(constants)
     Rᵛ = vapor_gas_constant(constants)
-    δᵈᵛ = Rᵈ / Rᵛ - 1
-    return pᵛ⁺ / (pᵣ + δᵈᵛ * pᵛ⁺)
+    ϵᵈᵛ = Rᵈ / Rᵛ
+    δᵈᵛ = ϵᵈᵛ - 1
+    return ϵᵈᵛ * pᵛ⁺ / (pᵣ + δᵈᵛ * pᵛ⁺)
 end
 
 #####

--- a/src/AtmosphereModels/Diagnostics/static_energy.jl
+++ b/src/AtmosphereModels/Diagnostics/static_energy.jl
@@ -110,7 +110,7 @@ function (d::StaticEnergyKernelFunction)(i, j, k, grid)
     qⁱ = q.ice
 
     # Moist static energy
-    e = cᵖᵐ * T + g * z - ℒˡᵣ * qˡ + ℒⁱᵣ * qⁱ
+    e = cᵖᵐ * T + g * z - ℒˡᵣ * qˡ - ℒⁱᵣ * qⁱ
 
     if d.flavor isa Specific
         return e

--- a/src/AtmosphereModels/Diagnostics/static_energy.jl
+++ b/src/AtmosphereModels/Diagnostics/static_energy.jl
@@ -66,7 +66,7 @@ Field(e)
 ├── operand: KernelFunctionOperation at (Center, Center, Center)
 ├── status: time=0.0
 └── data: 3×3×14 OffsetArray(::Array{Float64, 3}, 0:2, 0:2, -2:11) with eltype Float64 with indices 0:2×0:2×-2:11
-    └── max=3.03055e5, min=3.02663e5, mean=3.02859e5
+    └── max=3.03019e5, min=302661.0, mean=3.0284e5
 ```
 """
 function StaticEnergy(model, flavor_symbol=:specific)

--- a/src/AtmosphereModels/atmosphere_model_buoyancy.jl
+++ b/src/AtmosphereModels/atmosphere_model_buoyancy.jl
@@ -46,7 +46,7 @@ end
 @inline function OceanBuoyancyFormulations.∂z_b(i, j, k, grid, b::AtmosphereModelBuoyancy, tracers)
     g = b.thermodynamic_constants.gravitational_acceleration
     # Use ∂z(log ϑ) = ∂z(ϑ)/ϑ to keep the derivative and denominator at consistent grid locations
-    ∂z_log_ϑ = ∂zᶜᶜᶠ(i, j, k, grid, log_virtual_potential_temperature, 
+    ∂z_log_ϑ = ∂zᶜᶜᶠ(i, j, k, grid, log_virtual_potential_temperature,
                      b.thermodynamic_constants, b.dynamics, tracers.T, tracers.qᵛ)
     return g * ∂z_log_ϑ
 end

--- a/src/AtmosphereModels/atmosphere_model_buoyancy.jl
+++ b/src/AtmosphereModels/atmosphere_model_buoyancy.jl
@@ -61,6 +61,6 @@ end
     q = @inbounds MoistureMassFractions(qᵛ[i, j, k])
     Rᵐ = mixture_gas_constant(q, constants)
     Rᵈ = dry_air_gas_constant(constants)
-    cᵖᵈ = constants.dry_air.heat_capacity
-    return @inbounds Rᵐ / Rᵈ * T[i, j, k] * (pˢᵗ / pᵣ)^(Rᵈ / cᵖᵈ)
+    cᵖᵐ = mixture_heat_capacity(q, constants)
+    return @inbounds Rᵐ / Rᵈ * T[i, j, k] * (pˢᵗ / pᵣ)^(Rᵐ / cᵖᵐ)
 end

--- a/src/AtmosphereModels/atmosphere_model_buoyancy.jl
+++ b/src/AtmosphereModels/atmosphere_model_buoyancy.jl
@@ -45,9 +45,13 @@ end
 
 @inline function OceanBuoyancyFormulations.∂z_b(i, j, k, grid, b::AtmosphereModelBuoyancy, tracers)
     g = b.thermodynamic_constants.gravitational_acceleration
-    ∂z_ϑ = ∂zᶜᶜᶠ(i, j, k, grid, virtual_potential_temperature, b.thermodynamic_constants, b.dynamics, tracers.T, tracers.qᵛ)
-    ϑ = virtual_potential_temperature(i, j, k, grid, b.thermodynamic_constants, b.dynamics, tracers.T, tracers.qᵛ)
-    return g * ∂z_ϑ / ϑ
+    # Use ∂z(log ϑ) = ∂z(ϑ)/ϑ to keep the derivative and denominator at consistent grid locations
+    ∂z_log_ϑ = ∂zᶜᶜᶠ(i, j, k, grid, log_virtual_potential_temperature, b.thermodynamic_constants, b.dynamics, tracers.T, tracers.qᵛ)
+    return g * ∂z_log_ϑ
+end
+
+@inline function log_virtual_potential_temperature(i, j, k, grid, constants, dynamics, T, qᵛ)
+    return log(virtual_potential_temperature(i, j, k, grid, constants, dynamics, T, qᵛ))
 end
 
 @inline function virtual_potential_temperature(i, j, k, grid, constants, dynamics, T, qᵛ)

--- a/src/AtmosphereModels/atmosphere_model_buoyancy.jl
+++ b/src/AtmosphereModels/atmosphere_model_buoyancy.jl
@@ -51,7 +51,8 @@ end
 end
 
 @inline function log_virtual_potential_temperature(i, j, k, grid, constants, dynamics, T, qᵛ)
-    return log(virtual_potential_temperature(i, j, k, grid, constants, dynamics, T, qᵛ))
+    ϑ = virtual_potential_temperature(i, j, k, grid, constants, dynamics, T, qᵛ)
+    return log(ϑ)
 end
 
 @inline function virtual_potential_temperature(i, j, k, grid, constants, dynamics, T, qᵛ)

--- a/src/AtmosphereModels/atmosphere_model_buoyancy.jl
+++ b/src/AtmosphereModels/atmosphere_model_buoyancy.jl
@@ -57,6 +57,6 @@ end
     q = @inbounds MoistureMassFractions(qᵛ[i, j, k])
     Rᵐ = mixture_gas_constant(q, constants)
     Rᵈ = dry_air_gas_constant(constants)
-    cᵖᵐ = mixture_heat_capacity(q, constants)
-    return @inbounds Rᵐ / Rᵈ * T[i, j, k] * (pˢᵗ / pᵣ)^(Rᵐ / cᵖᵐ)
+    cᵖᵈ = constants.dry_air.heat_capacity
+    return @inbounds Rᵐ / Rᵈ * T[i, j, k] * (pˢᵗ / pᵣ)^(Rᵈ / cᵖᵈ)
 end

--- a/src/AtmosphereModels/atmosphere_model_buoyancy.jl
+++ b/src/AtmosphereModels/atmosphere_model_buoyancy.jl
@@ -46,7 +46,8 @@ end
 @inline function OceanBuoyancyFormulations.∂z_b(i, j, k, grid, b::AtmosphereModelBuoyancy, tracers)
     g = b.thermodynamic_constants.gravitational_acceleration
     # Use ∂z(log ϑ) = ∂z(ϑ)/ϑ to keep the derivative and denominator at consistent grid locations
-    ∂z_log_ϑ = ∂zᶜᶜᶠ(i, j, k, grid, log_virtual_potential_temperature, b.thermodynamic_constants, b.dynamics, tracers.T, tracers.qᵛ)
+    ∂z_log_ϑ = ∂zᶜᶜᶠ(i, j, k, grid, log_virtual_potential_temperature, 
+                     b.thermodynamic_constants, b.dynamics, tracers.T, tracers.qᵛ)
     return g * ∂z_log_ϑ
 end
 

--- a/src/AtmosphereModels/microphysics_interface.jl
+++ b/src/AtmosphereModels/microphysics_interface.jl
@@ -510,7 +510,10 @@ end
     qˡ = zero(qᵛᵉ)
     qˡ += haskey(ℳ, :qᶜˡ) ? ℳ.qᶜˡ : zero(qᵛᵉ)
     qˡ += haskey(ℳ, :qʳ) ? ℳ.qʳ : zero(qᵛᵉ)
-    return MoistureMassFractions(qᵛᵉ, qˡ)
+    qⁱ = zero(qᵛᵉ)
+    qⁱ += haskey(ℳ, :qᶜⁱ) ? ℳ.qᶜⁱ : zero(qᵛᵉ)
+    qⁱ += haskey(ℳ, :qˢ) ? ℳ.qˢ : zero(qᵛᵉ)
+    return MoistureMassFractions(qᵛᵉ, qˡ, qⁱ)
 end
 
 """

--- a/src/AtmosphereModels/microphysics_interface.jl
+++ b/src/AtmosphereModels/microphysics_interface.jl
@@ -507,12 +507,9 @@ end
 # NamedTuple contains specific moisture fractions computed from ρ-weighted prognostics.
 # Input qᵛᵉ is scheme-dependent specific moisture (vapor or equilibrium moisture).
 @inline function moisture_fractions(microphysics, ℳ::NamedTuple, qᵛᵉ)
-    qˡ = zero(qᵛᵉ)
-    qˡ += haskey(ℳ, :qᶜˡ) ? ℳ.qᶜˡ : zero(qᵛᵉ)
-    qˡ += haskey(ℳ, :qʳ) ? ℳ.qʳ : zero(qᵛᵉ)
-    qⁱ = zero(qᵛᵉ)
-    qⁱ += haskey(ℳ, :qᶜⁱ) ? ℳ.qᶜⁱ : zero(qᵛᵉ)
-    qⁱ += haskey(ℳ, :qˢ) ? ℳ.qˢ : zero(qᵛᵉ)
+    z = zero(qᵛᵉ)
+    qˡ = get(ℳ, :qᶜˡ, z) + get(ℳ, :qʳ, z)
+    qⁱ = get(ℳ, :qᶜⁱ, z) + get(ℳ, :qˢ, z)
     return MoistureMassFractions(qᵛᵉ, qˡ, qⁱ)
 end
 

--- a/src/AtmosphereModels/negative_moisture_correction.jl
+++ b/src/AtmosphereModels/negative_moisture_correction.jl
@@ -260,7 +260,7 @@ end
     # Use ifelse (not if/else) for GPU kernel compatibility.
     # When Nz < 2, clamp indices to 1 so reads are valid but dq_mass = 0.
     k_bot = 1
-    k_top = max(2, Nz)  # safe index: equals 2 when Nz ≥ 2, equals Nz when Nz < 2
+    k_top = min(2, Nz)  # safe index: equals 2 when Nz ≥ 2, equals Nz when Nz < 2
 
     @inbounds ρqᵛ_bot = ρqᵛᵉ[i, j, k_bot]
     @inbounds ρ_bot = ρ₀[i, j, k_bot]

--- a/src/Microphysics/microphysics_diagnostics.jl
+++ b/src/Microphysics/microphysics_diagnostics.jl
@@ -98,7 +98,7 @@ As with other diagnostics, `RelativeHumidity` may be wrapped in `Field` to store
 ├── operand: KernelFunctionOperation at (Center, Center, Center)
 ├── status: time=0.0
 └── data: 3×3×134 OffsetArray(::Array{Float64, 3}, 0:2, 0:2, -2:131) with eltype Float64 with indices 0:2×0:2×-2:131
-    └── max=0.214947, min=0.136946, mean=0.172492
+    └── max=0.214949, min=0.137169, mean=0.172626
 ```
 
 We also provide a convenience constructor for the Field:
@@ -114,7 +114,7 @@ We also provide a convenience constructor for the Field:
 ├── operand: KernelFunctionOperation at (Center, Center, Center)
 ├── status: time=0.0
 └── data: 3×3×134 OffsetArray(::Array{Float64, 3}, 0:2, 0:2, -2:131) with eltype Float64 with indices 0:2×0:2×-2:131
-    └── max=0.214947, min=0.136946, mean=0.172492
+    └── max=0.214949, min=0.137169, mean=0.172626
 ```
 """
 function RelativeHumidity(model)

--- a/src/Thermodynamics/clausius_clapeyron.jl
+++ b/src/Thermodynamics/clausius_clapeyron.jl
@@ -42,7 +42,7 @@ from the triple point pressure and temperature ``(pᵗʳ, Tᵗʳ)`` to pressure 
 and temperature ``T``, we obtain
 
 ```math
-\\log(pᵛ⁺ / pᵗʳ) = - ℒᵝ₀ / (Rᵛ T) + ℒᵝ₀ / (Rᵛ Tᵗʳ) + \\log \\left[ (Δcᵝ / Rᵛ) (T / Tᵗʳ) \\right] ,
+\\log(pᵛ⁺ / pᵗʳ) = - ℒᵝ₀ / (Rᵛ T) + ℒᵝ₀ / (Rᵛ Tᵗʳ) + (Δcᵝ / Rᵛ) \\log(T / Tᵗʳ) ,
 ```
 
 which then becomes

--- a/src/Thermodynamics/reference_states.jl
+++ b/src/Thermodynamics/reference_states.jl
@@ -94,15 +94,16 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Compute the reference pressure at height `z` that associated with the reference pressure `p₀` and
-potential temperature `θ₀`. The reference pressure is defined as the pressure of dry air at the
-reference pressure and temperature.
+Compute the reference pressure at height `z` that associated with the reference pressure `p₀`,
+potential temperature `θ₀`, and standard pressure `pˢᵗ`. The reference pressure is defined as
+the pressure of dry air at the reference pressure and temperature.
 """
-@inline function adiabatic_hydrostatic_pressure(z, p₀, θ₀, constants)
+@inline function adiabatic_hydrostatic_pressure(z, p₀, θ₀, pˢᵗ, constants)
     cᵖᵈ = constants.dry_air.heat_capacity
     Rᵈ = dry_air_gas_constant(constants)
     g = constants.gravitational_acceleration
-    return p₀ * (1 - g * z / (cᵖᵈ * θ₀))^(cᵖᵈ / Rᵈ)
+    T₀ = θ₀ * (p₀ / pˢᵗ)^(Rᵈ / cᵖᵈ)
+    return p₀ * (1 - g * z / (cᵖᵈ * T₀))^(cᵖᵈ / Rᵈ)
 end
 
 """
@@ -115,7 +116,7 @@ the density of dry air at the reference pressure and temperature.
 @inline function adiabatic_hydrostatic_density(z, p₀, θ₀, pˢᵗ, constants)
     Rᵈ = dry_air_gas_constant(constants)
     cᵖᵈ = constants.dry_air.heat_capacity
-    pᵣ = adiabatic_hydrostatic_pressure(z, p₀, θ₀, constants)
+    pᵣ = adiabatic_hydrostatic_pressure(z, p₀, θ₀, pˢᵗ, constants)
     ρ₀ = surface_density(p₀, θ₀, pˢᵗ, constants)
     return ρ₀ * (pᵣ / p₀)^(1 - Rᵈ / cᵖᵈ)
 end
@@ -255,14 +256,14 @@ end
 
 # Closed-form for constant potential temperature
 hydrostatic_pressure(z, p₀, θ₀::Number, pˢᵗ, constants) =
-    adiabatic_hydrostatic_pressure(z, p₀, θ₀, constants)
+    adiabatic_hydrostatic_pressure(z, p₀, θ₀, pˢᵗ, constants)
 
 hydrostatic_density(z, p₀, θ₀::Number, pˢᵗ, constants) =
     adiabatic_hydrostatic_density(z, p₀, θ₀, pˢᵗ, constants)
 
 function hydrostatic_temperature(z, p₀, θ₀::Number, pˢᵗ, constants)
     κ = dry_air_gas_constant(constants) / constants.dry_air.heat_capacity
-    p = adiabatic_hydrostatic_pressure(z, p₀, θ₀, constants)
+    p = adiabatic_hydrostatic_pressure(z, p₀, θ₀, pˢᵗ, constants)
     return θ₀ * (p / pˢᵗ)^κ
 end
 

--- a/test/diagnostics.jl
+++ b/test/diagnostics.jl
@@ -187,7 +187,7 @@ end
 
     θ_field = CenterField(grid)
     set!(θ_field, (x, y, z) -> begin
-        pᵣ_z = adiabatic_hydrostatic_pressure(z, p₀, θ₀, constants)
+        pᵣ_z = adiabatic_hydrostatic_pressure(z, p₀, θ₀, pˢᵗ, constants)
         T₀ * (pˢᵗ / pᵣ_z)^(Rᵈ / cᵖᵈ)
     end)
 

--- a/test/reference_states.jl
+++ b/test/reference_states.jl
@@ -7,6 +7,7 @@ using Breeze.Thermodynamics:
     compute_reference_state!,
     compute_hydrostatic_reference!,
     dry_air_gas_constant,
+    hydrostatic_pressure,
     vapor_gas_constant,
     saturation_specific_humidity,
     PlanarLiquidSurface
@@ -265,6 +266,26 @@ using Test
         ρ₀ = surface_density(ref)
         @test ρ₀ > 0
         @test ρ₀ isa FT
+    end
+
+    @testset "Closed-form hydrostatic pressure respects standard pressure" begin
+        p₀ = FT(101325)
+        pˢᵗ = FT(100000)
+        θ₀ = FT(288)
+        cᵖᵈ = constants.dry_air.heat_capacity
+        κ = Rᵈ / cᵖᵈ
+        T₀ = θ₀ * (p₀ / pˢᵗ)^κ
+
+        @test hydrostatic_pressure(FT(0), p₀, θ₀, pˢᵗ, constants) == p₀
+
+        for z in (FT(1000), FT(5000), FT(20000))
+            p_closed = hydrostatic_pressure(z, p₀, θ₀, pˢᵗ, constants)
+            p_expected = p₀ * (1 - g * z / (cᵖᵈ * T₀))^(cᵖᵈ / Rᵈ)
+            p_incorrect = p₀ * (1 - g * z / (cᵖᵈ * θ₀))^(cᵖᵈ / Rᵈ)
+
+            @test isapprox(p_closed, p_expected; rtol=sqrt(eps(FT)))
+            @test !isapprox(p_closed, p_incorrect; rtol=FT(1e-4))
+        end
     end
 
     #####


### PR DESCRIPTION
## Summary

Fixes seven physics bugs identified in #625:

- **Item 1** (high): `adiabatic_hydrostatic_pressure` used potential temperature `θ₀` directly instead of converting to actual temperature `T₀ = θ₀(p₀/pˢᵗ)^κ`, and was missing the `pˢᵗ` argument
- **Item 10** (high): `max(2, Nz)` → `min(2, Nz)` in bottom-up moisture borrowing — the old code indexed out of bounds when `Nz < 2`
- **Item 17** (critical): ice latent heat sign in moist static energy was wrong: `+ℒⁱᵣqⁱ` → `−ℒⁱᵣqⁱ`
- **Item 18** (critical): `saturation_total_specific_moisture` was missing a factor of `ϵᵈᵛ = Rᵈ/Rᵛ` in the numerator, overestimating saturation specific humidity by ~1/0.622
- **Item 15** (low): `∂z_b` divided a face-located derivative `∂zᶜᶜᶠ(ϑ)` by a center-located `ϑ`, creating a grid-staggering inconsistency; replaced with the equivalent `g · ∂zᶜᶜᶠ(log ϑ)`
- **Item 14** (low): `moisture_fractions` fallback for `NamedTuple` microphysical states accumulated only liquid species (`qᶜˡ`, `qʳ`), silently setting ice-phase species to zero; now includes `qᶜⁱ` and `qˢ`
- **Item 3** (medium): Clausius-Clapeyron docstring had `log[(Δcᵝ/Rᵛ)(T/Tᵗʳ)]` instead of the correct `(Δcᵝ/Rᵛ) log(T/Tᵗʳ)`

Note: the `virtual_potential_temperature` Poisson exponent fix (item 11) was attempted but reverted — needs further investigation.

Also includes doctest value updates cascading from these fixes and a refactor of `moisture_fractions` to use `get` dispatch instead of `haskey` + ternary.

## Test plan

- [x] New test in `test/reference_states.jl` verifies closed-form hydrostatic pressure respects `pˢᵗ`
- [x] Updated `test/diagnostics.jl` passes with corrected `adiabatic_hydrostatic_pressure` signature
- [ ] Verify turbulence closure buoyancy gradients are physically consistent (BOMEX or RICO)
- [ ] Confirm mixed-phase microphysics states produce correct `MoistureMassFractions` with nonzero ice

🤖 Generated with [Claude Code](https://claude.com/claude-code)