### PR TITLE
[CI] Remove redundant `env` block

### DIFF
--- a/.github/workflows/Validation.yml
+++ b/.github/workflows/Validation.yml
@@ -43,11 +43,14 @@ jobs:
         os:
           - ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2.7.0
+      - name: "Check out repository"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: "Install Julia"
+        uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2.7.0
         with:
           version: ${{ matrix.version }}
-      - uses: julia-actions/cache@9a93c5fb3e9c1c20b60fc80a478cae53e38618a4 # v3.0.2
+      - name: "Cache Julia depot"
+        uses: julia-actions/cache@9a93c5fb3e9c1c20b60fc80a478cae53e38618a4 # v3.0.2
       - name: Instantiate examples environment
         shell: julia --color=yes --project=examples {0}
         run: |

--- a/.github/workflows/Validation.yml
+++ b/.github/workflows/Validation.yml
@@ -22,9 +22,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  JULIA_PKG_SERVER_REGISTRY_PREFERENCE: 'eager'
-
 # needed to allow julia-actions/cache to delete old caches that it has created
 permissions:
   actions: write


### PR DESCRIPTION
It was already defined below.  Ref: https://github.com/NumericalEarth/Breeze.jl/pull/565#discussion_r3237957773