### PR TITLE
Fix bulk sensible heat flux potential temperature conversion

### DIFF
--- a/src/BoundaryConditions/BoundaryConditions.jl
+++ b/src/BoundaryConditions/BoundaryConditions.jl
@@ -25,10 +25,11 @@ export BulkDragFunction,
        default_neutral_sensible_heat_polynomial,
        default_neutral_latent_heat_polynomial
 
-using ..AtmosphereModels: AtmosphereModels, grid_moisture_fractions, dynamics_density
+using ..AtmosphereModels: AtmosphereModels, grid_moisture_fractions, dynamics_density, standard_pressure
 using ..AtmosphereModels.Diagnostics: VirtualPotentialTemperature, saturation_total_specific_moisture
 using ..Thermodynamics: saturation_specific_humidity, surface_density, PlanarLiquidSurface,
-                        mixture_heat_capacity, dry_air_gas_constant, vapor_gas_constant
+                        mixture_heat_capacity, dry_air_gas_constant, vapor_gas_constant,
+                        potential_temperature_from_temperature
 
 using Oceananigans: Oceananigans
 using Oceananigans.Architectures: Architectures
@@ -321,18 +322,18 @@ function materialize_atmosphere_boundary_condition(bc::BoundaryCondition{<:Flux,
                                  microphysical_fields, specific_prognostic_moisture, temperature)
 end
 
-# Materialize BulkSensibleHeatFlux: populate surface_pressure, thermodynamic_constants, preserve formulation
+# Materialize BulkSensibleHeatFlux: populate pressure data, thermodynamic_constants, preserve formulation
 function materialize_atmosphere_boundary_condition(bc::BulkSensibleHeatFluxBoundaryCondition,
                                                   side, loc, grid, dynamics, microphysics, surface_pressure, constants,
                                                   microphysical_fields, specific_prognostic_moisture, temperature)
 
     bf = bc.condition
     T₀ = materialize_surface_field(bf.surface_temperature, grid)
+    pˢᵗ = standard_pressure(dynamics)
     coef = materialize_coefficient(bf.coefficient, grid, dynamics, microphysics,
                                    surface_pressure, constants,
                                    microphysical_fields, specific_prognostic_moisture, temperature,
                                    Val(:scalar))
-
     # Auto-create FilteredSurfaceScalar if filtered_velocities is provided
     fs = if isnothing(bf.filtered_velocities)
         nothing
@@ -341,9 +342,8 @@ function materialize_atmosphere_boundary_condition(bc::BulkSensibleHeatFluxBound
                               filter_timescale=bf.filtered_velocities.filter_timescale)
     end
 
-    new_bf = BulkSensibleHeatFluxFunction(coef, bf.gustiness, T₀, surface_pressure, constants,
+    new_bf = BulkSensibleHeatFluxFunction(coef, bf.gustiness, T₀, surface_pressure, pˢᵗ, constants,
                                           bf.formulation, bf.filtered_velocities, fs)
-
     return BoundaryCondition(Flux(), new_bf)
 end
 
@@ -404,8 +404,12 @@ end
 BulkDragFunction(d, coef::NothingPolynomialCoefficient, g, t, fv) =
     BulkDragFunction(d, fill_polynomial(coef, default_neutral_drag_polynomial, Val(:momentum)), g, t, fv)
 
-BulkSensibleHeatFluxFunction(coef::NothingPolynomialCoefficient, g, t, p, c, f, fv, fs) =
-    BulkSensibleHeatFluxFunction(fill_polynomial(coef, default_neutral_sensible_heat_polynomial, Val(:scalar)), g, t, p, c, f, fv, fs)
+BulkSensibleHeatFluxFunction(coef::NothingPolynomialCoefficient, g, t, p, s, c, f) =
+    BulkSensibleHeatFluxFunction(fill_polynomial(coef, default_neutral_sensible_heat_polynomial, Val(:scalar)),
+                                 g, t, p, s, c, f, nothing, nothing)
+BulkSensibleHeatFluxFunction(coef::NothingPolynomialCoefficient, g, t, p, s, c, f, fv, fs) =
+    BulkSensibleHeatFluxFunction(fill_polynomial(coef, default_neutral_sensible_heat_polynomial, Val(:scalar)),
+                                 g, t, p, s, c, f, fv, fs)
 
 BulkVaporFluxFunction(coef::NothingPolynomialCoefficient, g, t, p, c, s, fv, fs) =
     BulkVaporFluxFunction(fill_polynomial(coef, default_neutral_latent_heat_polynomial, Val(:scalar)), g, t, p, c, s, fv, fs)

--- a/src/BoundaryConditions/bulk_scalar_fluxes.jl
+++ b/src/BoundaryConditions/bulk_scalar_fluxes.jl
@@ -5,11 +5,12 @@
 struct PotentialTemperatureFlux end
 struct StaticEnergyFlux end
 
-struct BulkSensibleHeatFluxFunction{C, G, T, P, TC, F, FV, FS}
+struct BulkSensibleHeatFluxFunction{C, G, T, P, SP, TC, F, FV, FS}
     coefficient :: C
     gustiness :: G
     surface_temperature :: T
     surface_pressure :: P
+    standard_pressure :: SP
     thermodynamic_constants :: TC
     formulation :: F
     filtered_velocities :: FV  # Nothing or FilteredSurfaceVelocities
@@ -17,7 +18,7 @@ struct BulkSensibleHeatFluxFunction{C, G, T, P, TC, F, FV, FS}
 end
 
 """
-    BulkSensibleHeatFluxFunction(; coefficient, gustiness=0, surface_temperature)
+$(TYPEDSIGNATURES)
 
 A bulk sensible heat flux function. The flux is computed as:
 
@@ -29,8 +30,12 @@ where `Cᵀ` is the transfer coefficient, `|U|` is the wind speed, and `Δϕ` is
 difference between the near-surface atmospheric value and the surface value of the
 thermodynamic variable appropriate to the formulation:
 
-- For `LiquidIcePotentialTemperatureFormulation`: `Δϕ = θ - θ₀` (potential temperature flux)
+- For `LiquidIcePotentialTemperatureFormulation`: `Δϕ = θ - θ₀`, where
+  `θ₀ = T₀ / Π₀` and `Π₀ = (p₀ / pˢᵗ)^(Rᵈ / cᵖᵈ)` (potential temperature flux)
 - For `StaticEnergyFormulation`: `Δϕ = e - cᵖᵈ T₀` (static energy flux)
+
+Here `p₀` is the actual surface pressure, while `pˢᵗ` is the fixed reference pressure
+used to define potential temperature.
 
 The `formulation` is set automatically during model construction based on the
 thermodynamic formulation.
@@ -44,7 +49,7 @@ thermodynamic formulation.
 """
 function BulkSensibleHeatFluxFunction(; coefficient, gustiness=0, surface_temperature, filtered_velocities=nothing)
     return BulkSensibleHeatFluxFunction(coefficient, gustiness, surface_temperature,
-                                        nothing, nothing, nothing, filtered_velocities, nothing)
+                                        nothing, nothing, nothing, nothing, filtered_velocities, nothing)
 end
 
 Adapt.adapt_structure(to, bf::BulkSensibleHeatFluxFunction) =
@@ -52,6 +57,7 @@ Adapt.adapt_structure(to, bf::BulkSensibleHeatFluxFunction) =
                                  Adapt.adapt(to, bf.gustiness),
                                  Adapt.adapt(to, bf.surface_temperature),
                                  Adapt.adapt(to, bf.surface_pressure),
+                                 Adapt.adapt(to, bf.standard_pressure),
                                  Adapt.adapt(to, bf.thermodynamic_constants),
                                  bf.formulation,
                                  Adapt.adapt(to, bf.filtered_velocities),
@@ -63,22 +69,33 @@ Base.summary(bf::BulkSensibleHeatFluxFunction) =
 
 # Compute the thermodynamic variable difference at the surface.
 # Default to potential temperature flux when formulation is not set (ρθ BCs passed directly).
-@inline bulk_sensible_heat_difference(i, j, grid, ::Nothing, T₀, constants, fields, fs) =
-    bulk_sensible_heat_difference(i, j, grid, PotentialTemperatureFlux(), T₀, constants, fields, fs)
+@inline bulk_sensible_heat_difference(i, j, grid, ::Nothing, bf, T₀, fields) =
+    bulk_sensible_heat_difference(i, j, grid, PotentialTemperatureFlux(), bf, T₀, fields, nothing)
+@inline bulk_sensible_heat_difference(i, j, grid, ::Nothing, bf, T₀, fields, fs) =
+    bulk_sensible_heat_difference(i, j, grid, PotentialTemperatureFlux(), bf, T₀, fields, fs)
 
 # No filtered scalar: read from 3D fields (current behavior)
-@inline function bulk_sensible_heat_difference(i, j, grid, ::PotentialTemperatureFlux, T₀, constants, fields, ::Nothing)
+@inline function bulk_sensible_heat_difference(i, j, grid, ::PotentialTemperatureFlux, bf, T₀, fields, ::Nothing)
     θ = @inbounds fields.θ[i, j, 1]
-    return θ - T₀
+    p₀ = bf.surface_pressure
+    pˢᵗ = bf.standard_pressure
+    constants = bf.thermodynamic_constants
+    θ₀ = potential_temperature_from_temperature(T₀, p₀, pˢᵗ, constants)
+    return θ - θ₀
 end
 
 # With filtered scalar: read from the 2D filtered field
-@inline function bulk_sensible_heat_difference(i, j, grid, ::PotentialTemperatureFlux, T₀, constants, fields, fs::FilteredSurfaceScalar)
+@inline function bulk_sensible_heat_difference(i, j, grid, ::PotentialTemperatureFlux, bf, T₀, fields, fs::FilteredSurfaceScalar)
     θ = @inbounds fs.field[i, j, 1]
-    return θ - T₀
+    p₀ = bf.surface_pressure
+    pˢᵗ = bf.standard_pressure
+    constants = bf.thermodynamic_constants
+    θ₀ = potential_temperature_from_temperature(T₀, p₀, pˢᵗ, constants)
+    return θ - θ₀
 end
 
-@inline function bulk_sensible_heat_difference(i, j, grid, ::StaticEnergyFlux, T₀, constants, fields, ::Nothing)
+@inline function bulk_sensible_heat_difference(i, j, grid, ::StaticEnergyFlux, bf, T₀, fields, ::Nothing)
+    constants = bf.thermodynamic_constants
     cᵖᵈ = constants.dry_air.heat_capacity
     cᵖᵛ = constants.vapor.heat_capacity
     qᵛ = @inbounds fields.qᵛ[i, j, 1]
@@ -88,7 +105,8 @@ end
     return e - e₀
 end
 
-@inline function bulk_sensible_heat_difference(i, j, grid, ::StaticEnergyFlux, T₀, constants, fields, fs::FilteredSurfaceScalar)
+@inline function bulk_sensible_heat_difference(i, j, grid, ::StaticEnergyFlux, bf, T₀, fields, fs::FilteredSurfaceScalar)
+    constants = bf.thermodynamic_constants
     cᵖᵈ = constants.dry_air.heat_capacity
     cᵖᵛ = constants.vapor.heat_capacity
     qᵛ = @inbounds fields.qᵛ[i, j, 1]
@@ -111,7 +129,7 @@ end
 
     Cᵀ = bulk_coefficient(i, j, grid, bf.coefficient, fields, T₀, bf.filtered_velocities)
 
-    Δϕ = bulk_sensible_heat_difference(i, j, grid, bf.formulation, T₀, constants, fields, bf.filtered_scalar)
+    Δϕ = bulk_sensible_heat_difference(i, j, grid, bf.formulation, bf, T₀, fields, bf.filtered_scalar)
     return - ρ₀ * Cᵀ * Ũ * Δϕ
 end
 

--- a/src/BoundaryConditions/thermodynamic_variable_bcs.jl
+++ b/src/BoundaryConditions/thermodynamic_variable_bcs.jl
@@ -322,8 +322,8 @@ set_sensible_heat_formulation(bc, formulation) = bc
 function set_sensible_heat_formulation(bc::BulkSensibleHeatFluxBoundaryCondition, formulation)
     bf = bc.condition
     new_bf = BulkSensibleHeatFluxFunction(bf.coefficient, bf.gustiness, bf.surface_temperature,
-                                           bf.surface_pressure, bf.thermodynamic_constants,
-                                           formulation, bf.filtered_velocities, bf.filtered_scalar)
+                                          bf.surface_pressure, bf.standard_pressure, bf.thermodynamic_constants,
+                                          formulation, bf.filtered_velocities, bf.filtered_scalar)
     return BoundaryCondition(Flux(), new_bf)
 end
 

