### PR TITLE
Fix moisture initialization in splitting supercell example

### DIFF
--- a/examples/splitting_supercell.jl
+++ b/examples/splitting_supercell.jl
@@ -14,7 +14,7 @@
 # The simulation initializes a conditionally unstable atmosphere with a warm bubble perturbation
 # that triggers deep convection. The environment includes:
 # - A realistic tropospheric potential temperature profile with a tropopause at 12 km
-# - Relative humidity that decreases with height, with the resulting water vapor mixing ratio capped at 14 kg/kg to 
+# - Relative humidity that decreases with height, with the resulting water vapor mixing ratio capped at 14 g/kg to
 # approximate a well-mixed boundary layer in the lowest kilometer.
 # - Wind shear in the lower 5 km to promote storm rotation and supercell development
 #

--- a/examples/splitting_supercell.jl
+++ b/examples/splitting_supercell.jl
@@ -132,7 +132,7 @@ function θ_background(z)
     return (z ≤ zᵖ) * θᵗ + (z > zᵖ) * θˢ
 end
 
-# Relative humidity profile (Equations 11–12 in [KlempEtAl2015](@citet)) combined with
+# Relative humidity profile (Equations 11–12 by [KlempEtAl2015](@citet)) combined with
 # a cap on the water vapor mixing ratio at ``qᵛ_max``. The local temperature and density
 # are obtained by numerically integrating the hydrostatic balance with the actual
 # ``θ(z)`` profile:

--- a/examples/splitting_supercell.jl
+++ b/examples/splitting_supercell.jl
@@ -14,7 +14,7 @@
 # The simulation initializes a conditionally unstable atmosphere with a warm bubble perturbation
 # that triggers deep convection. The environment includes:
 # - A realistic tropospheric potential temperature profile with a tropopause at 12 km
-# - Moisture that decreases with height, with relative humidity dropping above the tropopause
+# - Water vapor mixing ratio that decreases with height, falling to one-quarter of the surface value above the tropopause
 # - Wind shear in the lower 5 km to promote storm rotation and supercell development
 #
 # ### Potential temperature profile
@@ -106,6 +106,7 @@ dynamics = AnelasticDynamics(reference_state)
 θᵖ = 343       # K - tropopause potential temperature
 zᵖ = 12000     # m - tropopause height
 Tᵖ = 213       # K - tropopause temperature
+qᵛ⁰ = 0.014    # kg/kg - surface water vapor mixing ratio
 nothing #hide
 
 # Wind shear parameters control the low-level environmental wind profile:
@@ -119,6 +120,7 @@ nothing #hide
 
 g = constants.gravitational_acceleration
 cᵖᵈ = constants.dry_air.heat_capacity
+Rᵈ = dry_air_gas_constant(constants)
 nothing #hide
 
 # Background potential temperature profile (Equation 14 in [KlempEtAl2015](@citet)):
@@ -129,9 +131,21 @@ function θ_background(z)
     return (z ≤ zᵖ) * θᵗ + (z > zᵖ) * θˢ
 end
 
-# Relative humidity profile (decreases with height, 25% above tropopause):
+# Water vapor mixing ratio profile (Equation 18 in [KlempEtAl2015](@citet)),
+# scaled by the surface value ``qᵛ⁰``, reduced to one-quarter above the tropopause,
+# and clipped at the local saturation specific humidity. The local temperature
+# and density are estimated from a hydrostatic Exner profile ``Π(z) = 1 − g z/(cᵖᵈ θ₀)``
+# combined with the actual ``θ(z)``:
 
-ℋ_background(z) = (1 - 3/4 * (z / zᵖ)^(5/4)) * (z ≤ zᵖ) + 1/4 * (z > zᵖ)
+function qᵛ_background(z)
+    qᵛ_klemp = qᵛ⁰ * ((1 - 3/4 * (z / zᵖ)^(5/4)) * (z ≤ zᵖ) + 1/4 * (z > zᵖ))
+    Π = 1 - g * z / (cᵖᵈ * θ₀)
+    T = Π * θ_background(z)
+    p = reference_state.surface_pressure * Π^(cᵖᵈ / Rᵈ)
+    ρ = p / (Rᵈ * T)
+    qᵛ⁺ = saturation_specific_humidity(T, ρ, constants, PlanarLiquidSurface())
+    return min(qᵛ_klemp, qᵛ⁺)
+end
 
 # Zonal wind profile with linear shear below ``zˢ`` and smooth transition (Equations 15-16):
 
