### PR TITLE
Allow passing the float type as argument to `SplitExplicitTimeDiscretization`

### DIFF
--- a/benchmarking/run_benchmarks.jl
+++ b/benchmarking/run_benchmarks.jl
@@ -205,13 +205,13 @@ end
 make_closure(name, FT) = name == "nothing" ? nothing : (@eval $(Symbol(name)))(FT)
 
 # Dynamics: "anelastic", "compressible_explicit", "compressible_splitexplicit"
-function make_dynamics(name)
+function make_dynamics(name::AbstractString, FT::Type)
     if name == "anelastic"
         return nothing  # sentinel; convective_boundary_layer handles anelastic by default
     elseif name == "compressible_explicit"
         return CompressibleDynamics(ExplicitTimeStepping())
     elseif name == "compressible_splitexplicit"
-        return CompressibleDynamics(SplitExplicitTimeDiscretization(substeps=12))
+        return CompressibleDynamics(SplitExplicitTimeDiscretization(FT; substeps=12))
     else
         error("Unknown dynamics: $name. Use anelastic, compressible_explicit, or compressible_splitexplicit.")
     end
@@ -318,7 +318,7 @@ function run_benchmarks(args)
         println("-" ^ 70)
 
         # Create schemes
-        dynamics = make_dynamics(dyn_name)
+        dynamics = make_dynamics(dyn_name, FT)
         advection = make_advection(adv_name, FT)
         closure = make_closure(cls_name, FT)
         microphysics = make_microphysics(micro_name, FT)

--- a/src/CompressibleEquations/time_discretizations.jl
+++ b/src/CompressibleEquations/time_discretizations.jl
@@ -50,10 +50,12 @@ function SplitExplicitTimeDiscretization(FT=Float64;
                                          forward_weight=FT(0.6),
                                          divergence_damping_coefficient=FT(0.10),
                                          acoustic_damping_coefficient=FT(0.0))
-    return SplitExplicitTimeDiscretization(substeps,
-                                           forward_weight,
-                                           divergence_damping_coefficient,
-                                           acoustic_damping_coefficient)
+    return SplitExplicitTimeDiscretization(
+        substeps,
+        FT(forward_weight),
+        FT(divergence_damping_coefficient),
+        FT(acoustic_damping_coefficient),
+    )
 end
 
 """

--- a/src/CompressibleEquations/time_discretizations.jl
+++ b/src/CompressibleEquations/time_discretizations.jl
@@ -45,10 +45,11 @@ struct SplitExplicitTimeDiscretization{N, FT}
     acoustic_damping_coefficient :: FT
 end
 
-function SplitExplicitTimeDiscretization(; substeps=nothing,
-                                           forward_weight=0.6,
-                                           divergence_damping_coefficient=0.10,
-                                           acoustic_damping_coefficient=0.0)
+function SplitExplicitTimeDiscretization(FT=Float64;
+                                         substeps=nothing,
+                                         forward_weight=FT(0.6),
+                                         divergence_damping_coefficient=FT(0.10),
+                                         acoustic_damping_coefficient=FT(0.0))
     return SplitExplicitTimeDiscretization(substeps,
                                            forward_weight,
                                            divergence_damping_coefficient,


### PR DESCRIPTION
This makes it easier to construct the object with a different float type.