### PR TITLE
[CI] Update most Julia versions to v1.12.6

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,7 +43,7 @@ jobs:
       matrix:
         version:
           - "min"
-          - "1.12.5"
+          - "1.12.6"
         os:
           - ubuntu-latest
           - macOS-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -136,6 +136,13 @@ jobs:
           # preference file to test directory (the global one will be ignored during the
           # tests).
           cp -v /usr/local/share/julia/environments/breeze/LocalPreferences.toml test/.
+      - name: Instantiate test environment
+        shell: bash
+        run: |
+          julia --project=test --color=yes --check-bounds=${{ matrix.check-bounds }} -e '
+          using Pkg;
+          Pkg.instantiate()
+          '
       - name: Run tests
         shell: bash
         run: |

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -96,7 +96,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2.7.0
         with:
-          version: "1.12.5"
+          version: "1.12.6"
       - uses: julia-actions/cache@e97f6fc1a6e21c82253c85e269be7340376aa425 # v3.0.1
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/Validation.yml
+++ b/.github/workflows/Validation.yml
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - "1.12.4"
+          - "1.12.6"
         os:
           - ubuntu-latest
     steps:

--- a/.github/workflows/Whitespace.yml
+++ b/.github/workflows/Whitespace.yml
@@ -36,7 +36,7 @@ jobs:
           ref: '3b12a882e887753e4d2e9e9db65d99d3f7d9e26b'
       - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2.7.0
         with:
-          version: '1.12.4'
+          version: '1.12.6'
       - name: Check whitespace
         run: |
           .julia/contrib/check-whitespace.jl


### PR DESCRIPTION
Will update [our docker images](https://github.com/NumericalEarth/breeze-docker-images) when the [base Julia image](https://hub.docker.com/_/julia) is updated to v1.12.6.