### PR TITLE
(0.4.7) Bump Breeze version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Breeze"
 uuid = "660aa2fb-d4c8-4359-a52c-9c057bc511da"
-version = "0.4.6"
+version = "0.4.7"
 authors = ["NumericalEarth organization (github.com/NumericalEarth) and lovely contributors"]
 
 [workspace]


### PR DESCRIPTION
to capture #631 and use Breeze in NumericalEarth's tests which are broken at the moment