### PR TITLE
Pin CUDA.jl to v6.0 in tests

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -26,7 +26,7 @@ Breeze = {path = ".."}
 [compat]
 Adapt = "4.3.0"
 Aqua = "0.8"
-CUDA = "5, 6.0"
+CUDA = "5, ~6.0"
 ClimaComms = "0.6"
 CloudMicrophysics = "0.31.4, 0.32, 0.33, 0.34, 0.35"
 Dates = "<0.0.1, 1"


### PR DESCRIPTION
CUDA.jl v6.1.0 broke compatibility with Reactant.jl by [using a CUDA-specific intrinsic](https://github.com/JuliaGPU/CUDA.jl/pull/3077) which then Reactant.jl tries to use everywhere. For the time being we stick to CUDA.jl v6.0