### PR TITLE
[benchmarking] Compatibility for CUDA.jl v6

### DIFF
--- a/benchmarking/src/BreezeBenchmarks.jl
+++ b/benchmarking/src/BreezeBenchmarks.jl
@@ -27,6 +27,13 @@ using Oceananigans.Simulations: SpecifiedTimes
 using Breeze
 
 using CUDA: CUDA, CUDABackend
+# Compatibility for CUDA v5 and v6
+if isdefined(CUDA, :CUDACore)
+    using CUDA: CUDACore
+else
+    const CUDACore = CUDA
+end
+
 
 # Base functionalities
 include("metadata.jl")

--- a/benchmarking/src/utils.jl
+++ b/benchmarking/src/utils.jl
@@ -72,7 +72,7 @@ function benchmark_time_stepping(model;
     steps_per_second = time_steps / total_time_seconds
     grid_points_per_second = total_points / time_per_step_seconds
 
-    gpu_memory_used = arch isa GPU ? CUDA.MemoryInfo().pool_used_bytes : 0
+    gpu_memory_used = arch isa GPU ? CUDACore.MemoryInfo().pool_used_bytes : 0
     metadata = BenchmarkMetadata(arch)
 
     result = BenchmarkResult(
@@ -264,7 +264,7 @@ function run_benchmark_simulation(model;
     steps_per_second = time_steps / wall_time_seconds
     grid_points_per_second = total_points / time_per_step_seconds
 
-    gpu_memory_used = arch isa GPU ? CUDA.MemoryInfo().pool_used_bytes : 0
+    gpu_memory_used = arch isa GPU ? CUDACore.MemoryInfo().pool_used_bytes : 0
     metadata = BenchmarkMetadata(arch)
 
     result = SimulationResult(


### PR DESCRIPTION
[Famous last words](https://github.com/NumericalEarth/Breeze.jl/pull/637#issuecomment-4281735657)

> For the record, this didn't actually use CUDA.jl v6 because we're blocked by RRTMGP.jl, but in practice I don't expect any problem on the Breeze.jl's side: we don't have any CUDA-specific code in the source of Breeze.jl itself, not even extensions.  Main work was getting Oceananigans to be compatible with CUDA.jl v6, and that was completed already earlier today.

While the above is technically true, it was missing the benchmarks, which do use CUDA API.  Same change as https://github.com/CliMA/Oceananigans.jl/pull/5532.