### PR TITLE
Microphysics scheduler

### DIFF
--- a/examples/splitting_supercell_scheduled_microphysics.jl
+++ b/examples/splitting_supercell_scheduled_microphysics.jl
@@ -1,0 +1,264 @@
+# # Splitting supercell with scheduled microphysics
+#
+# This example mirrors the [splitting supercell](@ref) case but exercises Breeze's
+# `microphysics_schedule` keyword on [`AtmosphereModel`](@ref). Microphysics fires
+# every 20 simulated seconds (= 5 dycore steps at the fixed ``Δt = 4`` s) rather
+# than every step. The operator-split state update and the cached tendency fields
+# are both gated by the same schedule, which lets the dynamics super-step a
+# potentially expensive microphysics package without breaking thermodynamic
+# consistency.
+#
+# On firing, the schedule passes ``Δt_{\rm eff} = t - t_{\rm last\,fire}`` to
+# [`microphysics_model_update!`](@ref Breeze.AtmosphereModels.microphysics_model_update!),
+# so the operator-split Kessler scheme integrates over the actual elapsed window
+# rather than a single dycore step. In between firings, the dycore tendency kernels
+# read precomputed `CenterField` tendencies that were filled at the last firing.
+#
+# !!! warning
+#     Holding microphysical rates constant across 20 s windows is physically
+#     reasonable only for the slowly-varying part of the scheme. For Kessler-style
+#     sedimentation and rain evaporation in active convection, results may differ
+#     from the every-step reference. Use this example to evaluate the trade-off,
+#     not as a recommended production setting for deep convection.
+#
+# Other than the microphysics schedule, the physical setup, initial conditions,
+# and diagnostics are identical to the unscheduled `splitting_supercell` example.
+
+using Breeze
+using Breeze: DCMIP2016KesslerMicrophysics, TetensFormula
+using Breeze.Thermodynamics: hydrostatic_density, hydrostatic_temperature
+using Oceananigans: Oceananigans
+using Oceananigans.Units
+using Oceananigans.Grids: znodes
+
+using CairoMakie
+using CUDA
+using Printf
+
+# ## Domain and grid
+
+Oceananigans.defaults.FloatType = Float32
+
+Nx, Ny, Nz = 168, 168, 40
+Lx, Ly, Lz = 168kilometers, 168kilometers, 20kilometers
+
+grid = RectilinearGrid(GPU(),
+                       size = (Nx, Ny, Nz),
+                       x = (0, Lx),
+                       y = (0, Ly),
+                       z = (0, Lz),
+                       halo = (5, 5, 5),
+                       topology = (Periodic, Periodic, Bounded))
+
+# ## Reference state and dynamics
+
+constants = ThermodynamicConstants(saturation_vapor_pressure = TetensFormula())
+
+reference_state = ReferenceState(grid, constants,
+                                 surface_pressure = 100000,
+                                 potential_temperature = 300)
+
+dynamics = AnelasticDynamics(reference_state)
+
+# ## Background atmosphere profiles
+#
+# Same Klemp et al. (2015) profile used in the unscheduled example.
+
+θ₀ = 300       # K - surface potential temperature
+θᵖ = 343       # K - tropopause potential temperature
+zᵖ = 12000     # m - tropopause height
+Tᵖ = 213       # K - tropopause temperature
+qᵛ_max = 0.014 # kg/kg - cap on water vapor mixing ratio
+nothing #hide
+
+zˢ = 5kilometers  # m - shear layer height
+uˢ = 30           # m/s - maximum shear wind speed
+uᶜ = 15           # m/s - storm motion (Galilean translation speed)
+nothing #hide
+
+g = constants.gravitational_acceleration
+cᵖᵈ = constants.dry_air.heat_capacity
+nothing #hide
+
+function θ_background(z)
+    θᵗ = θ₀ + (θᵖ - θ₀) * (z / zᵖ)^(5/4)
+    θˢ = θᵖ * exp(g / (cᵖᵈ * Tᵖ) * (z - zᵖ))
+    return (z ≤ zᵖ) * θᵗ + (z > zᵖ) * θˢ
+end
+
+function qᵛ_bg(z)
+    ℋ = (1 - 3/4 * (z / zᵖ)^(5/4)) * (z ≤ zᵖ) + 1/4 * (z > zᵖ)
+    p₀ = reference_state.surface_pressure
+    pˢᵗ = reference_state.standard_pressure
+    T = hydrostatic_temperature(z, p₀, θ_background, pˢᵗ, constants)
+    ρ = hydrostatic_density(z, p₀, θ_background, pˢᵗ, constants)
+    qᵛ⁺ = saturation_specific_humidity(T, ρ, constants, PlanarLiquidSurface())
+    return min(ℋ * qᵛ⁺, qᵛ_max)
+end
+
+qᵛ_column = Field{Nothing, Nothing, Center}(grid)
+set!(qᵛ_column, qᵛ_bg)
+
+function u_background(z)
+    uˡ = uˢ * (z / zˢ) - uᶜ
+    uᵗ = (-4/5 + 3 * (z / zˢ) - 5/4 * (z / zˢ)^2) * uˢ - uᶜ
+    uᵘ = uˢ - uᶜ
+    return (z < (zˢ - 1000)) * uˡ +
+           (abs(z - zˢ) ≤ 1000) * uᵗ +
+           (z > (zˢ + 1000)) * uᵘ
+end
+
+# ## Warm bubble perturbation
+
+Δθ = 3              # K - perturbation amplitude
+rᵇʰ = 10kilometers  # m - bubble horizontal radius
+rᵇᵛ = 1500          # m - bubble vertical radius
+zᵇ = 1500           # m - bubble center height
+xᵇ = Lx / 2         # m - bubble center x-coordinate
+yᵇ = Ly / 2         # m - bubble center y-coordinate
+nothing #hide
+
+function θᵢ(x, y, z)
+    θ̄ = θ_background(z)
+    r = sqrt((x - xᵇ)^2 + (y - yᵇ)^2)
+    R = sqrt((r / rᵇʰ)^2 + ((z - zᵇ) / rᵇᵛ)^2)
+    θ′ = ifelse(R < 1, Δθ * cos(π * R / 2)^2, 0.0)
+    return θ̄ + θ′
+end
+
+uᵢ(x, y, z) = u_background(z)
+
+# ## Model setup with scheduled microphysics
+#
+# We use the DCMIP2016 Kessler microphysics scheme with high-order WENO advection,
+# and a 20-second `TimeInterval` schedule on microphysics.
+
+microphysics = DCMIP2016KesslerMicrophysics()
+advection = WENO(order=9)
+
+# `microphysics_schedule = TimeInterval(20)` makes microphysics fire every 20 simulated
+# seconds. The model allocates cached tendency fields at construction; in between
+# firings, the dycore tendency kernels read those caches via the cache-aware
+# `grid_microphysical_tendency` overload.
+
+microphysics_schedule = TimeInterval(20)
+
+model = AtmosphereModel(grid; dynamics, microphysics, microphysics_schedule, advection,
+                        thermodynamic_constants = constants)
+
+# ## Initialize and run
+
+set!(model, θ=θᵢ, qᵛ=qᵛ_column, u=uᵢ)
+
+## Fixed Δt = 4 s (no adaptive time-stepping wizard) so the schedule fires deterministically
+## every 5 dycore steps.
+simulation = Simulation(model; Δt=4, stop_time=2hours)
+Oceananigans.Diagnostics.erroring_NaNChecker!(simulation)
+
+# ## Diagnostics and progress
+
+θˡⁱ = liquid_ice_potential_temperature(model)
+qᶜˡ = model.microphysical_fields.qᶜˡ
+qʳ = model.microphysical_fields.qʳ
+qᵛ = model.microphysical_fields.qᵛ
+u, v, w = model.velocities
+
+wall_clock = Ref(time_ns())
+
+function progress(sim)
+    elapsed = 1e-9 * (time_ns() - wall_clock[])
+
+    msg = @sprintf("Iter: %d, t: %s, Δt: %s, wall time: %s, max|u|: %.2f m/s, max w: %.2f m/s, min w: %.2f m/s",
+                   iteration(sim), prettytime(sim), prettytime(sim.Δt), prettytime(elapsed),
+                   maximum(abs, u), maximum(w), minimum(w))
+
+    msg *= @sprintf(", max(qᵛ): %.2e, max(qᶜˡ): %.2e, max(qʳ): %.2e, μp last fire: %d",
+                    maximum(qᵛ), maximum(qᶜˡ), maximum(qʳ),
+                    sim.model.microphysics_state.last_fire_iteration)
+    @info msg
+
+    return nothing
+end
+
+add_callback!(simulation, progress, IterationInterval(100))
+
+max_w_ts = []
+max_w_times = []
+
+function collect_max_w(sim)
+    push!(max_w_times, time(sim))
+    push!(max_w_ts, maximum(w))
+    return nothing
+end
+
+add_callback!(simulation, collect_max_w, TimeInterval(1minutes))
+
+z = znodes(grid, Center())
+k_5km = searchsortedfirst(z, 5000)
+@info "Saving xy slices at z = $(z[k_5km]) m (k = $k_5km)"
+
+slice_outputs = (
+    wxy = view(w, :, :, k_5km),
+    qʳxy = view(qʳ, :, :, k_5km),
+    qᶜˡxy = view(qᶜˡ, :, :, k_5km),
+)
+
+slices_filename = "splitting_supercell_scheduled_microphysics_slices.jld2"
+simulation.output_writers[:slices] = JLD2Writer(model, slice_outputs; filename=slices_filename,
+                                                schedule = TimeInterval(2minutes),
+                                                overwrite_existing = true)
+
+run!(simulation)
+
+# ## Animation: horizontal slices at z ≈ 5 km
+
+wxy_ts = FieldTimeSeries(slices_filename, "wxy")
+qʳxy_ts = FieldTimeSeries(slices_filename, "qʳxy")
+qᶜˡxy_ts = FieldTimeSeries(slices_filename, "qᶜˡxy")
+
+times = wxy_ts.times
+Nt = length(times)
+
+wlim = maximum(abs, wxy_ts) / 2
+qʳlim = maximum(qʳxy_ts) / 4
+qᶜˡlim = maximum(qᶜˡxy_ts) / 4
+
+fig = Figure(size=(900, 400), fontsize=12)
+
+axw = Axis(fig[1, 1], aspect=1, xlabel="x (m)", ylabel="y (m)", title="w (m/s)")
+axqᶜˡ = Axis(fig[1, 2], aspect=1, xlabel="x (m)", ylabel="y (m)", title="qᶜˡ (kg/kg)")
+axqʳ = Axis(fig[1, 3], aspect=1, xlabel="x (m)", ylabel="y (m)", title="qʳ (kg/kg)")
+
+n = Observable(1)
+wxy_n = @lift wxy_ts[$n]
+qᶜˡxy_n = @lift qᶜˡxy_ts[$n]
+qʳxy_n = @lift qʳxy_ts[$n]
+title = @lift "Splitting supercell (μp every 20 s) at z ≈ 5 km, t = " * prettytime(times[$n])
+
+hmw = heatmap!(axw, wxy_n, colormap=:balance, colorrange=(-wlim, wlim))
+hmqᶜˡ = heatmap!(axqᶜˡ, qᶜˡxy_n, colormap=:dense, colorrange=(0, qᶜˡlim))
+hmqʳ = heatmap!(axqʳ, qʳxy_n, colormap=:amp, colorrange=(0, qʳlim))
+
+Colorbar(fig[2, 1], hmw, vertical=false)
+Colorbar(fig[2, 2], hmqᶜˡ, vertical=false)
+Colorbar(fig[2, 3], hmqʳ, vertical=false)
+
+fig[0, :] = Label(fig, title, fontsize=14, tellwidth=false)
+
+CairoMakie.record(fig, "splitting_supercell_scheduled_microphysics_slices.mp4", 1:Nt, framerate=10) do nn
+    n[] = nn
+end
+nothing #hide
+
+# ![](splitting_supercell_scheduled_microphysics_slices.mp4)
+
+# ## Maximum vertical velocity time series
+
+fig = Figure(size=(700, 400), fontsize=14)
+ax = Axis(fig[1, 1], xlabel="Time (s)", ylabel="Maximum w (m/s)",
+          title="Maximum Vertical Velocity (microphysics every 20 s)",
+          xticks=0:1800:7200)
+lines!(ax, max_w_times, max_w_ts, linewidth=2)
+
+save("supercell_scheduled_microphysics_max_w.png", fig) #src
+fig

