### PR TITLE
Add `vapor_gas_constant` to Breeze.jl exports

### DIFF
--- a/src/Breeze.jl
+++ b/src/Breeze.jl
@@ -84,6 +84,7 @@ export
     saturation_specific_humidity,
     adiabatic_hydrostatic_density,
     dry_air_gas_constant,
+    vapor_gas_constant,
     PlanarLiquidSurface,
     PlanarIceSurface,
 


### PR DESCRIPTION
For example, when computing virtual (potential) temperature we use the ratio εᵈᵛ ≡ Rᵈ / Rᵛ:
```julia
εᵈᵛ = dry_air_gas_constant(constants) / vapor_gas_constant(constants)
```