### PR TITLE
Avoid use of at-doc macro inside structs

### DIFF
--- a/src/Microphysics/bulk_microphysics.jl
+++ b/src/Microphysics/bulk_microphysics.jl
@@ -41,39 +41,39 @@ AtmosphereModels.negative_moisture_correction(bμp::BulkMicrophysics) = bμp.neg
 
 Base.summary(::BulkMicrophysics) = "BulkMicrophysics"
 
+"""
+    NonEquilibriumCloudFormation(liquid, ice=nothing)
+
+A cloud formation scheme where cloud liquid and ice are prognostic variables
+that evolve via condensation/evaporation and deposition/sublimation tendencies,
+rather than being diagnosed instantaneously via saturation adjustment.
+
+The condensation/evaporation and deposition/sublimation tendencies are commonly modeled as **relaxation toward
+saturation** with timescale `τ_relax`, including a latent-heat (psychrometric/thermal) correction factor; see
+[Morrison and Grabowski (2008)](@cite Morrison2008novel), Appendix Eq. (A3), and standard cloud microphysics
+texts such as [Pruppacher and Klett (2010)](@cite pruppacher2010microphysics) or
+[Rogers and Yau (1989)](@cite rogers1989short).
+
+For some bulk schemes (e.g. the CloudMicrophysics 1M extension), `liquid` and `ice` may be set to `nothing`
+and used purely as **phase indicators** (warm-phase vs mixed-phase), with any relaxation timescales sourced
+from the scheme's precipitation/category parameters instead.
+
+# Fields
+- `liquid`: Parameters for cloud liquid (contains relaxation timescale `τ_relax`)
+- `ice`: Parameters for cloud ice (contains relaxation timescale `τ_relax`), or `nothing` for warm-phase only
+
+# References
+
+* Morrison, H. and Grabowski, W. W. (2008). A novel approach for representing ice
+    microphysics in models: Description and tests using a kinematic framework.
+    J. Atmos. Sci., 65, 1528–1548. https://doi.org/10.1175/2007JAS2491.1
+* Pruppacher, H. R. and Klett, J. D. (2010). Microphysics of Clouds and Precipitation (2nd ed.).
+* Rogers, R. R. and Yau, M. K. (1989). A Short Course in Cloud Physics (3rd ed.).
+"""
 struct NonEquilibriumCloudFormation{L, I}
     liquid :: L
     ice :: I
 
-    @doc"""
-        NonEquilibriumCloudFormation(liquid, ice=nothing)
-
-    A cloud formation scheme where cloud liquid and ice are prognostic variables
-    that evolve via condensation/evaporation and deposition/sublimation tendencies,
-    rather than being diagnosed instantaneously via saturation adjustment.
-
-    The condensation/evaporation and deposition/sublimation tendencies are commonly modeled as **relaxation toward
-    saturation** with timescale `τ_relax`, including a latent-heat (psychrometric/thermal) correction factor; see
-    [Morrison and Grabowski (2008)](@cite Morrison2008novel), Appendix Eq. (A3), and standard cloud microphysics
-    texts such as [Pruppacher and Klett (2010)](@cite pruppacher2010microphysics) or
-    [Rogers and Yau (1989)](@cite rogers1989short).
-
-    For some bulk schemes (e.g. the CloudMicrophysics 1M extension), `liquid` and `ice` may be set to `nothing`
-    and used purely as **phase indicators** (warm-phase vs mixed-phase), with any relaxation timescales sourced
-    from the scheme's precipitation/category parameters instead.
-
-    # Fields
-    - `liquid`: Parameters for cloud liquid (contains relaxation timescale `τ_relax`)
-    - `ice`: Parameters for cloud ice (contains relaxation timescale `τ_relax`), or `nothing` for warm-phase only
-
-    # References
-
-    * Morrison, H. and Grabowski, W. W. (2008). A novel approach for representing ice
-        microphysics in models: Description and tests using a kinematic framework.
-        J. Atmos. Sci., 65, 1528–1548. https://doi.org/10.1175/2007JAS2491.1
-    * Pruppacher, H. R. and Klett, J. D. (2010). Microphysics of Clouds and Precipitation (2nd ed.).
-    * Rogers, R. R. and Yau, M. K. (1989). A Short Course in Cloud Physics (3rd ed.).
-    """
     function NonEquilibriumCloudFormation(liquid, ice=nothing)
         return new{typeof(liquid), typeof(ice)}(liquid, ice)
     end


### PR DESCRIPTION
In Julia v1.13, using at-doc inside struct to attach the docstring to an inner constructor [causes an extra hidden field to be added to the struct itself](https://github.com/JuliaLang/julia/issues/60681#issuecomment-4280636832), due to macro expansion rules.  Doesn't look like this is going to be changed upstream, so we have to work around it: luckily the fix is backward compatible, we only lose the convenience of having the docstring right above the constructor definition.

Same change as https://github.com/CliMA/Oceananigans.jl/pull/5527, taken out of #640.  PR best reviewed by [ignoring whitespace changes](https://github.com/NumericalEarth/Breeze.jl/pull/642/changes?w=1).