### PR TITLE
[CI] Give names to steps in benchmarks job

### DIFF
--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -81,7 +81,7 @@ jobs:
             advection: 'WENO5'
             backend: 'reactant'
             topology: 'PBB'
-            extra_flags: '--ad --simplified --float_type=Float64 --warmup_steps 1'
+            extra_flags: '--ad --simplified --float_type=Float64 --warmup_steps 1 --time_steps 1'
     defaults:
       run:
         shell: bash

--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -91,7 +91,8 @@ jobs:
       options: --gpus=all
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: "Check out repository"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Instantiate benchmarking environment
         shell: julia --color=yes --project {0}
         run: |
@@ -102,7 +103,8 @@ jobs:
         run: |
           earlyoom -m 3 -s 100 -r 300 --prefer 'julia' &
           julia --color=yes --project run_benchmarks.jl --device GPU --dynamics "${{ matrix.dynamics }}" --microphysics "${{ matrix.microphysics }}" --advection "${{ matrix.advection }}" --size "${{ matrix.grid }}" --backend "${{ matrix.backend }}" --topology "${{ matrix.topology }}" --warmup_steps 8 --time_steps 80 ${{ matrix.extra_flags }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      - name: "Upload benchmark results as artifacts"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: 'benchmarks-dynamics_${{ matrix.dynamics }}-microphysics_${{ matrix.microphysics }}-grid_${{ matrix.grid }}-advection_${{ matrix.advection }}-backend_${{ matrix.backend }}-topology_${{ matrix.topology }}'
           path: benchmarking/benchmark_results.*
@@ -124,7 +126,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: "Download benchmark results"
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: benchmarks-*
       - name: Merge results and create JSON for github-action-benchmark
@@ -221,7 +224,8 @@ jobs:
 
           with open('github-action-benchmark.json', 'w') as f:
               json.dump(data, f)
-      - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+      - name: "Generate token"
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         if: ${{ ! github.event.pull_request.head.repo.fork }}
         id: generate_token
         with:
@@ -247,7 +251,8 @@ jobs:
           git add .
           git commit -m'Save benchmark results for commit ${{ github.sha }}'
           git push -u origin main
-      - uses: benchmark-action/github-action-benchmark@a60cea5bc7b49e15c1f58f411161f99e0df48372 # v1.22.0
+      - name: "Publish benchmark results"
+        uses: benchmark-action/github-action-benchmark@a60cea5bc7b49e15c1f58f411161f99e0df48372 # v1.22.0
         with:
           name: Breeze.jl Benchmarks
           tool: "customBiggerIsBetter"

--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -81,7 +81,7 @@ jobs:
             advection: 'WENO5'
             backend: 'reactant'
             topology: 'PBB'
-            extra_flags: '--ad --simplified --float_type=Float64 --warmup_steps 1 --time_steps 1'
+            extra_flags: '--ad --simplified --float_type=Float64 --warmup_steps 1'
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
~After compilation, the run is actually fast (0.05 s), so we can run it for all 80 timesteps as is the default.  CC @dkytezab~ ***Edit***: PR repurposed to only give names to the steps, which is something I've been meaning to do for a while