### PR TITLE
Call `materialize_advection` for WENO GPU compatibility

### DIFF
--- a/src/AtmosphereModels/atmosphere_model.jl
+++ b/src/AtmosphereModels/atmosphere_model.jl
@@ -2,7 +2,7 @@ using ..Thermodynamics: Thermodynamics, ThermodynamicConstants
 
 using Oceananigans: Oceananigans, AbstractModel, Center, CenterField, Clock, Field,
                     Centered, fields, prognostic_fields
-using Oceananigans.Advection: Advection, adapt_advection_order, cell_advection_timescale
+using Oceananigans.Advection: Advection, adapt_advection_order, cell_advection_timescale, materialize_advection
 using Oceananigans.AbstractOperations: @at
 using Oceananigans.BoundaryConditions: FieldBoundaryConditions, regularize_field_boundary_conditions
 using Oceananigans.Diagnostics: Diagnostics as OceananigansDiagnostics, NaNChecker
@@ -251,7 +251,7 @@ function AtmosphereModel(grid;
     scalar_advection_tuple = with_tracers(scalar_names, scalar_advection, default_generator, with_velocities=false)
     momentum_advection_tuple = (; momentum = momentum_advection)
     advection = merge(momentum_advection_tuple, scalar_advection_tuple)
-    materialized_advection = NamedTuple(name => adapt_advection_order(scheme, grid) for (name, scheme) in pairs(advection))
+    materialized_advection = NamedTuple(name => adapt_advection_order(materialize_advection(scheme, grid), grid) for (name, scheme) in pairs(advection))
 
     model = AtmosphereModel(arch,
                             grid,


### PR DESCRIPTION
  ## Summary

  - Adds missing `materialize_advection` call in `AtmosphereModel` constructor, fixing WENO advection on GPU
  - Oceananigans v0.106.6 refactored WENO to defer the weight computation type (`WCT`) as `Nothing` until the grid architecture is known. `materialize_advection` resolves it to
  `BackendOptimizedDivision` on GPU. All Oceananigans models call this, but `AtmosphereModel` was never updated — causing `InvalidIRError: unsupported dynamic function invocation (call to
   newton_div)` when running any WENO scheme on GPU.

  ## Test plan

  - [x] Run RICO example on GPU (previously crashed at `run!` with `InvalidIRError`)
  - [x] Run BOMEX or other WENO example on GPU to confirm no regression
  - [ ] CPU examples should be unaffected (`materialize_advection` is a no-op for non-deferred schemes)