--- a/src/AtmosphereModels/AtmosphereModels.jl
+++ b/src/AtmosphereModels/AtmosphereModels.jl
@@ -49,6 +49,7 @@ export
     specific_prognostic_moisture_from_total,
     update_microphysical_fields!,
     update_microphysical_auxiliaries!,
+    update_microphysics!,
     initial_aerosol_number,
 
     # Interface functions (extended by BoundaryConditions and Forcings)

--- a/src/AtmosphereModels/atmosphere_model.jl
+++ b/src/AtmosphereModels/atmosphere_model.jl
@@ -27,7 +27,8 @@ function validate_tracers(tracers::Tuple)
 end
 
 mutable struct AtmosphereModel{Dyn, Frm, Arc, Tst, Grd, Clk, Thm, Mom, Moi, Buy,
-                               Tmp, Sol, Vel, Trc, Adv, Cor, Frc, Mic, Cnd, Cls, Cfs, Rad} <: AbstractModel{Tst, Arc}
+                               Tmp, Sol, Vel, Trc, Adv, Cor, Frc, Mic, Cnd, Cls, Cfs, Rad,
+                               Msc, Mtd, Mss} <: AbstractModel{Tst, Arc}
     architecture :: Arc
     grid :: Grd
     clock :: Clk
@@ -50,6 +51,9 @@ mutable struct AtmosphereModel{Dyn, Frm, Arc, Tst, Grd, Clk, Thm, Mom, Moi, Buy,
     closure :: Cls
     closure_fields :: Cfs
     radiation :: Rad
+    microphysics_schedule :: Msc
+    microphysics_tendencies :: Mtd
+    microphysics_state :: Mss
 end
 
 """
@@ -121,7 +125,8 @@ function AtmosphereModel(grid;
                          microphysics = nothing,
                          timestepper = nothing,
                          timestepper_kwargs = NamedTuple(),
-                         radiation = nothing)
+                         radiation = nothing,
+                         microphysics_schedule = nothing)
 
     # Use default dynamics if not specified
     isnothing(dynamics) && (dynamics = default_dynamics(grid, thermodynamic_constants))
@@ -253,6 +258,10 @@ function AtmosphereModel(grid;
     advection = merge(momentum_advection_tuple, scalar_advection_tuple)
     materialized_advection = NamedTuple(name => adapt_advection_order(materialize_advection(scheme, grid), grid) for (name, scheme) in pairs(advection))
 
+    FT = eltype(grid)
+    microphysics_tendencies = materialize_microphysics_tendencies(microphysics, formulation, microphysics_schedule, grid)
+    microphysics_state = isnothing(microphysics_schedule) ? nothing : MicrophysicsScheduleState(FT)
+
     model = AtmosphereModel(arch,
                             grid,
                             clock,
@@ -274,7 +283,10 @@ function AtmosphereModel(grid;
                             timestepper,
                             closure,
                             closure_fields,
-                            radiation)
+                            radiation,
+                            microphysics_schedule,
+                            microphysics_tendencies,
+                            microphysics_state)
 
     # Initialize thermodynamics (dynamics-specific)
     initialize_model_thermodynamics!(model)

--- a/src/AtmosphereModels/atmosphere_model.jl
+++ b/src/AtmosphereModels/atmosphere_model.jl
@@ -77,6 +77,13 @@ Arguments
      schemes may be provided. `scalar_advection` may be a `NamedTuple` with
      a different scheme for each respective scalar, identified by name.
 
+   * `microphysics_schedule`: optional schedule controlling how often microphysics
+     fires (e.g. `IterationInterval(N)`, `TimeInterval(Δt)`). Defaults to `nothing`
+     (microphysics fires every step). When set, the model allocates cached
+     tendency fields read by the dycore tendency kernels in between firings;
+     on each firing both the operator-split state update and the cache refill
+     see `Δt_eff = clock.time - last_fire_time`.
+
 Example
 =======
 
@@ -347,8 +354,13 @@ function Base.show(io::IO, model::AtmosphereModel)
 
     print(io, "├── forcing: ", forcing_summary, "\n",
               "├── tracers: ", tracernames, "\n",
-              "├── coriolis: ", summary(model.coriolis), "\n",
-              "└── microphysics: ", Mic)
+              "├── coriolis: ", summary(model.coriolis))
+
+    if !isnothing(model.microphysics_schedule)
+        print(io, "\n├── microphysics_schedule: ", model.microphysics_schedule)
+    end
+
+    print(io, "\n└── microphysics: ", Mic)
 end
 
 Advection.cell_advection_timescale(model::AtmosphereModel) = cell_advection_timescale(model.grid, model.velocities)

--- a/src/AtmosphereModels/dynamics_kernel_functions.jl
+++ b/src/AtmosphereModels/dynamics_kernel_functions.jl
@@ -123,6 +123,7 @@ end
                                  velocities,
                                  microphysics,
                                  microphysical_fields,
+                                 microphysics_tendencies,
                                  closure,
                                  closure_fields,
                                  clock,
@@ -142,6 +143,6 @@ end
     return ( - div_ρUc(i, j, k, grid, advection, ρ_field, Uᵗ, c)
              + c_div_ρU(i, j, k, grid, dynamics, velocities, c) # for PrescribedDynamics
              - ∇_dot_Jᶜ(i, j, k, grid, ρ_field, closure, closure_fields, id, c, clock, model_fields, closure_buoyancy)
-             + grid_microphysical_tendency(i, j, k, grid, microphysics, name, ρ, microphysical_fields, 𝒰, constants, velocities)
+             + grid_microphysical_tendency(i, j, k, grid, microphysics, name, microphysics_tendencies, ρ, microphysical_fields, 𝒰, constants, velocities)
              + c_forcing(i, j, k, grid, clock, model_fields))
 end

--- a/src/AtmosphereModels/microphysics_interface.jl
+++ b/src/AtmosphereModels/microphysics_interface.jl
@@ -255,13 +255,6 @@ end
                                     ρ, μ, 𝒰, constants, velocities) where N =
     haskey(cache, N) ? @inbounds(cache[N][i, j, k]) : zero(eltype(grid))
 
-# Transitional forwarders: callers passing no cache argument route to the no-cache method.
-# (To be removed in Task 6 once all call sites pass an explicit cache argument.)
-@inline grid_microphysical_tendency(i, j, k, grid, microphysics, name, ρ, fields, 𝒰, constants, velocities) =
-    grid_microphysical_tendency(i, j, k, grid, microphysics, name, nothing, ρ, fields, 𝒰, constants, velocities)
-@inline grid_microphysical_tendency(i, j, k, grid, ::Nothing, name, ρ, μ, 𝒰, constants, velocities) =
-    zero(eltype(grid))
-
 #####
 ##### Definition of the microphysics interface, with methods for "Nothing" microphysics
 #####

--- a/src/AtmosphereModels/microphysics_interface.jl
+++ b/src/AtmosphereModels/microphysics_interface.jl
@@ -234,13 +234,33 @@ this method directly without using `microphysical_state`.
 # Arguments
 - `velocities`: NamedTuple of velocity components `(; u, v, w)` [m/s].
 """
-@inline function grid_microphysical_tendency(i, j, k, grid, microphysics, name, ρ, fields, 𝒰, constants, velocities)
+# Default (no cache): build microphysical state and dispatch to microphysical_tendency.
+@inline function grid_microphysical_tendency(i, j, k, grid, microphysics, name, ::Nothing,
+                                             ρ, fields, 𝒰, constants, velocities)
     ℳ = grid_microphysical_state(i, j, k, grid, microphysics, fields, ρ, 𝒰, velocities)
     return microphysical_tendency(microphysics, name, ρ, ℳ, 𝒰, constants)
 end
 
-# Explicit Nothing fallback (for backward compatibility)
-@inline grid_microphysical_tendency(i, j, k, grid, microphysics::Nothing, name, ρ, μ, 𝒰, constants, velocities) = zero(grid)
+# Cache hit: read precomputed tendency. Val{N}+haskey compile-time => cache misses are branch-free zero.
+@inline function grid_microphysical_tendency(i, j, k, grid, microphysics, ::Val{N},
+                                             cache::NamedTuple,
+                                             ρ, fields, 𝒰, constants, velocities) where N
+    return haskey(cache, N) ? @inbounds(cache[N][i, j, k]) : zero(eltype(grid))
+end
+
+# Nothing microphysics — always zero, regardless of cache type.
+@inline grid_microphysical_tendency(i, j, k, grid, ::Nothing, name, ::Nothing,
+                                    ρ, μ, 𝒰, constants, velocities) = zero(eltype(grid))
+@inline grid_microphysical_tendency(i, j, k, grid, ::Nothing, ::Val{N}, cache::NamedTuple,
+                                    ρ, μ, 𝒰, constants, velocities) where N =
+    haskey(cache, N) ? @inbounds(cache[N][i, j, k]) : zero(eltype(grid))
+
+# Transitional forwarders: callers passing no cache argument route to the no-cache method.
+# (To be removed in Task 6 once all call sites pass an explicit cache argument.)
+@inline grid_microphysical_tendency(i, j, k, grid, microphysics, name, ρ, fields, 𝒰, constants, velocities) =
+    grid_microphysical_tendency(i, j, k, grid, microphysics, name, nothing, ρ, fields, 𝒰, constants, velocities)
+@inline grid_microphysical_tendency(i, j, k, grid, ::Nothing, name, ρ, μ, 𝒰, constants, velocities) =
+    zero(eltype(grid))
 
 #####
 ##### Definition of the microphysics interface, with methods for "Nothing" microphysics

--- a/src/AtmosphereModels/microphysics_interface.jl
+++ b/src/AtmosphereModels/microphysics_interface.jl
@@ -671,3 +671,37 @@ based on cloud properties.
 """
 @inline cloud_ice_effective_radius(i, j, k, grid, effective_radius_model::ConstantRadiusParticles, args...) =
     effective_radius_model.radius
+
+"""
+    MicrophysicsScheduleState{FT}
+
+Mutable state held by `AtmosphereModel` when scheduled microphysics is active.
+Tracks the time and iteration of the last microphysics firing so the driver
+can compute `Δt_eff = clock.time - last_fire_time`.
+"""
+mutable struct MicrophysicsScheduleState{FT}
+    last_fire_time      :: FT
+    last_fire_iteration :: Int
+end
+
+MicrophysicsScheduleState(FT::DataType) = MicrophysicsScheduleState{FT}(zero(FT), -1)
+
+"""
+$(TYPEDSIGNATURES)
+
+Allocate the cached microphysics tendency NamedTuple for `microphysics` on `grid`,
+keyed by the prognostic names microphysics contributes to (the thermodynamic
+prognostic name, the moisture prognostic, and `prognostic_field_names(microphysics)`).
+
+Returns `nothing` when `schedule === nothing` (the default — no caching).
+"""
+materialize_microphysics_tendencies(microphysics, formulation, ::Nothing, grid) = nothing
+
+function materialize_microphysics_tendencies(microphysics, formulation, schedule, grid)
+    thermo_name   = thermodynamic_density_name(formulation)
+    moisture_name = moisture_prognostic_name(microphysics)
+    micro_names   = prognostic_field_names(microphysics)
+    names = (thermo_name, moisture_name, micro_names...)
+    fields = NamedTuple{names}(ntuple(_ -> CenterField(grid), length(names)))
+    return fields
+end

--- a/src/AtmosphereModels/microphysics_interface.jl
+++ b/src/AtmosphereModels/microphysics_interface.jl
@@ -554,7 +554,8 @@ For example, the terminal velocity of falling rain.
 # via the generic fallback mechanism which calls the state-based method.
 
 """
-$(TYPEDSIGNATURES)
+    microphysics_model_update!(microphysics, model::AtmosphereModel)
+    microphysics_model_update!(microphysics, model, Δt_eff)
 
 Apply the operator-split microphysics state update for `microphysics` on `model`.
 The `Δt_eff` argument is the effective integration window — for unscheduled
@@ -563,8 +564,14 @@ the wall-clock interval since the last firing.
 
 Specific microphysics schemes extend the 3-argument form. The 2-argument shim
 forwards `model.clock.last_Δt` so existing call sites keep working.
+
+!!! warning
+    Scheme implementations MUST extend the 3-argument form
+    `microphysics_model_update!(microphysics, model, Δt_eff)`.
+    Do NOT add a 2-argument overload — it would shadow this shim and break
+    scheduled-microphysics call sites that pass an explicit `Δt_eff`.
 """
-microphysics_model_update!(microphysics, model) = microphysics_model_update!(microphysics, model, model.clock.last_Δt)
+function microphysics_model_update! end
 
 microphysics_model_update!(::Nothing, model, Δt_eff) = nothing
 

--- a/src/AtmosphereModels/microphysics_interface.jl
+++ b/src/AtmosphereModels/microphysics_interface.jl
@@ -786,3 +786,39 @@ compute_microphysics_tendencies!(::Nothing, microphysics, model, Δt_eff) = noth
         nothing
     end
 end
+
+"""
+$(TYPEDSIGNATURES)
+
+Drive microphysics for one `update_state!` cycle. When `model.microphysics_schedule`
+is `nothing`, falls back to per-step behavior identical to the previous code path.
+
+When a schedule is set, the operator-split state update and the cache refill are
+both gated by `schedule(model)` (with a forced firing on the first iteration).
+On firing, both receive `Δt_eff = clock.time − last_fire_time`.
+"""
+function update_microphysics!(model)
+    return update_microphysics!(model.microphysics, model.microphysics_schedule, model)
+end
+
+# Unscheduled path: behaves as before.
+function update_microphysics!(microphysics, ::Nothing, model)
+    microphysics_model_update!(microphysics, model, model.clock.last_Δt)
+    return nothing
+end
+
+# Scheduled path.
+function update_microphysics!(microphysics, schedule, model)
+    state = model.microphysics_state
+    clock = model.clock
+    first = clock.iteration == 0 && state.last_fire_iteration < 0
+
+    if first || schedule(model)
+        Δt_eff = first ? clock.last_Δt : (clock.time - state.last_fire_time)
+        microphysics_model_update!(microphysics, model, Δt_eff)
+        compute_microphysics_tendencies!(model.microphysics_tendencies, microphysics, model, Δt_eff)
+        state.last_fire_time = clock.time
+        state.last_fire_iteration = clock.iteration
+    end
+    return nothing
+end

--- a/src/AtmosphereModels/microphysics_interface.jl
+++ b/src/AtmosphereModels/microphysics_interface.jl
@@ -736,3 +736,53 @@ function materialize_microphysics_tendencies(microphysics, formulation, schedule
     fields = NamedTuple{names}(ntuple(_ -> CenterField(grid), length(names)))
     return fields
 end
+
+"""
+$(TYPEDSIGNATURES)
+
+Fill the cached microphysics tendency `cache` for `microphysics` on `model`.
+Builds `𝒰` and `ℳ` once per grid point and writes the tendency for every
+prognostic name in `keys(cache)` via static iteration over `Val(name)`.
+
+`Δt_eff` is forwarded for diagnostic / forward-Euler-style schemes that use it;
+the standard inline path ignores it.
+"""
+function compute_microphysics_tendencies!(cache, microphysics, model, Δt_eff)
+    cache === nothing && return nothing
+    grid = model.grid
+    arch = grid.architecture
+    fields = model.microphysical_fields
+    velocities = model.velocities
+    constants = model.thermodynamic_constants
+    formulation = model.formulation
+    dynamics = model.dynamics
+    moisture = specific_prognostic_moisture(model)
+    names = Val(keys(cache))
+
+    launch!(arch, grid, :xyz,
+            _compute_microphysics_tendencies!,
+            cache, names, grid, microphysics, fields, formulation, dynamics, moisture, constants, velocities)
+    return nothing
+end
+
+compute_microphysics_tendencies!(::Nothing, microphysics, model, Δt_eff) = nothing
+
+@kernel function _compute_microphysics_tendencies!(cache, ::Val{names}, grid, microphysics,
+                                                   fields, formulation, dynamics, moisture, constants, velocities) where names
+    i, j, k = @index(Global, NTuple)
+
+    ρ_field = dynamics_density(dynamics)
+    @inbounds ρ = ρ_field[i, j, k]
+    @inbounds qᵛᵉ = moisture[i, j, k]
+
+    q = grid_moisture_fractions(i, j, k, grid, microphysics, ρ, qᵛᵉ, fields)
+    𝒰 = diagnose_thermodynamic_state(i, j, k, grid, formulation, dynamics, q)
+    ℳ = grid_microphysical_state(i, j, k, grid, microphysics, fields, ρ, 𝒰, velocities)
+
+    ntuple(Val(length(names))) do n
+        Base.@_inline_meta
+        name = names[n]
+        @inbounds cache[name][i, j, k] = microphysical_tendency(microphysics, Val(name), ρ, ℳ, 𝒰, constants)
+        nothing
+    end
+end

--- a/src/AtmosphereModels/microphysics_interface.jl
+++ b/src/AtmosphereModels/microphysics_interface.jl
@@ -556,13 +556,17 @@ For example, the terminal velocity of falling rain.
 """
 $(TYPEDSIGNATURES)
 
-Apply microphysics model update for the given `microphysics` scheme.
+Apply the operator-split microphysics state update for `microphysics` on `model`.
+The `Δt_eff` argument is the effective integration window — for unscheduled
+microphysics it equals `model.clock.last_Δt`; for scheduled microphysics it is
+the wall-clock interval since the last firing.
 
-This function is called during `update_state!` to apply microphysics processes
-that operate on the full model state (not the tendency fields).
-Specific microphysics schemes should extend this function.
+Specific microphysics schemes extend the 3-argument form. The 2-argument shim
+forwards `model.clock.last_Δt` so existing call sites keep working.
 """
-microphysics_model_update!(microphysics::Nothing, model) = nothing
+microphysics_model_update!(microphysics, model) = microphysics_model_update!(microphysics, model, model.clock.last_Δt)
+
+microphysics_model_update!(::Nothing, model, Δt_eff) = nothing
 
 """
 $(TYPEDSIGNATURES)

--- a/src/AtmosphereModels/update_atmosphere_model_state.jl
+++ b/src/AtmosphereModels/update_atmosphere_model_state.jl
@@ -9,6 +9,11 @@ using Oceananigans.TurbulenceClosures: compute_closure_fields!
 using Oceananigans.Utils: launch! # , KernelParameters
 using Oceananigans.Operators: ℑxᶠᵃᵃ, ℑyᵃᶠᵃ, ℑzᵃᵃᶠ
 
+# 2-argument shim: forwards model.clock.last_Δt so existing call sites keep working.
+# Defined here (after AtmosphereModel) so the ::AtmosphereModel annotation is in scope.
+microphysics_model_update!(microphysics, model::AtmosphereModel) =
+    microphysics_model_update!(microphysics, model, model.clock.last_Δt)
+
 function TimeSteppers.update_state!(model::AtmosphereModel, callbacks=[]; compute_tendencies=true)
     fix_negative_moisture!(model)  # fix negative moisture from advection
     tracer_density_to_specific!(model) # convert tracer density to specific tracer distribution

--- a/src/AtmosphereModels/update_atmosphere_model_state.jl
+++ b/src/AtmosphereModels/update_atmosphere_model_state.jl
@@ -293,6 +293,7 @@ function compute_tendencies!(model::AtmosphereModel)
         advecting_velocities,
         model.microphysics,
         model.microphysical_fields,
+        model.microphysics_tendencies,
         model.closure,
         model.closure_fields,
         model.clock,

--- a/src/AtmosphereModels/update_atmosphere_model_state.jl
+++ b/src/AtmosphereModels/update_atmosphere_model_state.jl
@@ -23,7 +23,7 @@ function TimeSteppers.update_state!(model::AtmosphereModel, callbacks=[]; comput
     update_boundary_conditions!(prognostic_fields(model), model)
     update_radiation!(model.radiation, model)
     compute_forcings!(model)
-    microphysics_model_update!(model.microphysics, model)
+    update_microphysics!(model)
     compute_tendencies && compute_tendencies!(model)
 
     tracer_specific_to_density!(model) # convert specific tracer distribution to tracer density

--- a/src/Microphysics/bulk_microphysics.jl
+++ b/src/Microphysics/bulk_microphysics.jl
@@ -34,8 +34,8 @@ end
 # use the standard tendency interface, so the model-wide microphysics update is a no-op.
 # We forward to the cloud_formation / saturation-adjustment component to allow specialized
 # cloud formation schemes to hook into the update cycle.
-AtmosphereModels.microphysics_model_update!(bμp::BulkMicrophysics, model) =
-    AtmosphereModels.microphysics_model_update!(bμp.cloud_formation, model)
+AtmosphereModels.microphysics_model_update!(bμp::BulkMicrophysics, model, Δt_eff) =
+    AtmosphereModels.microphysics_model_update!(bμp.cloud_formation, model, Δt_eff)
 
 AtmosphereModels.negative_moisture_correction(bμp::BulkMicrophysics) = bμp.negative_moisture_correction
 
@@ -83,7 +83,7 @@ Base.summary(::NonEquilibriumCloudFormation) = "NonEquilibriumCloudFormation"
 
 # NonEquilibriumCloudFormation uses the standard tendency interface,
 # so the model-wide microphysics update is a no-op.
-AtmosphereModels.microphysics_model_update!(::NonEquilibriumCloudFormation, model) = nothing
+AtmosphereModels.microphysics_model_update!(::NonEquilibriumCloudFormation, model, Δt_eff) = nothing
 #####
 ##### Condensate formation models (for non-equilibrium schemes)
 #####

--- a/src/Microphysics/dcmip2016_kessler.jl
+++ b/src/Microphysics/dcmip2016_kessler.jl
@@ -422,11 +422,11 @@ This function launches a kernel that processes each column independently, with r
 The kernel handles conversion between mass fractions and mixing ratios
 internally for efficiency. Water vapor is diagnosed from ``q^v = q^t - q^{cl} - q^r``.
 """
-function AtmosphereModels.microphysics_model_update!(microphysics::DCMIP2016KM, model)
+function AtmosphereModels.microphysics_model_update!(microphysics::DCMIP2016KM, model, Δt_eff)
     grid = model.grid
     arch = architecture(grid)
     Nz = grid.Nz
-    Δt = model.clock.last_Δt
+    Δt = Δt_eff
 
     # Skip microphysics update if timestep is zero, infinite, or invalid
     # (e.g., during model construction before any time step has been taken)
@@ -857,8 +857,8 @@ For a Lagrangian parcel, the microphysics processes are:
 Note: Rain sedimentation is not applicable to a Lagrangian parcel since
 the parcel is a closed system (rain does not fall out of the parcel).
 """
-function AtmosphereModels.microphysics_model_update!(microphysics::DCMIP2016KM, model::ParcelModel)
-    Δt = model.clock.last_Δt
+function AtmosphereModels.microphysics_model_update!(microphysics::DCMIP2016KM, model::ParcelModel, Δt_eff)
+    Δt = Δt_eff
 
     # Skip microphysics update if timestep is zero, infinite, or invalid
     (isnan(Δt) || isinf(Δt) || Δt ≤ 0) && return nothing

--- a/src/Microphysics/saturation_adjustment.jl
+++ b/src/Microphysics/saturation_adjustment.jl
@@ -56,7 +56,7 @@ end
 
 # SaturationAdjustment operates through the thermodynamic state adjustment pathway,
 # so no explicit model update is needed.
-AtmosphereModels.microphysics_model_update!(::SaturationAdjustment, model) = nothing
+AtmosphereModels.microphysics_model_update!(::SaturationAdjustment, model, Δt_eff) = nothing
 
 #####
 ##### Warm-phase equilibrium moisture fractions

--- a/src/PotentialTemperatureFormulations/potential_temperature_tendency.jl
+++ b/src/PotentialTemperatureFormulations/potential_temperature_tendency.jl
@@ -76,6 +76,7 @@ end
                                                 velocities,
                                                 microphysics,
                                                 microphysical_fields,
+                                                microphysics_tendencies,
                                                 closure,
                                                 closure_fields,
                                                 clock,
@@ -100,7 +101,7 @@ end
     return ( - div_ρUc(i, j, k, grid, advection, ρ_field, velocities, potential_temperature)
              + c_div_ρU(i, j, k, grid, dynamics, velocities, potential_temperature)
              - ∇_dot_Jᶜ(i, j, k, grid, ρ_field, closure, closure_fields, id, potential_temperature, clock, model_fields, closure_buoyancy)
-             + grid_microphysical_tendency(i, j, k, grid, microphysics, Val(:ρθ), ρ, microphysical_fields, 𝒰, constants, velocities)
+             + grid_microphysical_tendency(i, j, k, grid, microphysics, Val(:ρθ), microphysics_tendencies, ρ, microphysical_fields, 𝒰, constants, velocities)
              + ρθ_forcing(i, j, k, grid, clock, model_fields)
              + (Fρe + div_ℐ) / (cᵖᵐ * Π)
     )

--- a/src/StaticEnergyFormulations/static_energy_tendency.jl
+++ b/src/StaticEnergyFormulations/static_energy_tendency.jl
@@ -48,6 +48,7 @@ end
                                         velocities,
                                         microphysics,
                                         microphysical_fields,
+                                        microphysics_tendencies,
                                         closure,
                                         closure_fields,
                                         clock,
@@ -73,7 +74,7 @@ end
              + c_div_ρU(i, j, k, grid, dynamics, velocities, specific_energy)
              - buoyancy_flux
              - ∇_dot_Jᶜ(i, j, k, grid, ρ_field, closure, closure_fields, id, specific_energy, clock, model_fields, closure_buoyancy)
-             + grid_microphysical_tendency(i, j, k, grid, microphysics, Val(:ρe), ρ, microphysical_fields, 𝒰, constants, velocities)
+             + grid_microphysical_tendency(i, j, k, grid, microphysics, Val(:ρe), microphysics_tendencies, ρ, microphysical_fields, 𝒰, constants, velocities)
              + ρe_forcing(i, j, k, grid, clock, model_fields)
              + radiation_flux_divergence(i, j, k, grid, radiation_flux_divergence_field))
 end

--- a/test/scheduled_microphysics.jl
+++ b/test/scheduled_microphysics.jl
@@ -119,11 +119,12 @@ end
     𝒰 = nothing
     velocities = nothing
 
-    val_qcl = Breeze.AtmosphereModels.grid_microphysical_tendency(2, 2, 2, grid, nothing, Val(:ρqᶜˡ), cache, 1.0, fields, 𝒰, constants, velocities)
-    val_qr  = Breeze.AtmosphereModels.grid_microphysical_tendency(2, 2, 2, grid, nothing, Val(:ρqʳ),  cache, 1.0, fields, 𝒰, constants, velocities)
-    val_miss = Breeze.AtmosphereModels.grid_microphysical_tendency(2, 2, 2, grid, nothing, Val(:ρθ), cache, 1.0, fields, 𝒰, constants, velocities)
+    FT = eltype(grid)
+    val_qcl  = @allowscalar Breeze.AtmosphereModels.grid_microphysical_tendency(2, 2, 2, grid, nothing, Val(:ρqᶜˡ), cache, one(FT), fields, 𝒰, constants, velocities)
+    val_qr   = @allowscalar Breeze.AtmosphereModels.grid_microphysical_tendency(2, 2, 2, grid, nothing, Val(:ρqʳ),  cache, one(FT), fields, 𝒰, constants, velocities)
+    val_miss = @allowscalar Breeze.AtmosphereModels.grid_microphysical_tendency(2, 2, 2, grid, nothing, Val(:ρθ),   cache, one(FT), fields, 𝒰, constants, velocities)
 
-    @test @allowscalar(val_qcl) ≈ 0.25
-    @test @allowscalar(val_qr)  ≈ -0.5
-    @test @allowscalar(val_miss) == 0
+    @test val_qcl  ≈ 0.25
+    @test val_qr   ≈ -0.5
+    @test val_miss == 0
 end

--- a/test/scheduled_microphysics.jl
+++ b/test/scheduled_microphysics.jl
@@ -212,3 +212,11 @@ end
     @test inline_G.ρθ  ≈ cached_G.ρθ  atol = 1e-12 rtol = 1e-12
     @test inline_G.ρqᵉ ≈ cached_G.ρqᵉ atol = 1e-12 rtol = 1e-12
 end
+
+@testset "show includes microphysics_schedule" begin
+    grid = RectilinearGrid(default_arch; size=(4, 4, 4), extent=(100, 100, 100))
+    model = AtmosphereModel(grid; microphysics_schedule = IterationInterval(7))
+    s = sprint(show, model)
+    @test occursin("microphysics_schedule", s)
+    @test occursin("IterationInterval", s)
+end

--- a/test/scheduled_microphysics.jl
+++ b/test/scheduled_microphysics.jl
@@ -2,7 +2,7 @@ using Breeze
 using Oceananigans
 using Oceananigans.Utils: IterationInterval
 using Breeze.Microphysics: DCMIP2016KesslerMicrophysics
-using Breeze.Thermodynamics: TetensFormula
+using Breeze.Thermodynamics: TetensFormula, dry_air_gas_constant
 using Test
 
 @testset "Scheduled microphysics: construction [$(FT)]" for FT in test_float_types()
@@ -60,8 +60,8 @@ end
     set!(model.dynamics.reference_state.density, reshape(ρ_prof, 1, 1, Nz))
     set!(model.dynamics.reference_state.pressure, reshape(p_prof, 1, 1, Nz))
 
-    # Supersaturated vapor (ρqᵛ = 0.02 >> saturation ≈ 0.009 at T=288K, p=90kPa),
-    # large cloud water (ρqᶜˡ = 0.01 >> autoconversion threshold 0.001), no rain.
+    # ρqᵛ = 0.02 is initialized well above saturation at the parcel's actual
+    # temperature, and ρqᶜˡ = 0.01 >> autoconversion threshold 0.001, with no rain.
     # In this regime saturation adjustment drives condensation (Δrˢᵃᵗ > 0) so
     # evaporation is suppressed, and the net cloud→rain rate is dominated by
     # autoconversion which is linear in Δt. Rain production therefore scales as 2×
@@ -72,9 +72,13 @@ end
     set!(model.microphysical_fields.ρqʳ,  reshape(zeros(FT, Nz), 1, 1, Nz))
     set!(model.moisture_density, reshape(ρqᵛ_init, 1, 1, Nz))
 
-    # Set θˡⁱ consistent with T ≈ 288 K
+    # Set θˡⁱ consistent with T = 288 K at the reference pressure level.
+    # Π = (p/p₀)^(Rᵈ/cᵖᵈ), θ = T/Π. Use project constants so this tracks
+    # if they change.
     T_init = FT(288)
-    Π = (p_prof[1] / p₀)^(FT(287) / FT(1003))
+    Rᵈ = FT(dry_air_gas_constant(constants))
+    cᵖᵈ = FT(constants.dry_air.heat_capacity)
+    Π = (p_prof[1] / p₀)^(Rᵈ / cᵖᵈ)
     θ_init = T_init / Π
     ρθ_init = fill(FT(1.0) * θ_init, Nz)
     set!(model.formulation.potential_temperature_density, reshape(ρθ_init, 1, 1, Nz))

--- a/test/scheduled_microphysics.jl
+++ b/test/scheduled_microphysics.jl
@@ -1,6 +1,8 @@
 using Breeze
 using Oceananigans
 using Oceananigans.Utils: IterationInterval
+using Breeze.Microphysics: DCMIP2016KesslerMicrophysics
+using Breeze.Thermodynamics: TetensFormula
 using Test
 
 @testset "Scheduled microphysics: construction [$(FT)]" for FT in test_float_types()
@@ -23,4 +25,79 @@ using Test
         @test model.microphysics_state isa Breeze.AtmosphereModels.MicrophysicsScheduleState{FT}
         @test model.microphysics_state.last_fire_iteration == -1
     end
+end
+
+@testset "microphysics_model_update! Δt_eff plumbing" begin
+    grid = RectilinearGrid(default_arch; size=(4, 4, 4), extent=(100, 100, 100))
+    model = AtmosphereModel(grid)  # microphysics = nothing → no-op
+    # 3-arg form must work and be a no-op
+    @test Breeze.AtmosphereModels.microphysics_model_update!(model.microphysics, model, 1.0) === nothing
+    # 2-arg shim must forward to the 3-arg method
+    @test Breeze.AtmosphereModels.microphysics_model_update!(model.microphysics, model) === nothing
+end
+
+@testset "DCMIP2016KM consumes Δt_eff" begin
+    FT = Float64
+    Nz = 8
+
+    # DCMIP2016 Kessler uses TetensFormula with liquid_temperature_offset=36
+    tetens = TetensFormula(liquid_temperature_offset=36)
+    constants = ThermodynamicConstants(FT; saturation_vapor_pressure=tetens)
+
+    grid = RectilinearGrid(CPU(); size=(1, 1, Nz), x=(0, 100), y=(0, 100),
+                           z=(0, 4000), topology=(Periodic, Periodic, Bounded))
+
+    microphysics = DCMIP2016KesslerMicrophysics(FT)
+
+    p₀ = FT(100000)
+    ref_state = ReferenceState(grid, constants; surface_pressure=p₀)
+    dynamics = AnelasticDynamics(ref_state)
+    model = AtmosphereModel(grid; dynamics, microphysics, thermodynamic_constants=constants)
+
+    # Constant reference profile
+    ρ_prof = fill(FT(1.0), Nz)
+    p_prof = fill(FT(90000), Nz)
+    set!(model.dynamics.reference_state.density, reshape(ρ_prof, 1, 1, Nz))
+    set!(model.dynamics.reference_state.pressure, reshape(p_prof, 1, 1, Nz))
+
+    # Supersaturated vapor (ρqᵛ = 0.02 >> saturation ≈ 0.009 at T=288K, p=90kPa),
+    # large cloud water (ρqᶜˡ = 0.01 >> autoconversion threshold 0.001), no rain.
+    # In this regime saturation adjustment drives condensation (Δrˢᵃᵗ > 0) so
+    # evaporation is suppressed, and the net cloud→rain rate is dominated by
+    # autoconversion which is linear in Δt. Rain production therefore scales as 2×
+    # when Δt doubles.
+    ρqᶜˡ_init = fill(FT(0.01), Nz)
+    ρqᵛ_init  = fill(FT(0.02), Nz)
+    set!(model.microphysical_fields.ρqᶜˡ, reshape(ρqᶜˡ_init, 1, 1, Nz))
+    set!(model.microphysical_fields.ρqʳ,  reshape(zeros(FT, Nz), 1, 1, Nz))
+    set!(model.moisture_density, reshape(ρqᵛ_init, 1, 1, Nz))
+
+    # Set θˡⁱ consistent with T ≈ 288 K
+    T_init = FT(288)
+    Π = (p_prof[1] / p₀)^(FT(287) / FT(1003))
+    θ_init = T_init / Π
+    ρθ_init = fill(FT(1.0) * θ_init, Nz)
+    set!(model.formulation.potential_temperature_density, reshape(ρθ_init, 1, 1, Nz))
+    model.clock.last_Δt = FT(1.0)
+
+    snapshot(field) = copy(Array(interior(field, 1, 1, :)))
+    saved_ρqᶜˡ = snapshot(model.microphysical_fields.ρqᶜˡ)
+    saved_ρqʳ  = snapshot(model.microphysical_fields.ρqʳ)
+
+    # Integrate for Δt_eff = 1 s
+    Breeze.AtmosphereModels.microphysics_model_update!(model.microphysics, model, FT(1.0))
+    state_a_ρqʳ = snapshot(model.microphysical_fields.ρqʳ)
+
+    # Restore and integrate for Δt_eff = 2 s
+    set!(model.microphysical_fields.ρqᶜˡ, reshape(saved_ρqᶜˡ, 1, 1, Nz))
+    set!(model.microphysical_fields.ρqʳ,  reshape(saved_ρqʳ, 1, 1, Nz))
+    Breeze.AtmosphereModels.microphysics_model_update!(model.microphysics, model, FT(2.0))
+    state_b_ρqʳ = snapshot(model.microphysical_fields.ρqʳ)
+
+    # Rain produced over Δt=1 and Δt=2 — expect 2× scaling to first order
+    Δa = state_a_ρqʳ .- saved_ρqʳ      # rain produced in Δt=1 s
+    Δb = state_b_ρqʳ .- saved_ρqʳ      # rain produced in Δt=2 s
+    nonzero = findall(>(1e-9), abs.(Δa))
+    @test !isempty(nonzero)
+    @test all(@. abs(Δb[nonzero] / Δa[nonzero] - 2) < 0.5)
 end

--- a/test/scheduled_microphysics.jl
+++ b/test/scheduled_microphysics.jl
@@ -188,3 +188,27 @@ end
     Breeze.AtmosphereModels.update_microphysics!(model)
     @test model.microphysics_state.last_fire_iteration == 3
 end
+
+@testset "Cache path matches inline path at IterationInterval(1)" begin
+    using Breeze.Microphysics: SaturationAdjustment
+    using Breeze.AtmosphereModels: moisture_prognostic_name
+
+    grid = RectilinearGrid(default_arch; size=(4, 4, 8), extent=(1000, 1000, 1000))
+    μ = SaturationAdjustment()
+
+    function build_and_step(; schedule)
+        model = AtmosphereModel(grid; microphysics = μ, microphysics_schedule = schedule)
+        set!(model, ρθ = 300, ρqᵉ = 1e-3)
+        sim = Simulation(model, Δt = 1.0, stop_iteration = 1, verbose = false)
+        run!(sim)
+        moist_name = moisture_prognostic_name(model.microphysics)
+        return (ρθ   = copy(parent(model.timestepper.Gⁿ.ρθ)),
+                ρqᵉ  = copy(parent(model.timestepper.Gⁿ[moist_name])))
+    end
+
+    inline_G = build_and_step(schedule = nothing)
+    cached_G = build_and_step(schedule = IterationInterval(1))
+
+    @test inline_G.ρθ  ≈ cached_G.ρθ  atol = 1e-12 rtol = 1e-12
+    @test inline_G.ρqᵉ ≈ cached_G.ρqᵉ atol = 1e-12 rtol = 1e-12
+end

--- a/test/scheduled_microphysics.jl
+++ b/test/scheduled_microphysics.jl
@@ -24,7 +24,10 @@ using Test
         @test :ρθ in keys(model.microphysics_tendencies)
         @test :ρqᵛ in keys(model.microphysics_tendencies)
         @test model.microphysics_state isa Breeze.AtmosphereModels.MicrophysicsScheduleState{FT}
-        @test model.microphysics_state.last_fire_iteration == -1
+        # Construction calls set!(model, θ=θ₀) → update_state! → update_microphysics!, which
+        # fires at iteration 0 (IterationInterval(5) returns true at 0). So last_fire_iteration
+        # is 0 after construction, not -1.
+        @test model.microphysics_state.last_fire_iteration == 0
     end
 end
 
@@ -151,4 +154,37 @@ end
     for (_, f) in pairs(model.microphysics_tendencies)
         @test all(isfinite, parent(f))
     end
+end
+
+@testset "update_microphysics! honors the schedule" begin
+    using Breeze.Microphysics: SaturationAdjustment
+
+    grid = RectilinearGrid(default_arch; size=(4, 4, 4), extent=(100, 100, 100))
+    μ = SaturationAdjustment()
+    model = AtmosphereModel(grid; microphysics = μ, microphysics_schedule = IterationInterval(3))
+    set!(model, ρθ = 300, ρqᵛ = 1e-3)
+
+    # First iteration always fires
+    @allowscalar model.clock.iteration = 0
+    @allowscalar model.clock.time = 0
+    @allowscalar model.clock.last_Δt = 1.0
+    Breeze.AtmosphereModels.update_microphysics!(model)
+    @test model.microphysics_state.last_fire_iteration == 0
+
+    # Iterations 1, 2 should NOT fire
+    @allowscalar model.clock.iteration = 1
+    @allowscalar model.clock.time = 1
+    Breeze.AtmosphereModels.update_microphysics!(model)
+    @test model.microphysics_state.last_fire_iteration == 0
+
+    @allowscalar model.clock.iteration = 2
+    @allowscalar model.clock.time = 2
+    Breeze.AtmosphereModels.update_microphysics!(model)
+    @test model.microphysics_state.last_fire_iteration == 0
+
+    # Iteration 3 should fire (IterationInterval(3))
+    @allowscalar model.clock.iteration = 3
+    @allowscalar model.clock.time = 3
+    Breeze.AtmosphereModels.update_microphysics!(model)
+    @test model.microphysics_state.last_fire_iteration == 3
 end

--- a/test/scheduled_microphysics.jl
+++ b/test/scheduled_microphysics.jl
@@ -3,6 +3,7 @@ using Oceananigans
 using Oceananigans.Utils: IterationInterval
 using Breeze.Microphysics: DCMIP2016KesslerMicrophysics
 using Breeze.Thermodynamics: TetensFormula, dry_air_gas_constant
+using GPUArraysCore: @allowscalar
 using Test
 
 @testset "Scheduled microphysics: construction [$(FT)]" for FT in test_float_types()
@@ -104,4 +105,25 @@ end
     nonzero = findall(>(1e-9), abs.(Δa))
     @test !isempty(nonzero)
     @test all(@. abs(Δb[nonzero] / Δa[nonzero] - 2) < 0.5)
+end
+
+@testset "grid_microphysical_tendency cache overload" begin
+    grid = RectilinearGrid(default_arch; size=(4, 4, 4), extent=(100, 100, 100))
+    cache = (ρqᶜˡ = CenterField(grid), ρqʳ = CenterField(grid))
+    @allowscalar fill!(parent(cache.ρqᶜˡ), 0.25)
+    @allowscalar fill!(parent(cache.ρqʳ), -0.5)
+
+    # Stand-in args (microphysics = nothing, ρ = 1, fields, 𝒰, constants, velocities)
+    constants = ThermodynamicConstants()
+    fields = (;)
+    𝒰 = nothing
+    velocities = nothing
+
+    val_qcl = Breeze.AtmosphereModels.grid_microphysical_tendency(2, 2, 2, grid, nothing, Val(:ρqᶜˡ), cache, 1.0, fields, 𝒰, constants, velocities)
+    val_qr  = Breeze.AtmosphereModels.grid_microphysical_tendency(2, 2, 2, grid, nothing, Val(:ρqʳ),  cache, 1.0, fields, 𝒰, constants, velocities)
+    val_miss = Breeze.AtmosphereModels.grid_microphysical_tendency(2, 2, 2, grid, nothing, Val(:ρθ), cache, 1.0, fields, 𝒰, constants, velocities)
+
+    @test @allowscalar(val_qcl) ≈ 0.25
+    @test @allowscalar(val_qr)  ≈ -0.5
+    @test @allowscalar(val_miss) == 0
 end

--- a/test/scheduled_microphysics.jl
+++ b/test/scheduled_microphysics.jl
@@ -1,0 +1,26 @@
+using Breeze
+using Oceananigans
+using Oceananigans.Utils: IterationInterval
+using Test
+
+@testset "Scheduled microphysics: construction [$(FT)]" for FT in test_float_types()
+    Oceananigans.defaults.FloatType = FT
+    grid = RectilinearGrid(default_arch; size=(4, 4, 8), extent=(1000, 1000, 1000))
+
+    @testset "default (no schedule)" begin
+        model = AtmosphereModel(grid)
+        @test model.microphysics_schedule === nothing
+        @test model.microphysics_tendencies === nothing
+        @test model.microphysics_state === nothing
+    end
+
+    @testset "with IterationInterval(5)" begin
+        model = AtmosphereModel(grid; microphysics_schedule = IterationInterval(5))
+        @test model.microphysics_schedule isa IterationInterval
+        @test model.microphysics_tendencies isa NamedTuple
+        @test :ρθ in keys(model.microphysics_tendencies)
+        @test :ρqᵛ in keys(model.microphysics_tendencies)
+        @test model.microphysics_state isa Breeze.AtmosphereModels.MicrophysicsScheduleState{FT}
+        @test model.microphysics_state.last_fire_iteration == -1
+    end
+end

--- a/test/scheduled_microphysics.jl
+++ b/test/scheduled_microphysics.jl
@@ -128,3 +128,27 @@ end
     @test val_qr   ≈ -0.5
     @test val_miss == 0
 end
+
+@testset "compute_microphysics_tendencies! fills the cache" begin
+    using Breeze.Microphysics: SaturationAdjustment
+
+    grid = RectilinearGrid(default_arch; size=(4, 4, 8), extent=(100, 100, 1000))
+    μ = SaturationAdjustment()
+    model = AtmosphereModel(grid; microphysics = μ, microphysics_schedule = IterationInterval(1))
+
+    # Initialize state so 𝒰 / ℳ build cleanly
+    set!(model, ρθ = 300, ρqᵛ = 1e-3)
+    Breeze.AtmosphereModels.update_state!(model; compute_tendencies = false)
+
+    # Sanity: cache exists and has the expected names
+    @test model.microphysics_tendencies isa NamedTuple
+    @test :ρθ in keys(model.microphysics_tendencies) || :ρe in keys(model.microphysics_tendencies)
+
+    # Manually invoke the cache-filling kernel and ensure no errors
+    Breeze.AtmosphereModels.compute_microphysics_tendencies!(model.microphysics_tendencies, model.microphysics, model, 1.0)
+
+    # Cache fields should be finite
+    for (_, f) in pairs(model.microphysics_tendencies)
+        @test all(isfinite, parent(f))
+    end
+end

--- a/test/scheduled_microphysics.jl
+++ b/test/scheduled_microphysics.jl
@@ -220,3 +220,52 @@ end
     @test occursin("microphysics_schedule", s)
     @test occursin("IterationInterval", s)
 end
+
+# SaturationAdjustment always produces zero tendencies (microphysical_tendency returns
+# zero(ρ) for all names), so checking cache content across non-firing iterations is
+# trivially true — both snapshots are zero. Instead we test last_fire_iteration, which
+# is the authoritative record of whether the schedule fired.
+@testset "Cache held constant between firings" begin
+    using Breeze.Microphysics: SaturationAdjustment
+
+    grid = RectilinearGrid(default_arch; size=(4, 4, 8), extent=(1000, 1000, 1000))
+    μ = SaturationAdjustment()
+    model = AtmosphereModel(grid; microphysics = μ, microphysics_schedule = IterationInterval(5))
+    set!(model, ρθ = 300, ρqᵉ = 1e-3)
+
+    sim = Simulation(model, Δt = 1.0, stop_iteration = 1, verbose = false)
+    run!(sim)
+    # iter 0 fires on warmup; iter 1 does not (IterationInterval(5) fires at 0, 5, 10, ...)
+    @test model.microphysics_state.last_fire_iteration == 0
+
+    sim.stop_iteration = 4
+    run!(sim)
+    # iter 2, 3, 4 do not fire
+    @test model.microphysics_state.last_fire_iteration == 0
+
+    sim.stop_iteration = 5
+    run!(sim)
+    # iter 5 fires
+    @test model.microphysics_state.last_fire_iteration == 5
+end
+
+@testset "Mass conservation under super-stepping" begin
+    using Breeze.Microphysics: SaturationAdjustment
+
+    grid = RectilinearGrid(default_arch; size=(4, 4, 8), x=(0, 1000), y=(0, 1000), z=(0, 1000),
+                           topology=(Periodic, Periodic, Bounded))
+    μ = SaturationAdjustment()
+    model = AtmosphereModel(grid; microphysics = μ, microphysics_schedule = IterationInterval(5))
+    set!(model, ρθ = 300, ρqᵉ = 1e-3)
+
+    total_qt(m) = @allowscalar sum(parent(m.moisture_density))
+
+    initial = total_qt(model)
+    sim = Simulation(model, Δt = 0.5, stop_iteration = 25, verbose = false)
+    run!(sim)
+    final = total_qt(model)
+
+    rel_err = abs(final - initial) / abs(initial)
+    # SatAdj has no precipitation flux, so moisture mass is conserved up to roundoff
+    @test rel_err < 1e-6
+end


### PR DESCRIPTION
## Motivation

  Microphysics can be expensive, yet the right *coupling frequency* with the dynamics is still an open question (substep vs. superstep, and at what cadence). This PR exposes that knob via a `microphysics_schedule` keyword. The default (`nothing`) is a
  no-op, byte-identical to before; setting a schedule lets you super-step microphysics and study the trade-off without touching the dycore call site.

## Summary

  Adds opt-in scheduled microphysics to `AtmosphereModel` via a new `microphysics_schedule` keyword (e.g., `IterationInterval(N)`, `TimeInterval(Δt)`).

  When set, microphysics tendencies are cached to per-prognostic `CenterField`s and refilled only when the schedule fires. In between firings, the dycore reads the held cache, allowing the dynamics to super-step microphysics. The operator-split entry point `microphysics_model_update!` is plumbed with an explicit `Δt_eff = clock.time - last_fire_time`, so schemes (e.g. `DCMIP2016KesslerMicrophysics`) integrate over the actual elapsed window rather than a single dycore step.

  With `microphysics_schedule = nothing` (the default), the path is bit-identical to the previous code: cache fields are `nothing`, dispatch resolves to the existing inline `grid_microphysical_tendency`, and the operator-split call reduces to `microphysics_model_update!(μ, model, clock.last_Δt)`.

  ## Changes

  - New `microphysics_schedule` keyword on `AtmosphereModel` + cached tendency fields + `MicrophysicsScheduleState`
  - `microphysics_model_update!` refactored to a 3-arg form `(microphysics, model, Δt_eff)` with a backward-compatible 2-arg shim; `DCMIP2016KM` (grid + parcel) now reads `Δt_eff` instead of the clock
  - Cache-aware `grid_microphysical_tendency` overload (compile-time `haskey` via `Val{N}` dispatch)
  - New `compute_microphysics_tendencies!` kernel that builds `𝒰` and `ℳ` once per grid point and writes the tendency for every cached name via static `Val` iteration
  - New `update_microphysics!(model)` driver replaces the bare `microphysics_model_update!` call in `update_state!`
  - Three dycore tendency kernels (`scalar_tendency`, `static_energy_tendency`, `potential_temperature_tendency`) thread the cache through `common_args`
  - `Base.show(io, ::AtmosphereModel)` displays the schedule when set; constructor docstring updated
  - New example `examples/splitting_supercell_scheduled_microphysics.jl` (DCMIP2016 Kessler + `TimeInterval(20)` at fixed `Δt = 4` s → fires every 5 dycore steps)
                                              