@@ -171,11 +185,11 @@ uᵢ(x, y, z) = u_background(z)
 
 # ## Visualization of initial conditions and warm bubble perturbation
 #
-# We visualize the background potential temperature, relative humidity, and wind shear profiles
-# that define the environmental stratification:
+# We visualize the background potential temperature, water vapor mixing ratio, and wind shear
+# profiles that define the environmental stratification:
 
 θ_profile = set!(Field{Nothing, Nothing, Center}(grid), z -> θ_background(z))
-ℋ_profile = set!(Field{Nothing, Nothing, Center}(grid), z -> ℋ_background(z) * 100)
+qᵛ_profile = set!(Field{Nothing, Nothing, Center}(grid), z -> qᵛ_background(z) * 1000)
 u_profile = set!(Field{Nothing, Nothing, Center}(grid), z -> u_background(z))
 
 fig = Figure(size=(1000, 400), fontsize=14)
@@ -184,9 +198,9 @@ axθ = Axis(fig[1, 1], xlabel="θ (K)", ylabel="z (km)", title="Potential temper
 lines!(axθ, θ_profile, linewidth=2, color=:magenta)
 hlines!(axθ, [zᵖ / 1000], color=:gray, linestyle=:dash)
 
-axℋ = Axis(fig[1, 2], xlabel="ℋ (%)", ylabel="z (km)", title="Relative humidity")
-lines!(axℋ, ℋ_profile, linewidth=2, color=:dodgerblue)
-hlines!(axℋ, [zᵖ / 1000], color=:gray, linestyle=:dash)
+axqᵛ = Axis(fig[1, 2], xlabel="qᵛ (g/kg)", ylabel="z (km)", title="Water vapor mixing ratio")
+lines!(axqᵛ, qᵛ_profile, linewidth=2, color=:dodgerblue)
+hlines!(axqᵛ, [zᵖ / 1000], color=:gray, linestyle=:dash)
 
 axu = Axis(fig[1, 3], xlabel="u (m/s)", ylabel="z (km)", title="Wind profile")
 lines!(axu, u_profile, linewidth=2, color=:orangered)
@@ -225,9 +239,9 @@ model = AtmosphereModel(grid; dynamics, microphysics, advection, thermodynamic_c
 #
 # We initialize the model with the previously described initial conditions, including a warm-bubble perturbation.
 
-ℋᵢ(x, y, z) = ℋ_background(z)
+qᵛᵢ(x, y, z) = qᵛ_background(z)
 
-set!(model, θ=θᵢ, ℋ=ℋᵢ, u=uᵢ)
+set!(model, θ=θᵢ, qᵛ=qᵛᵢ, u=uᵢ)
 
 # ## Simulation
 #

--- a/examples/splitting_supercell.jl
+++ b/examples/splitting_supercell.jl
@@ -14,7 +14,8 @@
 # The simulation initializes a conditionally unstable atmosphere with a warm bubble perturbation
 # that triggers deep convection. The environment includes:
 # - A realistic tropospheric potential temperature profile with a tropopause at 12 km
-# - Relative humidity that decreases with height (25% above the tropopause), with the resulting water vapor mixing ratio capped at a surface value
+# - Relative humidity that decreases with height, with the resulting water vapor mixing ratio capped at 14 kg/kg to 
+# approximate a well-mixed boundary layer in the lowest kilometer.
 # - Wind shear in the lower 5 km to promote storm rotation and supercell development
 #
 # ### Potential temperature profile

--- a/examples/splitting_supercell.jl
+++ b/examples/splitting_supercell.jl
@@ -58,6 +58,7 @@
 
 using Breeze
 using Breeze: DCMIP2016KesslerMicrophysics, TetensFormula
+using Breeze.Thermodynamics: hydrostatic_density, hydrostatic_temperature
 using Oceananigans: Oceananigans
 using Oceananigans.Units
 using Oceananigans.Grids: znodes
@@ -120,7 +121,6 @@ nothing #hide
 
 g = constants.gravitational_acceleration
 cᵖᵈ = constants.dry_air.heat_capacity
-Rᵈ = dry_air_gas_constant(constants)
 nothing #hide
 
 # Background potential temperature profile (Equation 14 in [KlempEtAl2015](@citet)):
@@ -133,15 +133,15 @@ end
 
 # Relative humidity profile (Equations 11–12 in [KlempEtAl2015](@citet)) combined with
 # a cap on the water vapor mixing ratio at ``qᵛ_max``. The local temperature and density
-# are estimated from a hydrostatic Exner profile ``Π(z) = 1 − g z/(cᵖᵈ θ₀)`` combined
-# with the actual ``θ(z)``:
+# are obtained by numerically integrating the hydrostatic balance with the actual
+# ``θ(z)`` profile:
 
 function qᵛ_background(z)
     ℋ = (1 - 3/4 * (z / zᵖ)^(5/4)) * (z ≤ zᵖ) + 1/4 * (z > zᵖ)
-    Π = 1 - g * z / (cᵖᵈ * θ₀)
-    T = Π * θ_background(z)
-    p = reference_state.surface_pressure * Π^(cᵖᵈ / Rᵈ)
-    ρ = p / (Rᵈ * T)
+    p₀ = reference_state.surface_pressure
+    pˢᵗ = reference_state.standard_pressure
+    T = hydrostatic_temperature(z, p₀, θ_background, pˢᵗ, constants)
+    ρ = hydrostatic_density(z, p₀, θ_background, pˢᵗ, constants)
     qᵛ⁺ = saturation_specific_humidity(T, ρ, constants, PlanarLiquidSurface())
     return min(ℋ * qᵛ⁺, qᵛ_max)
 end

--- a/examples/splitting_supercell.jl
+++ b/examples/splitting_supercell.jl
@@ -133,7 +133,7 @@ function θ_background(z)
 end
 
 # Relative humidity profile (Equations 11–12 by [KlempEtAl2015](@citet)) combined with
-# a cap on the water vapor mixing ratio at ``qᵛ_max``. The local temperature and density
+# a cap on the water vapor mixing ratio at ``qᵛ_{max}``. The local temperature and density
 # are obtained by numerically integrating the hydrostatic balance with the actual
 # ``θ(z)`` profile:
 

--- a/examples/splitting_supercell.jl
+++ b/examples/splitting_supercell.jl
@@ -106,7 +106,7 @@ dynamics = AnelasticDynamics(reference_state)
 θᵖ = 343       # K - tropopause potential temperature
 zᵖ = 12000     # m - tropopause height
 Tᵖ = 213       # K - tropopause temperature
-qᵛ⁰ = 0.014    # kg/kg - cap on water vapor mixing ratio
+qᵛ_max = 0.014    # kg/kg - cap on water vapor mixing ratio
 nothing #hide
 
 # Wind shear parameters control the low-level environmental wind profile:
@@ -132,7 +132,7 @@ function θ_background(z)
 end
 
 # Relative humidity profile (Equations 11–12 in [KlempEtAl2015](@citet)) combined with
-# a cap on the water vapor mixing ratio at ``qᵛ⁰``. The local temperature and density
+# a cap on the water vapor mixing ratio at ``qᵛ_max``. The local temperature and density
 # are estimated from a hydrostatic Exner profile ``Π(z) = 1 − g z/(cᵖᵈ θ₀)`` combined
 # with the actual ``θ(z)``:
 
@@ -143,7 +143,7 @@ function qᵛ_background(z)
     p = reference_state.surface_pressure * Π^(cᵖᵈ / Rᵈ)
     ρ = p / (Rᵈ * T)
     qᵛ⁺ = saturation_specific_humidity(T, ρ, constants, PlanarLiquidSurface())
-    return min(ℋ * qᵛ⁺, qᵛ⁰)
+    return min(ℋ * qᵛ⁺, qᵛ_max)
 end
 
 # Zonal wind profile with linear shear below ``zˢ`` and smooth transition (Equations 15-16):

--- a/examples/splitting_supercell.jl
+++ b/examples/splitting_supercell.jl
@@ -14,8 +14,8 @@
 # The simulation initializes a conditionally unstable atmosphere with a warm bubble perturbation
 # that triggers deep convection. The environment includes:
 # - A realistic tropospheric potential temperature profile with a tropopause at 12 km
-# - Relative humidity that decreases with height, with the resulting water vapor mixing ratio capped at 0.014 kg/kg to
-# approximate a well-mixed boundary layer in the lowest kilometer.
+# - Relative humidity that decreases with height, with the resulting water vapor mixing ratio capped at
+#   0.014 kg/kg "to approximate a well-mixed boundary layer in the lowest kilometer" ([KlempEtAl2015](@citet)).
 # - Wind shear in the lower 5 km to promote storm rotation and supercell development
 #
 # ### Potential temperature profile
@@ -108,7 +108,7 @@ dynamics = AnelasticDynamics(reference_state)
 θᵖ = 343       # K - tropopause potential temperature
 zᵖ = 12000     # m - tropopause height
 Tᵖ = 213       # K - tropopause temperature
-qᵛ_max = 0.014  # kg/kg - cap on water vapor mixing ratio
+qᵛ_max = 0.014 # kg/kg - Equation 13 in Klemp et al. (2015)
 nothing #hide
 
 # Wind shear parameters control the low-level environmental wind profile:
@@ -133,7 +133,7 @@ function θ_background(z)
 end
 
 # Relative humidity profile (Equations 11–12 by [KlempEtAl2015](@citet)) combined with
-# a cap on the water vapor mixing ratio at ``qᵛ_{max}``. The local temperature and density
+# the water vapor cap ``qᵛ_{max}`` from Equation 13. The local temperature and density
 # are obtained by numerically integrating the hydrostatic balance with the actual
 # ``θ(z)`` profile:
 

--- a/examples/splitting_supercell.jl
+++ b/examples/splitting_supercell.jl
@@ -14,7 +14,7 @@
 # The simulation initializes a conditionally unstable atmosphere with a warm bubble perturbation
 # that triggers deep convection. The environment includes:
 # - A realistic tropospheric potential temperature profile with a tropopause at 12 km
-# - Water vapor mixing ratio that decreases with height, falling to one-quarter of the surface value above the tropopause
+# - Relative humidity that decreases with height (25% above the tropopause), with the resulting water vapor mixing ratio capped at a surface value
 # - Wind shear in the lower 5 km to promote storm rotation and supercell development
 #
 # ### Potential temperature profile
@@ -106,7 +106,7 @@ dynamics = AnelasticDynamics(reference_state)
 θᵖ = 343       # K - tropopause potential temperature
 zᵖ = 12000     # m - tropopause height
 Tᵖ = 213       # K - tropopause temperature
-qᵛ⁰ = 0.014    # kg/kg - surface water vapor mixing ratio
+qᵛ⁰ = 0.014    # kg/kg - cap on water vapor mixing ratio
 nothing #hide
 
 # Wind shear parameters control the low-level environmental wind profile:
@@ -131,20 +131,19 @@ function θ_background(z)
     return (z ≤ zᵖ) * θᵗ + (z > zᵖ) * θˢ
 end
 
-# Water vapor mixing ratio profile (Equation 18 in [KlempEtAl2015](@citet)),
-# scaled by the surface value ``qᵛ⁰``, reduced to one-quarter above the tropopause,
-# and clipped at the local saturation specific humidity. The local temperature
-# and density are estimated from a hydrostatic Exner profile ``Π(z) = 1 − g z/(cᵖᵈ θ₀)``
-# combined with the actual ``θ(z)``:
+# Relative humidity profile (Equations 11–12 in [KlempEtAl2015](@citet)) combined with
+# a cap on the water vapor mixing ratio at ``qᵛ⁰``. The local temperature and density
+# are estimated from a hydrostatic Exner profile ``Π(z) = 1 − g z/(cᵖᵈ θ₀)`` combined
+# with the actual ``θ(z)``:
 
 function qᵛ_background(z)
-    qᵛ_klemp = qᵛ⁰ * ((1 - 3/4 * (z / zᵖ)^(5/4)) * (z ≤ zᵖ) + 1/4 * (z > zᵖ))
+    ℋ = (1 - 3/4 * (z / zᵖ)^(5/4)) * (z ≤ zᵖ) + 1/4 * (z > zᵖ)
     Π = 1 - g * z / (cᵖᵈ * θ₀)
     T = Π * θ_background(z)
     p = reference_state.surface_pressure * Π^(cᵖᵈ / Rᵈ)
     ρ = p / (Rᵈ * T)
     qᵛ⁺ = saturation_specific_humidity(T, ρ, constants, PlanarLiquidSurface())
-    return min(qᵛ_klemp, qᵛ⁺)
+    return min(ℋ * qᵛ⁺, qᵛ⁰)
 end
 
 # Zonal wind profile with linear shear below ``zˢ`` and smooth transition (Equations 15-16):

--- a/examples/splitting_supercell.jl
+++ b/examples/splitting_supercell.jl
@@ -137,7 +137,7 @@ end
 # are obtained by numerically integrating the hydrostatic balance with the actual
 # ``θ(z)`` profile:
 
-function qᵛ_background(z)
+function qᵛ_bg(z)
     ℋ = (1 - 3/4 * (z / zᵖ)^(5/4)) * (z ≤ zᵖ) + 1/4 * (z > zᵖ)
     p₀ = reference_state.surface_pressure
     pˢᵗ = reference_state.standard_pressure
@@ -151,7 +151,7 @@ end
 # per vertical level rather than once per horizontal grid point:
 
 qᵛ_column = Field{Nothing, Nothing, Center}(grid)
-set!(qᵛ_column, qᵛ_background)
+set!(qᵛ_column, qᵛ_bg)
 
 # Zonal wind profile with linear shear below ``zˢ`` and smooth transition (Equations 15-16):
 

--- a/examples/splitting_supercell.jl
+++ b/examples/splitting_supercell.jl
@@ -108,7 +108,7 @@ dynamics = AnelasticDynamics(reference_state)
 θᵖ = 343       # K - tropopause potential temperature
 zᵖ = 12000     # m - tropopause height
 Tᵖ = 213       # K - tropopause temperature
-qᵛ_max = 0.014    # kg/kg - cap on water vapor mixing ratio
+qᵛ_max = 0.014  # kg/kg - cap on water vapor mixing ratio
 nothing #hide
 
 # Wind shear parameters control the low-level environmental wind profile:

--- a/examples/splitting_supercell.jl
+++ b/examples/splitting_supercell.jl
@@ -14,7 +14,7 @@
 # The simulation initializes a conditionally unstable atmosphere with a warm bubble perturbation
 # that triggers deep convection. The environment includes:
 # - A realistic tropospheric potential temperature profile with a tropopause at 12 km
-# - Relative humidity that decreases with height, with the resulting water vapor mixing ratio capped at 14 g/kg to
+# - Relative humidity that decreases with height, with the resulting water vapor mixing ratio capped at 0.014 kg/kg to
 # approximate a well-mixed boundary layer in the lowest kilometer.
 # - Wind shear in the lower 5 km to promote storm rotation and supercell development
 #

--- a/examples/splitting_supercell.jl
+++ b/examples/splitting_supercell.jl
@@ -146,6 +146,12 @@ function qᵛ_background(z)
     return min(ℋ * qᵛ⁺, qᵛ_max)
 end
 
+# Evaluate ``qᵛ`` on a column field so the hydrostatic integration runs only once
+# per vertical level rather than once per horizontal grid point:
+
+qᵛ_column = Field{Nothing, Nothing, Center}(grid)
+set!(qᵛ_column, qᵛ_background)
+
 # Zonal wind profile with linear shear below ``zˢ`` and smooth transition (Equations 15-16):
 
 function u_background(z)
@@ -188,7 +194,7 @@ uᵢ(x, y, z) = u_background(z)
 # profiles that define the environmental stratification:
 
 θ_profile = set!(Field{Nothing, Nothing, Center}(grid), z -> θ_background(z))
-qᵛ_profile = set!(Field{Nothing, Nothing, Center}(grid), z -> qᵛ_background(z) * 1000)
+qᵛ_profile = set!(Field{Nothing, Nothing, Center}(grid), 1000 * qᵛ_column)
 u_profile = set!(Field{Nothing, Nothing, Center}(grid), z -> u_background(z))
 
 fig = Figure(size=(1000, 400), fontsize=14)
@@ -238,9 +244,7 @@ model = AtmosphereModel(grid; dynamics, microphysics, advection, thermodynamic_c
 #
 # We initialize the model with the previously described initial conditions, including a warm-bubble perturbation.
 
-qᵛᵢ(x, y, z) = qᵛ_background(z)
-
-set!(model, θ=θᵢ, qᵛ=qᵛᵢ, u=uᵢ)
+set!(model, θ=θᵢ, qᵛ=qᵛ_column, u=uᵢ)
 
 # ## Simulation
 #

--- a/examples/splitting_supercell.jl
+++ b/examples/splitting_supercell.jl
@@ -195,7 +195,7 @@ uᵢ(x, y, z) = u_background(z)
 # profiles that define the environmental stratification:
 
 θ_profile = set!(Field{Nothing, Nothing, Center}(grid), z -> θ_background(z))
-qᵛ_profile = set!(Field{Nothing, Nothing, Center}(grid), 1000 * qᵛ_column)
+qᵛ_profile = set!(Field{Nothing, Nothing, Center}(grid), 1000 * qᵛ_column) # convert kg/kg -> g/kg
 u_profile = set!(Field{Nothing, Nothing, Center}(grid), z -> u_background(z))
 
 fig = Figure(size=(1000, 400), fontsize=14)

--- a/examples/splitting_supercell.jl
+++ b/examples/splitting_supercell.jl
@@ -108,7 +108,7 @@ dynamics = AnelasticDynamics(reference_state)
 θᵖ = 343       # K - tropopause potential temperature
 zᵖ = 12000     # m - tropopause height
 Tᵖ = 213       # K - tropopause temperature
-qᵛ_max = 0.014 # kg/kg - Equation 13 in Klemp et al. (2015)
+qᵛ_max = 0.014 # kg/kg - cap on water vapor mixing ratio from Klemp et al. (2015)
 nothing #hide
 
 # Wind shear parameters control the low-level environmental wind profile:
@@ -133,7 +133,7 @@ function θ_background(z)
 end
 
 # Relative humidity profile (Equations 11–12 by [KlempEtAl2015](@citet)) combined with
-# the water vapor cap ``qᵛ_{max}`` from Equation 13. The local temperature and density
+# the water vapor cap ``qᵛ_{max}``. The local temperature and density
 # are obtained by numerically integrating the hydrostatic balance with the actual
 # ``θ(z)`` profile:
 


### PR DESCRIPTION
## Summary

Fixes the moisture initialization in `examples/splitting_supercell.jl` to match the Klemp et al. (2015) specification (Eqs. 11–12).

- **Before**: the shape function `1 − 3/4 (z/zᵖ)^{5/4}` was passed as relative humidity with no cap. At the 300 K / 1000 hPa surface this gave ℋ = 1, i.e. saturation with `qᵥ ≈ 22.8 g/kg` — far wetter than Klemp's sounding and yielding ~6000 J/kg CAPE.
- **After**: apply the RH profile as specified, compute `qᵥ = ℋ · qᵛ⁺(T, p)`, and cap at `qᵛ_max = 0.014 kg/kg` (Klemp's surface limit). Local T, p, ρ are estimated from a hydrostatic Exner profile `Π(z) = 1 − g z/(cᵖᵈ θ₀)` combined with the actual `θ(z)`. Back-of-envelope CAPE drops to ~1400 J/kg, in the expected range for this test.

The initial narrative, the profile visualization (now showing qᵛ in g/kg), and the `set!` call (now uses `qᵛ=` instead of `ℋ=`) were updated correspondingly.

## Test plan

- [ ] Build the example locally and confirm the initial-conditions figure shows the expected qᵛ profile (≈14 g/kg at surface, tapering to ~0 in the stratosphere)
- [ ] Run the 2-hour simulation and verify the storm splits and the max-w time series is closer to DCMIP2016 reference values than the previous ~60 m/s extreme
- [ ] Inspect the first output slice at t ≈ 2 min to confirm no spurious stratospheric cloud layer from initial supersaturation