--- a/src/ParcelModels/parcel_dynamics.jl
+++ b/src/ParcelModels/parcel_dynamics.jl
@@ -424,7 +424,7 @@ end
         θₖ = θ_field[i, j, k]
         pₖ = p_field[i, j, k]
     end
-    @inbounds T_field[i, j, k] = @inline temperature_from_potential_temperature(θₖ, pₖ, constants; pˢᵗ)
+    @inbounds T_field[i, j, k] = @inline temperature_from_potential_temperature(θₖ, pₖ, pˢᵗ, constants)
 end
 
 """

--- a/src/Thermodynamics/Thermodynamics.jl
+++ b/src/Thermodynamics/Thermodynamics.jl
@@ -15,7 +15,8 @@ export ThermodynamicConstants, ReferenceState, ExnerReferenceState, compute_refe
        dewpoint_temperature,
        vapor_pressure, relative_humidity,
        adiabatic_hydrostatic_pressure, adiabatic_hydrostatic_density, surface_density,
-       temperature_from_potential_temperature, temperature, with_temperature, with_moisture,
+       temperature_from_potential_temperature, potential_temperature_from_temperature,
+       temperature, with_temperature, with_moisture,
        PlanarLiquidSurface, PlanarIceSurface, PlanarMixedPhaseSurface,
        # Phase equilibrium types
        AbstractPhaseEquilibrium, WarmPhaseEquilibrium, MixedPhaseEquilibrium,

--- a/src/Thermodynamics/dynamic_states.jl
+++ b/src/Thermodynamics/dynamic_states.jl
@@ -58,7 +58,7 @@ end
 end
 
 """
