### PR TITLE
[CI] Update all GPU jobs to use julia v1.12.6

### DIFF
--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -53,7 +53,7 @@ jobs:
         shell: bash
         working-directory: ./benchmarking
     container:
-      image: 'ghcr.io/numericalearth/breeze-docker-images:benchmarking-julia_1.12.5'
+      image: 'ghcr.io/numericalearth/breeze-docker-images:benchmarking-julia_1.12.6'
       options: --gpus=all
     timeout-minutes: 30
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,7 +58,7 @@ jobs:
         include:
           # `--check-bounds=auto` is necessary for testing Reactant workloads
           # until https://github.com/EnzymeAD/Reactant.jl/issues/2347 is fixed.
-          - version: "1.12.5"
+          - version: "1.12.6"
             os: aws-linux-nvidia-gpu-l4
             arch: "default"
             check-bounds: "auto"

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -36,7 +36,7 @@ jobs:
       statuses: write
     runs-on: aws-linux-nvidia-gpu-l4
     container:
-      image: 'ghcr.io/numericalearth/breeze-docker-images:docs-julia_1.12.5'
+      image: 'ghcr.io/numericalearth/breeze-docker-images:docs-julia_1.12.6'
       options: --gpus=all
     timeout-minutes: 75
     steps:


### PR DESCRIPTION
Images updates in https://github.com/NumericalEarth/breeze-docker-images/commit/3fb503c77ffc3d3a175f87bfbdf9c3f5c94f577f