### PR TITLE
Add `eltype` and `architecture` methods for `AtmosphereModel`

### DIFF
--- a/src/AtmosphereModels/atmosphere_model.jl
+++ b/src/AtmosphereModels/atmosphere_model.jl
@@ -4,6 +4,7 @@ using Oceananigans: Oceananigans, AbstractModel, Center, CenterField, Clock, Fie
                     Centered, fields, prognostic_fields
 using Oceananigans.Advection: Advection, adapt_advection_order, cell_advection_timescale, materialize_advection
 using Oceananigans.AbstractOperations: @at
+using Oceananigans.Architectures: Architectures
 using Oceananigans.BoundaryConditions: FieldBoundaryConditions, regularize_field_boundary_conditions
 using Oceananigans.Diagnostics: Diagnostics as OceananigansDiagnostics, NaNChecker
 using Oceananigans.Models: Models, validate_model_halo, validate_tracer_advection
@@ -309,6 +310,10 @@ function atmosphere_model_forcing_summary(model::AtmosphereModel)
     summary_tuple = Tuple(string(name, "=>", nameof(typeof(forcing[name]))) for name in names)
     return join(summary_tuple, ", ")
 end
+
+# AtmosphereModel has a grid, so we can use grid-based implementations
+Base.eltype(model::AtmosphereModel) = eltype(model.grid)
+Architectures.architecture(model::AtmosphereModel) = model.grid.architecture
 
 function Base.show(io::IO, model::AtmosphereModel)
     TS = nameof(typeof(model.timestepper))

--- a/test/atmosphere_model_construction.jl
+++ b/test/atmosphere_model_construction.jl
@@ -2,6 +2,7 @@ using Breeze
 using Breeze.Thermodynamics: TetensFormula
 using GPUArraysCore: @allowscalar
 using Oceananigans
+using Oceananigans.Architectures: architecture
 using Oceananigans.Diagnostics: erroring_NaNChecker!
 using Oceananigans.Operators: ℑzᵃᵃᶠ
 using Test
@@ -28,6 +29,8 @@ end
     Nx = Ny = 3
     grid = RectilinearGrid(default_arch; size=(Nx, Ny, 8), x=(0, 1_000), y=(0, 1_000), z=(0, 1_000))
     model = AtmosphereModel(grid)
+    @test eltype(model) == FT
+    @test architecture(model) == default_arch
     @test model.grid === grid
 
     @testset "show includes forcing and thermodynamic constants" begin

--- a/test/atmosphere_model_construction.jl
+++ b/test/atmosphere_model_construction.jl
@@ -24,7 +24,7 @@ function run_nan_checker_test(arch; erroring)
     return nothing
 end
 
-@testset "AtmosphereModel [$(FT)]" for FT in test_float_types()
+@testset "AtmosphereModel [$(FT)]" for FT in all_float_types()
     Oceananigans.defaults.FloatType = FT
     Nx = Ny = 3
     grid = RectilinearGrid(default_arch; size=(Nx, Ny, 8), x=(0, 1_000), y=(0, 1_000), z=(0, 1_000))


### PR DESCRIPTION
Without these methods, we were hitting very generic fallback methods in Oceananigans which always return `Float64` for the eltype and `nothing` for the architecture.  This was particularly bad on Metal GPUs because the `eltype` of the model was always `Float64` despite the model being `Float32`