-    temperature_from_potential_temperature(θ, p, constants; pˢᵗ=1e5, qᵛ=0)
+$(TYPEDSIGNATURES)
 
 Compute temperature from potential temperature and pressure.
 
@@ -70,15 +70,61 @@ with no condensate and computes temperature using the standard thermodynamic rel
 - `p`: Pressure [Pa]
 - `constants`: Thermodynamic constants
 
-# Keyword Arguments
-- `pˢᵗ`: Standard pressure for potential temperature definition [Pa] (default: 1e5)
-- `qᵛ`: Specific humidity [kg/kg] (default: 0, dry air)
+# Additional Arguments
+- `pˢᵗ`: Standard pressure for potential temperature definition [Pa]
+- `qᵛ`: Specific humidity [kg/kg]
 """
-@inline function temperature_from_potential_temperature(θ, p, constants; pˢᵗ=1e5, qᵛ=zero(θ))
+@inline function temperature_from_potential_temperature(θ, p, pˢᵗ, constants, qᵛ)
+    FT = promote_type(typeof(θ), typeof(p), typeof(qᵛ))
+    θ = convert(FT, θ)
+    p = convert(FT, p)
+    pˢᵗ = convert(FT, pˢᵗ)
+    qᵛ = convert(FT, qᵛ)
     q = MoistureMassFractions(qᵛ)  # vapor only, no condensate
     𝒰 = LiquidIcePotentialTemperatureState(θ, q, pˢᵗ, p)
     return temperature(𝒰, constants)
 end
+
+@inline temperature_from_potential_temperature(θ, p, pˢᵗ, constants) =
+    temperature_from_potential_temperature(θ, p, pˢᵗ, constants, zero(θ))
+
+@inline temperature_from_potential_temperature(θ, p, constants) =
+    temperature_from_potential_temperature(θ, p, 1e5, constants)
+
+"""
+$(TYPEDSIGNATURES)
+
+Compute potential temperature from temperature and pressure.
+
+This is a convenience function that constructs a `LiquidIcePotentialTemperatureState`
+with no condensate and computes potential temperature using the standard thermodynamic relations.
+
+# Arguments
+- `T`: Temperature [K]
+- `p`: Pressure [Pa]
+- `constants`: Thermodynamic constants
+
+# Additional Arguments
+- `pˢᵗ`: Standard pressure for potential temperature definition [Pa]
+- `qᵛ`: Specific humidity [kg/kg]
+"""
+@inline function potential_temperature_from_temperature(T, p, pˢᵗ, constants, qᵛ)
+    FT = promote_type(typeof(T), typeof(p), typeof(qᵛ))
+    T = convert(FT, T)
+    p = convert(FT, p)
+    pˢᵗ = convert(FT, pˢᵗ)
+    qᵛ = convert(FT, qᵛ)
+    q = MoistureMassFractions(qᵛ)  # vapor only, no condensate
+    𝒰₀ = LiquidIcePotentialTemperatureState(zero(T), q, pˢᵗ, p)
+    𝒰₁ = with_temperature(𝒰₀, T, constants)
+    return 𝒰₁.potential_temperature
+end
+
+@inline potential_temperature_from_temperature(T, p, pˢᵗ, constants) =
+    potential_temperature_from_temperature(T, p, pˢᵗ, constants, zero(T))
+
+@inline potential_temperature_from_temperature(T, p, constants) =
+    potential_temperature_from_temperature(T, p, 1e5, constants)
 
 @inline function with_temperature(𝒰::LiquidIcePotentialTemperatureState, T, constants)
     Π = exner_function(𝒰, constants)

--- a/test/forcing_and_boundary_conditions.jl
+++ b/test/forcing_and_boundary_conditions.jl
@@ -1,6 +1,7 @@
 using Breeze
-using Breeze.AtmosphereModels: thermodynamic_density
-using Breeze.BoundaryConditions: EnergyFluxBoundaryCondition
+using Breeze.AtmosphereModels: thermodynamic_density, surface_pressure, standard_pressure
+using Breeze.BoundaryConditions: EnergyFluxBoundaryCondition, FilteredSurfaceVelocities
+using Breeze.Thermodynamics: potential_temperature_from_temperature
 using GPUArraysCore: @allowscalar
 using Oceananigans: Oceananigans
 using Oceananigans.BoundaryConditions: BoundaryCondition
@@ -98,6 +99,63 @@ end
         set!(model; θ=θ₀)
         time_step!(model, 1e-6)
         @test true
+    end
+
+    @testset "BulkSensibleHeatFlux uses surface-equivalent θ [$FT]" begin
+        using Oceananigans.Models: BoundaryConditionOperation
+
+        grid_1 = RectilinearGrid(default_arch; size=(1, 1, 1), x=(0, 100), y=(0, 100), z=(0, 100))
+        bc = BulkSensibleHeatFlux(surface_temperature=FT(T₀), coefficient=FT(Cᴰ), gustiness=FT(gustiness))
+        ρθ_bcs = FieldBoundaryConditions(bottom=bc)
+        model = AtmosphereModel(grid_1; boundary_conditions=(; ρθ=ρθ_bcs))
+
+        constants = model.thermodynamic_constants
+        p₀ = surface_pressure(model.dynamics)
+        pˢᵗ = standard_pressure(model.dynamics)
+        θ_surface = potential_temperature_from_temperature(FT(T₀), p₀, pˢᵗ, constants)
+
+        @test p₀ != pˢᵗ
+        @test abs(θ_surface - FT(T₀)) > increment_tolerance(FT)
+
+        set!(model; θ=θ_surface, u=FT(5))
+
+        ρθ = thermodynamic_density(model.formulation)
+        Jᶿ_op = BoundaryConditionOperation(ρθ, :bottom, model)
+        Jᶿ_field = Field(Jᶿ_op)
+        compute!(Jᶿ_field)
+
+        @test all(abs.(interior(Jᶿ_field)) .<= increment_tolerance(FT))
+    end
+
+    @testset "BulkSensibleHeatFlux uses surface-equivalent filtered θ [$FT]" begin
+        using Oceananigans.Models: BoundaryConditionOperation
+
+        grid_1 = RectilinearGrid(default_arch; size=(1, 1, 1), x=(0, 100), y=(0, 100), z=(0, 100))
+        fv = FilteredSurfaceVelocities(grid_1; filter_timescale=FT(3600))
+        bc = BulkSensibleHeatFlux(surface_temperature = FT(T₀),
+                                  coefficient = FT(Cᴰ),
+                                  gustiness = FT(gustiness),
+                                  filtered_velocities = fv)
+        ρθ_bcs = FieldBoundaryConditions(bottom=bc)
+        model = AtmosphereModel(grid_1; boundary_conditions=(; ρθ=ρθ_bcs))
+
+        constants = model.thermodynamic_constants
+        p₀ = surface_pressure(model.dynamics)
+        pˢᵗ = standard_pressure(model.dynamics)
+        θ_surface = potential_temperature_from_temperature(FT(T₀), p₀, pˢᵗ, constants)
+
+        set!(model; θ=θ_surface, u=FT(5))
+        Oceananigans.initialize!(model)
+
+        ρθ = thermodynamic_density(model.formulation)
+        bc_condition = Oceananigans.boundary_conditions(ρθ).bottom.condition
+        @test bc_condition.filtered_scalar !== nothing
+
+        Jᶿ_op = BoundaryConditionOperation(ρθ, :bottom, model)
+        Jᶿ_field = Field(Jᶿ_op)
+        compute!(Jᶿ_field)
+
+        @test all(abs.(interior(Jᶿ_field)) .<= increment_tolerance(FT))
     end
 
     @testset "BulkSensibleHeatFlux with StaticEnergyFormulation [$FT]" begin

--- a/test/unit_tests.jl
+++ b/test/unit_tests.jl
@@ -210,7 +210,9 @@ using Breeze.Thermodynamics:
     MoistureMassFractions,
     StaticEnergyState,
     temperature,
-    mixture_heat_capacity
+    mixture_heat_capacity,
+    temperature_from_potential_temperature,
+    potential_temperature_from_temperature
 
 @testset "Thermodynamics" begin
     thermo = ThermodynamicConstants()
@@ -245,6 +247,25 @@ end
         T★ = temperature(𝒰, thermo)
         @test T★ ≈ T
     end
+end
+
+@testset "Potential temperature convenience functions [$(FT)]" for FT in test_float_types()
+    thermo = ThermodynamicConstants(FT)
+    p = FT(101325)
+    pˢᵗ = FT(1e5)
+    T = FT(290)
+
+    θ = potential_temperature_from_temperature(T, p, pˢᵗ, thermo)
+    θ_default = potential_temperature_from_temperature(T, p, thermo)
+    θ_integer_temperature = potential_temperature_from_temperature(290, p, pˢᵗ, thermo)
+
+    @test θ != T
+    @test temperature_from_potential_temperature(θ, p, pˢᵗ, thermo) ≈ T
+    @test θ_default isa FT
+    @test temperature_from_potential_temperature(θ_default, p, thermo) isa FT
+    @test temperature_from_potential_temperature(θ_default, p, thermo) ≈ T
+    @test θ_integer_temperature isa FT
+    @test θ_integer_temperature ≈ θ
 end
 
 #####


### PR DESCRIPTION
## Summary

This PR fixes the `PotentialTemperatureFlux` branch of `BulkSensibleHeatFlux` so it compares atmospheric potential temperature against the surface-equivalent potential temperature, not the raw surface temperature.

The change is intentionally narrow:

- thread `standard_pressure` into the materialized bulk sensible heat boundary condition
- convert `T₀` to `θ₀` before forming the bulk temperature difference
- add a symmetric `potential_temperature_from_temperature` helper and use it at the boundary-condition call site
- add regression coverage for the zero-flux matched-`θ` case, plus helper round-trip tests

## Problem

For `ρθ` boundary conditions, the bulk sensible heat flux path was effectively using

`Δθ = θ - T₀`

instead of comparing like with like.

That is only correct when the actual surface pressure `p₀` is equal to the fixed reference pressure `pˢᵗ` used to define potential temperature. In Breeze those pressures are generally not the same:

- `p₀` is the actual surface pressure
- `pˢᵗ` is the fixed reference pressure used in the definition of `θ`

When `p₀ ≠ pˢᵗ`, this produces a systematic bias in the potential-temperature bulk flux.

## What Changed

- `BulkSensibleHeatFluxFunction` now carries `standard_pressure` through construction, adaptation, and materialization
- the `PotentialTemperatureFlux` path now converts the configured surface temperature to surface-equivalent potential temperature with

`θ₀ = potential_temperature_from_temperature(T₀, p₀, constants; pˢᵗ)`

- the `StaticEnergyFlux` path is unchanged
- `BulkSensibleHeatFlux(...)` remains unchanged from the caller’s perspective

## Why This Is The Right Fix

The bug lives at the boundary-condition interface between a user-provided surface temperature and a prognostic potential-temperature formulation. The fix therefore stays local to that interface:

- the thermodynamics conversion is implemented once in a helper that mirrors the existing `temperature_from_potential_temperature` convenience function
- the bulk flux code reuses that helper instead of carrying a second inline conversion
- no broader thermodynamics refactor or public API redesign is introduced

## Validation

- `Pkg.test("Breeze"; test_args=\`unit_tests\`)`
- `Pkg.test("Breeze"; test_args=\`forcing_and_boundary_conditions\`)`
- `Pkg.test("Breeze"; test_args=\`quality_assurance\`)`

The new regression test sets the near-surface atmospheric `θ` equal to the dry-equivalent surface `θ₀` under nonzero wind and verifies that the materialized bottom `ρθ` bulk sensible heat flux is zero to floating-point tolerance. Before this fix, that case was biased by the `θ - T₀` mismatch.
