### PR TITLE
[benchmarking] Support AMD GPUs

### DIFF
--- a/benchmarking/Project.toml
+++ b/benchmarking/Project.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["NumericalEarth organization (github.com/NumericalEarth) and contributors"]
 
 [deps]
+AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
 Breeze = "660aa2fb-d4c8-4359-a52c-9c057bc511da"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
@@ -19,6 +20,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Breeze = {path = ".."}
 
 [compat]
+AMDGPU = "2.3.0"
 ArgParse = "1"
 CUDA = "5, 6.0"
 CloudMicrophysics = "0.31.4, 0.32, 0.33, 0.34, 0.35"

--- a/benchmarking/run_benchmarks.jl
+++ b/benchmarking/run_benchmarks.jl
@@ -29,6 +29,9 @@ using Breeze
 using Breeze: CompressibleDynamics, SplitExplicitTimeDiscretization, ExplicitTimeStepping
 using Breeze.Microphysics: NonEquilibriumCloudFormation
 
+using CUDA: CUDABackend
+using AMDGPU: ROCBackend
+
 # Load CloudMicrophysics extension for OneMomentCloudMicrophysics
 using CloudMicrophysics: CloudMicrophysics
 const CMExt = Base.get_extension(Breeze, :BreezeCloudMicrophysicsExt)
@@ -182,7 +185,7 @@ end
 #####
 
 # Simple constructors: "CPU" -> CPU(), "Float32" -> Float32
-make_architecture(name) = (@eval $(Symbol(name)))()
+make_architecture(name) = eval(Meta.parse(name))()
 make_float_type(name) = @eval $(Symbol(name))
 
 # Advection: parse "WENO5" -> WENO(FT; order=5), "Centered2" -> Centered(FT; order=2)

--- a/benchmarking/src/BreezeBenchmarks.jl
+++ b/benchmarking/src/BreezeBenchmarks.jl
@@ -33,7 +33,7 @@ if isdefined(CUDA, :CUDACore)
 else
     const CUDACore = CUDA
 end
-
+using AMDGPU: AMDGPU, ROCBackend
 
 # Base functionalities
 include("metadata.jl")

--- a/benchmarking/src/metadata.jl
+++ b/benchmarking/src/metadata.jl
@@ -19,7 +19,7 @@ function BenchmarkMetadata(arch)
     gpu_name = nothing
     cuda_version = nothing
 
-    if arch isa Oceananigans.Architectures.GPU{CUDABackend}
+    if arch isa GPU{CUDABackend}
         try
             gpu_name = CUDA.name(CUDA.device())
             cuda_version = string(CUDA.runtime_version())
@@ -27,6 +27,13 @@ function BenchmarkMetadata(arch)
             gpu_name = "Unknown GPU"
             cuda_version = "Unknown"
         end
+    elseif arch isa GPU{ROCBackend}
+        try
+            gpu_name = unsafe_string(pointer(UInt8.(collect(AMDGPU.HIP.properties(AMDGPU.device()).name))))
+        catch
+            gpu_name = "Unknown GPU"
+        end
+        cuda_version = "unknown"
     end
 
     # Get CPU model

--- a/benchmarking/src/utils.jl
+++ b/benchmarking/src/utils.jl
@@ -3,6 +3,15 @@
 ##### Benchmark utilities
 #####
 
+function memory_reclaim(arch)
+    # Reclaim memory, so that next benchmarks will start from a clean state.
+    if arch isa GPU{CUDABackend}
+        CUDA.reclaim()
+    elseif arch isa GPU{ROCBackend}
+        AMDGPU.reclaim()
+    end
+end
+
 """
     benchmark_time_stepping(model;
                             time_steps = 100,
@@ -72,7 +81,7 @@ function benchmark_time_stepping(model;
     steps_per_second = time_steps / total_time_seconds
     grid_points_per_second = total_points / time_per_step_seconds
 
-    gpu_memory_used = arch isa GPU ? CUDACore.MemoryInfo().pool_used_bytes : 0
+    gpu_memory_used = arch isa GPU{CUDABackend} ? CUDACore.MemoryInfo().pool_used_bytes : 0
     metadata = BenchmarkMetadata(arch)
 
     result = BenchmarkResult(
@@ -98,15 +107,12 @@ function benchmark_time_stepping(model;
         @info "    Total time: $(@sprintf("%.3f", total_time_seconds)) s"
         @info "    Time per step: $(@sprintf("%.6f", time_per_step_seconds)) s"
         @info "    Grid points/s: $(@sprintf("%.2e", grid_points_per_second))"
-        if arch isa GPU
+        if arch isa GPU{CUDABackend}
             @info "    GPU memory usage: $(Base.format_bytes(gpu_memory_used))"
         end
     end
 
-    if arch isa GPU
-        # Reclaim memory, so that next benchmarks will start from a clean state.
-        CUDA.reclaim()
-    end
+    memory_reclaim(arch)
 
     return result
 end
@@ -264,7 +270,7 @@ function run_benchmark_simulation(model;
     steps_per_second = time_steps / wall_time_seconds
     grid_points_per_second = total_points / time_per_step_seconds
 
-    gpu_memory_used = arch isa GPU ? CUDACore.MemoryInfo().pool_used_bytes : 0
+    gpu_memory_used = arch isa GPU{CUDABackend} ? CUDACore.MemoryInfo().pool_used_bytes : 0
     metadata = BenchmarkMetadata(arch)
 
     result = SimulationResult(
@@ -300,10 +306,7 @@ function run_benchmark_simulation(model;
         end
     end
 
-    if arch isa GPU
-        # Reclaim memory, so that next simulations will start from a clean state.
-        CUDA.reclaim()
-    end
+    memory_reclaim(arch)
 
     return result
 end
@@ -314,7 +317,12 @@ end
 
 synchronize_device(::Oceananigans.Architectures.CPU) = nothing
 
-function synchronize_device(::Oceananigans.Architectures.GPU)
+function synchronize_device(::Oceananigans.Architectures.GPU{CUDABackend})
     CUDA.synchronize()
+    return nothing
+end
+
+function synchronize_device(::Oceananigans.Architectures.GPU{ROCBackend})
+    AMDGPU.synchronize()
     return nothing
 end


### PR DESCRIPTION
Simple adaptation to support AMD GPUs when running the benchmarks.  Only downside is that it requires adding the `AMDGPU` package explicitly to the benchmarking environment.