### PR TITLE
Drop :grid from default_included_properties; test no-warning init

### DIFF
--- a/src/AtmosphereModels/atmosphere_model.jl
+++ b/src/AtmosphereModels/atmosphere_model.jl
@@ -461,4 +461,4 @@ function OceananigansDiagnostics.default_nan_checker(model::AtmosphereModel)
 end
 
 # For compatibility with Oceananigans JLD2Writer
-Oceananigans.OutputWriters.default_included_properties(::AtmosphereModel) = [:grid, :thermodynamic_constants]
+Oceananigans.OutputWriters.default_included_properties(::AtmosphereModel) = [:thermodynamic_constants]

--- a/test/output_writers.jl
+++ b/test/output_writers.jl
@@ -32,6 +32,6 @@ using Logging: Warn
             @test file["serialized/grid"] == on_architecture(CPU(), grid)
         end
     finally
-        isfile(writer.filepath) && rm(writer.filepath, force=true)
+        rm(writer.filepath; force=true)
     end
 end

--- a/test/output_writers.jl
+++ b/test/output_writers.jl
@@ -1,0 +1,37 @@
+using Test
+using Breeze
+using Oceananigans
+using Oceananigans.Architectures: on_architecture, CPU
+using Oceananigans.OutputWriters: jldopen
+using Logging: Warn
+
+# Regression test for https://github.com/NumericalEarth/Breeze.jl/issues/643.
+# Before the fix, Breeze's `default_included_properties` override included `:grid`,
+# which collided with Oceananigans' automatic grid serialization and produced a
+# "grid is already present within this group" warning during JLD2Writer init.
+@testset "JLD2Writer initializes without warnings [$(FT)]" for FT in test_float_types()
+    Oceananigans.defaults.FloatType = FT
+    grid = RectilinearGrid(default_arch; size=(2, 2, 4), extent=(100, 100, 100))
+    model = AtmosphereModel(grid)
+
+    filepath = tempname() * ".jld2"
+    outputs = (; ρu = model.momentum.ρu)
+
+    writer = JLD2Writer(model, outputs;
+                        filename = filepath,
+                        schedule = IterationInterval(1),
+                        overwrite_existing = true)
+
+    try
+        @test_logs min_level=Warn Oceananigans.initialize!(writer, model)
+        @test isfile(writer.filepath)
+
+        jldopen(writer.filepath, "r") do file
+            @test haskey(file, "serialized/grid")
+            @test haskey(file, "serialized/thermodynamic_constants")
+            @test file["serialized/grid"] == on_architecture(CPU(), grid)
+        end
+    finally
+        isfile(writer.filepath) && rm(writer.filepath, force=true)
+    end
+end


### PR DESCRIPTION
## Summary
- Drop `:grid` from `default_included_properties(::AtmosphereModel)` so Oceananigans' automatic grid serialization (CliMA/Oceananigans.jl#5486) isn't duplicated.
- Add a regression test (`test/output_writers.jl`) that initializes a `JLD2Writer` attached to an `AtmosphereModel` and asserts no warnings, plus verifies the file contains `serialized/grid` (matching the model grid) and `serialized/thermodynamic_constants`.

Closes #643.

## Test plan
- [x] `julia --project=test test/runtests.jl --jobs=1 output_writers` passes (5/5 assertions)
- [x] CI green on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)