### PR TITLE
Accept specific-quantity keys in AtmosphereModel forcings

### DIFF
--- a/benchmarking/src/convective_boundary_layer.jl
+++ b/benchmarking/src/convective_boundary_layer.jl
@@ -154,7 +154,7 @@ function convective_boundary_layer(arch = CPU();
         ρu_bcs = FieldBoundaryConditions(bottom = ρu_drag_bc)
         ρv_bcs = FieldBoundaryConditions(bottom = ρv_drag_bc)
 
-        forcing = (; ρu = geostrophic.ρu, ρv = geostrophic.ρv)
+        forcing = (; u = geostrophic.u, v = geostrophic.v)
 
         model = AtmosphereModel(grid;
             dynamics,

--- a/examples/bomex.jl
+++ b/examples/bomex.jl
@@ -148,55 +148,55 @@ geostrophic = geostrophic_forcings(z -> uᵍ(z), z -> vᵍ(z))
 #
 # A prescribed large-scale drying tendency removes moisture above the cloud layer
 # ([Siebesma2003](@citet); Appendix B, Eq. B4). This represents the effects of
-# advection by the large-scale circulation.
+# advection by the large-scale circulation. We supply this tendency in specific form
+# (per unit mass); Breeze multiplies by ``ρ`` automatically at kernel time when the
+# forcing is keyed under the specific variable name `qᵉ`.
 
-ρᵣ = reference_state.density
 drying = Field{Nothing, Nothing, Center}(grid)
 dqdt_profile = AtmosphericProfilesLibrary.Bomex_dqtdt(FT)
 set!(drying, z -> dqdt_profile(z))
-set!(drying, ρᵣ * drying)
-ρqᵉ_drying_forcing = Forcing(drying)
+qᵉ_drying_forcing = Forcing(drying)
 
 # ## Radiative cooling
 #
 # A prescribed radiative cooling profile is applied to the thermodynamic equation
 # ([Siebesma2003](@citet); Appendix B, Eq. B3). Below the inversion, radiative cooling
-# of about 2 K/day counteracts the surface heating. We use an energy forcing for radiation
-# to ensure that it is applied to the potential temperature conservation equation
-# consistently (see below for some elaboration about that).
+# of about 2 K/day counteracts the surface heating. We supply the cooling as a specific
+# energy tendency `e` (J/kg/s) so it is consistently applied to the potential temperature
+# equation (see below).
 
-Fρe_field = Field{Nothing, Nothing, Center}(grid)
+radiative_cooling = Field{Nothing, Nothing, Center}(grid)
 cᵖᵈ = constants.dry_air.heat_capacity
 dTdt_bomex = AtmosphericProfilesLibrary.Bomex_dTdt(FT)
-set!(Fρe_field, z -> dTdt_bomex(1, z))
-set!(Fρe_field, ρᵣ * cᵖᵈ * Fρe_field)
-ρe_radiation_forcing = Forcing(Fρe_field)
+set!(radiative_cooling, z -> cᵖᵈ * dTdt_bomex(1, z))
+e_radiation_forcing = Forcing(radiative_cooling)
 
 # ## Assembling all the forcings
 #
-# We build tuples of forcings for all the variables. Note that forcing functions
-# are provided for both `ρθ` and `ρe`, which both contribute to the tendency of `ρθ`
-# in different ways. In particular, the tendency for `ρθ` is written
+# Forcings on the same prognostic field can be supplied either under the
+# density-weighted key (e.g. `ρθ`) or under the specific key (e.g. `θ`); Breeze
+# applies the ``ρ`` factor automatically in the latter case. When both keys are
+# present for the same field, Breeze sums the contributions. Here we keep
+# `subsidence` and `geostrophic` under density-weighted keys because they
+# already produce ``F_{ρϕ}`` internally, and supply the prescribed drying and
+# radiative-cooling tendencies under their specific keys.
+#
+# Forcings on `ρe` and `ρθ` both contribute to the tendency of `ρθ` in different
+# ways. The tendency for `ρθ` is written
 #
 # ```math
 # ∂_t (ρ θ) = - \boldsymbol{\nabla \cdot} \, ( ρ \boldsymbol{u} θ ) + F_{ρθ} + \frac{1}{cᵖᵐ Π} F_{ρ e} + \cdots
 # ```
 #
-# where ``F_{ρ e}`` denotes the forcing function provided for `ρe` (e.g. for "energy density"),
-# ``F_{ρθ}`` denotes the forcing function provided for `ρθ`, and the ``\cdots`` denote
-# additional terms.
-#
-# The geostrophic forcing provides both `ρu` and `ρv` components, which we merge with
-# the subsidence forcing.
+# where ``F_{ρ e}`` denotes the forcing on `ρe` (energy density), ``F_{ρθ}`` denotes
+# the forcing on `ρθ`, and the ``\cdots`` denote additional terms.
 
-ρu_forcing = (subsidence, geostrophic.ρu)
-ρv_forcing = (subsidence, geostrophic.ρv)
-ρqᵉ_forcing = (subsidence, ρqᵉ_drying_forcing)
-ρθ_forcing = subsidence
-ρe_forcing = ρe_radiation_forcing
-
-forcing = (; ρu=ρu_forcing, ρv=ρv_forcing, ρθ=ρθ_forcing,
-             ρe=ρe_forcing, ρqᵉ=ρqᵉ_forcing)
+forcing = (; ρu = (subsidence, geostrophic.ρu),
+             ρv = (subsidence, geostrophic.ρv),
+             ρθ = subsidence,
+             ρqᵉ = subsidence,
+             qᵉ = qᵉ_drying_forcing,
+             e = e_radiation_forcing)
 nothing #hide
 
 # ## Model setup

--- a/examples/bomex.jl
+++ b/examples/bomex.jl
@@ -173,29 +173,26 @@ e_radiation_forcing = Forcing(radiative_cooling)
 
 # ## Assembling all the forcings
 #
-# Forcings on the same prognostic field can be supplied either under the
-# density-weighted key (e.g. `ρθ`) or under the specific key (e.g. `θ`); Breeze
-# applies the ``ρ`` factor automatically in the latter case. When both keys are
-# present for the same field, Breeze sums the contributions. Here we keep
-# `subsidence` and `geostrophic` under density-weighted keys because they
-# already produce ``F_{ρϕ}`` internally, and supply the prescribed drying and
-# radiative-cooling tendencies under their specific keys.
+# Forcings are keyed under specific prognostic names (`u`, `v`, `θ`, `qᵉ`, `e`);
+# Breeze applies the density factor ``ρ`` automatically at kernel time. When
+# multiple forcings act on the same prognostic field — e.g. subsidence and the
+# geostrophic adjustment on the horizontal velocity — they are combined as a
+# tuple, and Breeze sums their contributions.
 #
-# Forcings on `ρe` and `ρθ` both contribute to the tendency of `ρθ` in different
+# Forcings on `e` and `θ` both contribute to the tendency of `ρθ` in different
 # ways. The tendency for `ρθ` is written
 #
 # ```math
-# ∂_t (ρ θ) = - \boldsymbol{\nabla \cdot} \, ( ρ \boldsymbol{u} θ ) + F_{ρθ} + \frac{1}{cᵖᵐ Π} F_{ρ e} + \cdots
+# ∂_t (ρ θ) = - \boldsymbol{\nabla \cdot} \, ( ρ \boldsymbol{u} θ ) + ρ F_θ + \frac{ρ F_e}{cᵖᵐ Π} + \cdots
 # ```
 #
-# where ``F_{ρ e}`` denotes the forcing on `ρe` (energy density), ``F_{ρθ}`` denotes
-# the forcing on `ρθ`, and the ``\cdots`` denote additional terms.
+# where ``F_e`` denotes the specific energy forcing supplied under `e` and
+# ``F_θ`` denotes the specific potential-temperature forcing supplied under `θ`.
 
-forcing = (; ρu = (subsidence, geostrophic.ρu),
-             ρv = (subsidence, geostrophic.ρv),
-             ρθ = subsidence,
-             ρqᵉ = subsidence,
-             qᵉ = qᵉ_drying_forcing,
+forcing = (; u = (subsidence, geostrophic.u),
+             v = (subsidence, geostrophic.v),
+             θ = subsidence,
+             qᵉ = (subsidence, qᵉ_drying_forcing),
              e = e_radiation_forcing)
 nothing #hide
 

--- a/examples/neutral_atmospheric_boundary_layer.jl
+++ b/examples/neutral_atmospheric_boundary_layer.jl
@@ -133,12 +133,7 @@ coriolis = FPlane(f=1e-4)
 uᵍ, vᵍ = 15, 0  # m/s, simulation "S" by Moeng and Sullivan (1994)
 geostrophic = geostrophic_forcings(uᵍ, vᵍ)
 
-ρu_forcing = geostrophic.ρu
-ρv_forcing = geostrophic.ρv
-ρw_forcing = ρw_sponge
-ρθ_forcing = ρθ_sponge
-
-forcing = (; ρu=ρu_forcing, ρv=ρv_forcing, ρw=ρw_forcing, ρθ=ρθ_forcing)
+forcing = (; u=geostrophic.u, v=geostrophic.v, ρw=ρw_sponge, ρθ=ρθ_sponge)
 nothing #hide
 
 # ## Model setup

--- a/examples/rico.jl
+++ b/examples/rico.jl
@@ -155,18 +155,15 @@ qᵉ_large_scale_forcing = Forcing(∂t_qᵉ_large_scale)
 
 # ## Assembling forcing and boundary conditions
 #
-# `subsidence` and `geostrophic` are keyed by their density-weighted prognostic
-# names because they already produce ``F_{ρϕ}`` internally. The prescribed
-# moisture and θ tendencies are keyed under their specific names, and Breeze
-# combines all entries on the same prognostic field via `MultipleForcings`.
+# Forcings are keyed under specific prognostic names (`u`, `v`, `w`, `θ`, `qᵉ`);
+# Breeze applies the density factor ``ρ`` automatically at kernel time. The
+# Oceananigans `Relaxation` sponge damps the vertical velocity `w` toward zero.
 
-forcing = (; ρu = (subsidence, geostrophic.ρu),
-             ρv = (subsidence, geostrophic.ρv),
-             ρw = sponge,
-             ρqᵉ = subsidence,
-             ρθ = subsidence,
-             qᵉ = qᵉ_large_scale_forcing,
-             θ = θ_large_scale_forcing)
+forcing = (; u = (subsidence, geostrophic.u),
+             v = (subsidence, geostrophic.v),
+             w = sponge,
+             qᵉ = (subsidence, qᵉ_large_scale_forcing),
+             θ = (subsidence, θ_large_scale_forcing))
 boundary_conditions = (ρe=ρe_bcs, ρqᵉ=ρqᵉ_bcs, ρu=ρu_bcs, ρv=ρv_bcs)
 nothing #hide
 

--- a/examples/rico.jl
+++ b/examples/rico.jl
@@ -134,36 +134,39 @@ geostrophic = geostrophic_forcings(z -> uᵍ(z), z -> vᵍ(z))
 # ## Moisture tendency
 #
 # A prescribed large-scale moisture tendency represents the effects of advection
-# by the large-scale circulation [vanZanten2011](@cite).
+# by the large-scale circulation [vanZanten2011](@cite). We supply this tendency
+# in specific form; Breeze multiplies by ``ρ`` automatically at kernel time when
+# the forcing is keyed under the specific variable name `qᵉ`.
 
-ρᵣ = reference_state.density
-∂t_ρqᵉ_large_scale = Field{Nothing, Nothing, Center}(grid)
+∂t_qᵉ_large_scale = Field{Nothing, Nothing, Center}(grid)
 dqdt_profile = AtmosphericProfilesLibrary.Rico_dqtdt(FT)
-set!(∂t_ρqᵉ_large_scale, z -> dqdt_profile(z))
-set!(∂t_ρqᵉ_large_scale, ρᵣ * ∂t_ρqᵉ_large_scale)
-∂t_ρqᵉ_large_scale_forcing = Forcing(∂t_ρqᵉ_large_scale)
+set!(∂t_qᵉ_large_scale, z -> dqdt_profile(z))
+qᵉ_large_scale_forcing = Forcing(∂t_qᵉ_large_scale)
 
 # ## Radiative cooling
 #
 # A prescribed radiative cooling profile is applied to the thermodynamic equation.
-# The RICO case uses a constant radiative cooling rate of ``-2.5`` K/day
-# applied uniformly throughout the domain [vanZanten2011](@cite).
-# This is the key simplification that allows us to avoid interactive radiation.
+# The RICO case uses a constant radiative cooling rate of ``-2.5`` K/day applied
+# uniformly throughout the domain [vanZanten2011](@cite). This is the key
+# simplification that allows us to avoid interactive radiation. We supply it
+# under the specific potential-temperature key `θ`.
 
-∂t_ρθ_large_scale = Field{Nothing, Nothing, Center}(grid)
-∂t_θ_large_scale = - 2.5 / day # K / day
-set!(∂t_ρθ_large_scale, ρᵣ * ∂t_θ_large_scale)
-ρθ_large_scale_forcing = Forcing(∂t_ρθ_large_scale)
+θ_large_scale_forcing = (x, y, z, t) -> - 2.5 / day
 
 # ## Assembling forcing and boundary conditions
+#
+# `subsidence` and `geostrophic` are keyed by their density-weighted prognostic
+# names because they already produce ``F_{ρϕ}`` internally. The prescribed
+# moisture and θ tendencies are keyed under their specific names, and Breeze
+# combines all entries on the same prognostic field via `MultipleForcings`.
 
-Fρu = (subsidence, geostrophic.ρu)
-Fρv = (subsidence, geostrophic.ρv)
-Fρw = sponge
-Fρqᵉ = (subsidence, ∂t_ρqᵉ_large_scale_forcing)
-Fρθ = (subsidence, ρθ_large_scale_forcing)
-
-forcing = (ρu=Fρu, ρv=Fρv, ρw=Fρw, ρqᵉ=Fρqᵉ, ρθ=Fρθ)
+forcing = (; ρu = (subsidence, geostrophic.ρu),
+             ρv = (subsidence, geostrophic.ρv),
+             ρw = sponge,
+             ρqᵉ = subsidence,
+             ρθ = subsidence,
+             qᵉ = qᵉ_large_scale_forcing,
+             θ = θ_large_scale_forcing)
 boundary_conditions = (ρe=ρe_bcs, ρqᵉ=ρqᵉ_bcs, ρu=ρu_bcs, ρv=ρv_bcs)
 nothing #hide
 

--- a/src/AtmosphereModels/AtmosphereModels.jl
+++ b/src/AtmosphereModels/AtmosphereModels.jl
@@ -56,7 +56,6 @@ export
     materialize_atmosphere_model_forcing,
     compute_forcing!,
     is_density_tendency_forcing,
-    wrap_specific_forcing,
 
     # Radiation (implemented by extensions)
     RadiativeTransferModel,

--- a/src/AtmosphereModels/AtmosphereModels.jl
+++ b/src/AtmosphereModels/AtmosphereModels.jl
@@ -55,6 +55,8 @@ export
     materialize_atmosphere_model_boundary_conditions,
     materialize_atmosphere_model_forcing,
     compute_forcing!,
+    is_density_tendency_forcing,
+    wrap_specific_forcing,
 
     # Radiation (implemented by extensions)
     RadiativeTransferModel,

--- a/src/AtmosphereModels/atmosphere_model.jl
+++ b/src/AtmosphereModels/atmosphere_model.jl
@@ -431,16 +431,35 @@ function atmosphere_model_forcing(user_forcings::NamedTuple, prognostic_fields, 
     return forcings
 end
 
-# Assemble the materialized forcing for one prognostic field, combining any user-supplied
-# ρ-keyed entry with any specific-keyed entry on the same prognostic.
+# Assemble the materialized forcing for one prognostic field. Dispatch on the result of
+# `specific_name_of(density_name)`: a `Symbol` is the specific alias of a ρ-prefixed
+# prognostic; `Nothing` means the prognostic name is already in specific form (e.g. a
+# user tracer like `:c`) and has no separate density alias.
 function assemble_field_forcing(density_name, target_field, user_forcings, model_names, context)
-    specific_name = specific_name_of(density_name)
-    raw_specific_forcing = isnothing(specific_name) ? nothing :
-                           get(user_forcings, specific_name, nothing)
+    return assemble_field_forcing(density_name, specific_name_of(density_name),
+                                  target_field, user_forcings, model_names, context)
+end
+
+# ρ-prefixed prognostic: combine any user-supplied ρ-keyed entry with any specific-keyed
+# entry on the same prognostic, wrapping the specific-keyed entry in SpecificForcing.
+function assemble_field_forcing(density_name, specific_name::Symbol, target_field,
+                                user_forcings, model_names, context)
+    raw_specific_forcing = get(user_forcings, specific_name, nothing)
     wrapped_specific_forcing = wrap_specific_forcing(raw_specific_forcing, density_name)
     raw_density_forcing = get(user_forcings, density_name, nothing)
     combined = combine_forcing_values(raw_density_forcing, wrapped_specific_forcing)
     return materialize_or_default(combined, target_field, density_name, model_names, context)
+end
+
+# Unprefixed prognostic (a user tracer like `:c`): the prognostic name *is* in specific
+# form, so any forcing supplied under that name is a specific tendency and gets wrapped
+# in SpecificForcing — the ρ factor is then applied at kernel time, matching the
+# convention used for ρ-prefixed prognostics' specific aliases.
+function assemble_field_forcing(density_name, ::Nothing, target_field,
+                                user_forcings, model_names, context)
+    raw_forcing = get(user_forcings, density_name, nothing)
+    wrapped_forcing = wrap_specific_forcing(raw_forcing, density_name)
+    return materialize_or_default(wrapped_forcing, target_field, density_name, model_names, context)
 end
 
 # Strip the `ρ` prefix from a density-weighted prognostic name; returns `nothing` for

--- a/src/AtmosphereModels/atmosphere_model.jl
+++ b/src/AtmosphereModels/atmosphere_model.jl
@@ -432,11 +432,11 @@ function atmosphere_model_forcing(user_forcings::NamedTuple, prognostic_fields, 
 end
 
 # Assemble the materialized forcing for one prognostic field. Dispatch on the result of
-# `specific_name_of(density_name)`: a `Symbol` is the specific alias of a ρ-prefixed
+# `specific_name_of(prognostic_name)`: a `Symbol` is the specific alias of a ρ-prefixed
 # prognostic; `Nothing` means the prognostic name is already in specific form (e.g. a
 # user tracer like `:c`) and has no separate density alias.
-function assemble_field_forcing(density_name, target_field, user_forcings, model_names, context)
-    return assemble_field_forcing(density_name, specific_name_of(density_name),
+function assemble_field_forcing(prognostic_name, target_field, user_forcings, model_names, context)
+    return assemble_field_forcing(prognostic_name, specific_name_of(prognostic_name),
                                   target_field, user_forcings, model_names, context)
 end
 
@@ -455,11 +455,11 @@ end
 # form, so any forcing supplied under that name is a specific tendency and gets wrapped
 # in SpecificForcing — the ρ factor is then applied at kernel time, matching the
 # convention used for ρ-prefixed prognostics' specific aliases.
-function assemble_field_forcing(density_name, ::Nothing, target_field,
+function assemble_field_forcing(tracer_name, ::Nothing, target_field,
                                 user_forcings, model_names, context)
-    raw_forcing = get(user_forcings, density_name, nothing)
-    wrapped_forcing = wrap_specific_forcing(raw_forcing, density_name)
-    return materialize_or_default(wrapped_forcing, target_field, density_name, model_names, context)
+    raw_forcing = get(user_forcings, tracer_name, nothing)
+    wrapped_forcing = wrap_specific_forcing(raw_forcing, tracer_name)
+    return materialize_or_default(wrapped_forcing, target_field, tracer_name, model_names, context)
 end
 
 # Strip the `ρ` prefix from a density-weighted prognostic name; returns `nothing` for

--- a/src/AtmosphereModels/atmosphere_model.jl
+++ b/src/AtmosphereModels/atmosphere_model.jl
@@ -422,18 +422,7 @@ function atmosphere_model_forcing(user_forcings::NamedTuple, prognostic_fields, 
     forcing_context = (; coriolis, density, specific_fields)
 
     materialized = Tuple(
-        let density_name = n,
-            specific_name = startswith(string(n), "ρ") ? Symbol(string(n)[nextind(string(n), 1):end]) : nothing
-            ρ_value    = density_name in user_forcing_names ? user_forcings[density_name] : nothing
-            spec_raw   = (specific_name !== nothing && specific_name in user_forcing_names) ?
-                         user_forcings[specific_name] : nothing
-            spec_value = spec_raw === nothing ? nothing :
-                         wrap_specific_forcing(spec_raw, density_name)
-            combined   = combine_forcing_values(ρ_value, spec_value)
-            combined === nothing ?
-                Returns(zero(eltype(f))) :
-                materialize_atmosphere_model_forcing(combined, f, density_name, model_names, forcing_context)
-        end
+        assemble_field_forcing(n, f, user_forcings, model_names, forcing_context)
         for (n, f) in pairs(forcing_fields)
     )
 
@@ -442,14 +431,39 @@ function atmosphere_model_forcing(user_forcings::NamedTuple, prognostic_fields, 
     return forcings
 end
 
+# Assemble the materialized forcing for one prognostic field, combining any user-supplied
+# ρ-keyed entry with any specific-keyed entry on the same prognostic.
+function assemble_field_forcing(density_name, target_field, user_forcings, model_names, context)
+    specific_name = specific_name_of(density_name)
+    raw_specific_forcing = isnothing(specific_name) ? nothing :
+                           get(user_forcings, specific_name, nothing)
+    wrapped_specific_forcing = wrap_specific_forcing(raw_specific_forcing, density_name)
+    raw_density_forcing = get(user_forcings, density_name, nothing)
+    combined = combine_forcing_values(raw_density_forcing, wrapped_specific_forcing)
+    return materialize_or_default(combined, target_field, density_name, model_names, context)
+end
+
+# Strip the `ρ` prefix from a density-weighted prognostic name; returns `nothing` for
+# any name that is not ρ-prefixed.
+function specific_name_of(density_name)
+    s = string(density_name)
+    return startswith(s, "ρ") ? Symbol(s[nextind(s, 1):end]) : nothing
+end
+
+# Default forcing for fields the user did not supply: a Returns that yields zero at every
+# grid point. Dispatch on Nothing keeps the assemble path branch-free.
+materialize_or_default(::Nothing, target_field, density_name, model_names, context) =
+    Returns(zero(target_field.grid))
+
+materialize_or_default(forcing, target_field, density_name, model_names, context) =
+    materialize_atmosphere_model_forcing(forcing, target_field, density_name, model_names, context)
+
 # Build (specific_name => density_name) pairs from a tuple of prognostic ρ-names.
 function specific_to_density_pairs(forcing_names)
     pairs = Pair{Symbol, Symbol}[]
     for name in forcing_names
-        s = string(name)
-        if startswith(s, "ρ")
-            push!(pairs, Symbol(s[nextind(s, 1):end]) => name)
-        end
+        specific_name = specific_name_of(name)
+        isnothing(specific_name) || push!(pairs, specific_name => name)
     end
     return Tuple(pairs)
 end

--- a/src/AtmosphereModels/atmosphere_model.jl
+++ b/src/AtmosphereModels/atmosphere_model.jl
@@ -399,7 +399,7 @@ function atmosphere_model_forcing(user_forcings::NamedTuple, prognostic_fields, 
     # Build a specific→density name map for any prognostic name that starts with `ρ`.
     # For example, :ρθ contributes :θ => :ρθ. Users may supply forcings under either key,
     # and the dispatch routes specific-keyed values through wrap_specific_forcing.
-    specific_to_density = NamedTuple(_specific_to_density_pairs(forcing_names))
+    specific_to_density = NamedTuple(specific_to_density_pairs(forcing_names))
     valid_specific_names = keys(specific_to_density)
 
     for name in user_forcing_names
@@ -429,7 +429,7 @@ function atmosphere_model_forcing(user_forcings::NamedTuple, prognostic_fields, 
                          user_forcings[specific_name] : nothing
             spec_value = spec_raw === nothing ? nothing :
                          wrap_specific_forcing(spec_raw, density_name)
-            combined   = _combine_forcing_values(ρ_value, spec_value)
+            combined   = combine_forcing_values(ρ_value, spec_value)
             combined === nothing ?
                 Returns(zero(eltype(f))) :
                 materialize_atmosphere_model_forcing(combined, f, density_name, model_names, forcing_context)
@@ -443,7 +443,7 @@ function atmosphere_model_forcing(user_forcings::NamedTuple, prognostic_fields, 
 end
 
 # Build (specific_name => density_name) pairs from a tuple of prognostic ρ-names.
-function _specific_to_density_pairs(forcing_names)
+function specific_to_density_pairs(forcing_names)
     pairs = Pair{Symbol, Symbol}[]
     for name in forcing_names
         s = string(name)
@@ -458,15 +458,15 @@ end
 # for the same prognostic. `nothing` denotes "user did not supply this side". The two
 # sides are flattened into a single tuple so the existing tuple-materialization path
 # wraps them in MultipleForcings.
-_combine_forcing_values(::Nothing, ::Nothing) = nothing
-_combine_forcing_values(a::Tuple, ::Nothing) = a
-_combine_forcing_values(::Nothing, b::Tuple) = b
-_combine_forcing_values(a, ::Nothing) = a
-_combine_forcing_values(::Nothing, b) = b
-_combine_forcing_values(a::Tuple, b::Tuple) = (a..., b...)
-_combine_forcing_values(a::Tuple, b) = (a..., b)
-_combine_forcing_values(a, b::Tuple) = (a, b...)
-_combine_forcing_values(a, b) = (a, b)
+combine_forcing_values(::Nothing, ::Nothing) = nothing
+combine_forcing_values(a::Tuple, ::Nothing) = a
+combine_forcing_values(::Nothing, b::Tuple) = b
+combine_forcing_values(a, ::Nothing) = a
+combine_forcing_values(::Nothing, b) = b
+combine_forcing_values(a::Tuple, b::Tuple) = (a..., b...)
+combine_forcing_values(a::Tuple, b) = (a..., b)
+combine_forcing_values(a, b::Tuple) = (a, b...)
+combine_forcing_values(a, b) = (a, b)
 
 function Oceananigans.fields(model::AtmosphereModel)
     formulation_fields = fields(model.formulation)

--- a/src/AtmosphereModels/atmosphere_model.jl
+++ b/src/AtmosphereModels/atmosphere_model.jl
@@ -230,8 +230,12 @@ function AtmosphereModel(grid;
 
     moisture_specific = moisture_specific_name(microphysics)
     specific_prognostic_moisture = microphysical_fields[moisture_specific]
-    model_fields = merge(prognostic_model_fields, velocities, microphysical_fields,
-                         (; T=temperature))
+    # Build `model_fields` with the same key order as Oceananigans.fields(model::AtmosphereModel)
+    # below. ContinuousForcing resolves `field_dependencies` to positional indices at
+    # materialize time and looks them up positionally at runtime; the two tuples must
+    # agree on ordering, or forcings will read the wrong field.
+    model_fields = merge(prognostic_model_fields, fields(formulation), velocities,
+                         (; T=temperature), microphysical_fields)
     density = dynamics_density(dynamics)
     forcing = atmosphere_model_forcing(forcing, prognostic_model_fields, model_fields,
                                        grid, coriolis, density,

--- a/src/AtmosphereModels/atmosphere_model.jl
+++ b/src/AtmosphereModels/atmosphere_model.jl
@@ -459,12 +459,14 @@ end
 # sides are flattened into a single tuple so the existing tuple-materialization path
 # wraps them in MultipleForcings.
 _combine_forcing_values(::Nothing, ::Nothing) = nothing
+_combine_forcing_values(a::Tuple, ::Nothing) = a
+_combine_forcing_values(::Nothing, b::Tuple) = b
 _combine_forcing_values(a, ::Nothing) = a
 _combine_forcing_values(::Nothing, b) = b
-_combine_forcing_values(a, b) = (a, b)
+_combine_forcing_values(a::Tuple, b::Tuple) = (a..., b...)
 _combine_forcing_values(a::Tuple, b) = (a..., b)
 _combine_forcing_values(a, b::Tuple) = (a, b...)
-_combine_forcing_values(a::Tuple, b::Tuple) = (a..., b...)
+_combine_forcing_values(a, b) = (a, b)
 
 function Oceananigans.fields(model::AtmosphereModel)
     formulation_fields = fields(model.formulation)

--- a/src/AtmosphereModels/atmosphere_model.jl
+++ b/src/AtmosphereModels/atmosphere_model.jl
@@ -396,10 +396,17 @@ function atmosphere_model_forcing(user_forcings::NamedTuple, prognostic_fields, 
 
     forcing_names = keys(forcing_fields)
 
+    # Build a specific→density name map for any prognostic name that starts with `ρ`.
+    # For example, :ρθ contributes :θ => :ρθ. Users may supply forcings under either key,
+    # and the dispatch routes specific-keyed values through wrap_specific_forcing.
+    specific_to_density = NamedTuple(_specific_to_density_pairs(forcing_names))
+    valid_specific_names = keys(specific_to_density)
+
     for name in user_forcing_names
-        if name ∉ forcing_names
+        if name ∉ forcing_names && name ∉ valid_specific_names
             msg = string("Invalid forcing: forcing contains an entry for $name, but $name is not a prognostic field!", '\n',
-                         "The forcing fields are ", forcing_names)
+                         "The forcing fields are ", forcing_names,
+                         "; specific-key aliases are ", valid_specific_names, '.')
             throw(ArgumentError(msg))
         end
     end
@@ -415,16 +422,49 @@ function atmosphere_model_forcing(user_forcings::NamedTuple, prognostic_fields, 
     forcing_context = (; coriolis, density, specific_fields)
 
     materialized = Tuple(
-        n in keys(user_forcings) ?
-            materialize_atmosphere_model_forcing(user_forcings[n], f, n, model_names, forcing_context) :
-            Returns(zero(eltype(f)))
-            for (n, f) in pairs(forcing_fields)
+        let density_name = n,
+            specific_name = startswith(string(n), "ρ") ? Symbol(string(n)[nextind(string(n), 1):end]) : nothing
+            ρ_value    = density_name in user_forcing_names ? user_forcings[density_name] : nothing
+            spec_raw   = (specific_name !== nothing && specific_name in user_forcing_names) ?
+                         user_forcings[specific_name] : nothing
+            spec_value = spec_raw === nothing ? nothing :
+                         wrap_specific_forcing(spec_raw, density_name)
+            combined   = _combine_forcing_values(ρ_value, spec_value)
+            combined === nothing ?
+                Returns(zero(eltype(f))) :
+                materialize_atmosphere_model_forcing(combined, f, density_name, model_names, forcing_context)
+        end
+        for (n, f) in pairs(forcing_fields)
     )
 
     forcings = NamedTuple{forcing_names}(materialized)
 
     return forcings
 end
+
+# Build (specific_name => density_name) pairs from a tuple of prognostic ρ-names.
+function _specific_to_density_pairs(forcing_names)
+    pairs = Pair{Symbol, Symbol}[]
+    for name in forcing_names
+        s = string(name)
+        if startswith(s, "ρ")
+            push!(pairs, Symbol(s[nextind(s, 1):end]) => name)
+        end
+    end
+    return Tuple(pairs)
+end
+
+# Combine a density-keyed forcing value with the specific-keyed forcing value supplied
+# for the same prognostic. `nothing` denotes "user did not supply this side". The two
+# sides are flattened into a single tuple so the existing tuple-materialization path
+# wraps them in MultipleForcings.
+_combine_forcing_values(::Nothing, ::Nothing) = nothing
+_combine_forcing_values(a, ::Nothing) = a
+_combine_forcing_values(::Nothing, b) = b
+_combine_forcing_values(a, b) = (a, b)
+_combine_forcing_values(a::Tuple, b) = (a..., b)
+_combine_forcing_values(a, b::Tuple) = (a, b...)
+_combine_forcing_values(a::Tuple, b::Tuple) = (a..., b...)
 
 function Oceananigans.fields(model::AtmosphereModel)
     formulation_fields = fields(model.formulation)

--- a/src/AtmosphereModels/forcing_interface.jl
+++ b/src/AtmosphereModels/forcing_interface.jl
@@ -48,3 +48,34 @@ This function is extended by the `Forcings` module for forcing types that
 require pre-computation (e.g., `SubsidenceForcing` which computes horizontal averages).
 """
 compute_forcing!(forcing) = nothing # Fallback - do nothing
+
+"""
+$(TYPEDSIGNATURES)
+
+Return `true` if `forcing` produces a density-weighted tendency `F_{ρϕ}` directly
+(i.e., already includes the multiplication by `ρ`).
+
+Forcings that return density tendencies must be supplied under their density-weighted
+key (e.g., `ρθ`, `ρu`) rather than the corresponding specific key (`θ`, `u`), because
+the specific-key dispatch wraps user values in `SpecificForcing`, which would multiply
+by `ρ` a second time. This trait is used by `atmosphere_model_forcing` to reject such
+misuses with a clear error.
+
+Defaults to `false`. Extended for `SubsidenceForcing` and `GeostrophicForcing` in the
+`Forcings` module.
+"""
+is_density_tendency_forcing(::Any) = false
+
+"""
+    wrap_specific_forcing(value, density_name)
+
+Wrap `value` so that the kernel-time density factor `ρ` is applied automatically when
+the user supplies a forcing keyed by a specific (per-unit-mass) variable name like
+`θ`, `u`, `qᵉ`. Implemented in the `Forcings` module: constructs a `SpecificForcing`,
+recurses into tuples, and errors if `value` is itself a density-tendency forcing like
+`SubsidenceForcing` (which would double-count `ρ`).
+
+`density_name` is the corresponding density-weighted prognostic name (e.g. `:ρθ`) used
+to produce a helpful error message when the wrap is rejected.
+"""
+function wrap_specific_forcing end

--- a/src/Breeze.jl
+++ b/src/Breeze.jl
@@ -120,6 +120,7 @@ export
     # Forcing utilities
     geostrophic_forcings,
     SubsidenceForcing,
+    SpecificForcing,
 
     # Grid utilities
     PiecewiseStretchedDiscretization,

--- a/src/Forcings/Forcings.jl
+++ b/src/Forcings/Forcings.jl
@@ -50,6 +50,8 @@ end
 ##### return specific tendencies and so are accepted here directly.
 #####
 
+AtmosphereModels.wrap_specific_forcing(::Nothing, density_name) = nothing
+
 function AtmosphereModels.wrap_specific_forcing(value, density_name)
     if is_density_tendency_forcing(value)
         msg = string("Forcing of type ", nameof(typeof(value)),

--- a/src/Forcings/Forcings.jl
+++ b/src/Forcings/Forcings.jl
@@ -67,7 +67,8 @@ function AtmosphereModels.wrap_specific_forcing(value, density_name)
     return SpecificForcing(value)
 end
 
-AtmosphereModels.wrap_specific_forcing(values::Tuple, density_name) =
-    map(v -> wrap_specific_forcing(v, density_name), values)
+function AtmosphereModels.wrap_specific_forcing(values::Tuple, density_name)
+    return map(v -> wrap_specific_forcing(v, density_name), values)
+end
 
 end

--- a/src/Forcings/Forcings.jl
+++ b/src/Forcings/Forcings.jl
@@ -43,16 +43,11 @@ function AtmosphereModels.compute_forcing!(mf::MultipleForcings)
 end
 
 #####
-##### Density-tendency forcing trait: identifies Breeze forcings that already produce F_{ρϕ}
-##### so the atmosphere-model dispatch can reject misuse under specific keys.
-#####
-
-AtmosphereModels.is_density_tendency_forcing(::SubsidenceForcing) = true
-AtmosphereModels.is_density_tendency_forcing(::GeostrophicForcing) = true
-
-#####
 ##### Specific-key wrapping: build a SpecificForcing for a user value supplied under a
-##### specific name (`θ`, `u`, ...). Tuples recurse; density-tendency forcings error.
+##### specific name (`θ`, `u`, ...). Tuples recurse; user-defined density-tendency
+##### forcings (i.e., those whose kernels already include the ρ factor) error to
+##### prevent double-counting. Breeze's own SubsidenceForcing and GeostrophicForcing
+##### return specific tendencies and so are accepted here directly.
 #####
 
 function AtmosphereModels.wrap_specific_forcing(value, density_name)

--- a/src/Forcings/Forcings.jl
+++ b/src/Forcings/Forcings.jl
@@ -3,7 +3,8 @@ module Forcings
 export
     geostrophic_forcings,
     SubsidenceForcing,
-    GeostrophicForcing
+    GeostrophicForcing,
+    SpecificForcing
 
 using DocStringExtensions: TYPEDSIGNATURES
 
@@ -15,6 +16,7 @@ using ..AtmosphereModels: AtmosphereModels, materialize_atmosphere_model_forcing
 
 include("geostrophic_forcings.jl")
 include("subsidence_forcing.jl")
+include("specific_forcing.jl")
 
 #####
 ##### Extension of materialize_forcing with context argument

--- a/src/Forcings/Forcings.jl
+++ b/src/Forcings/Forcings.jl
@@ -12,7 +12,8 @@ using Oceananigans: Average, Field, set!, compute!
 using Oceananigans.Grids: Center, Face
 using Oceananigans.Forcings: materialize_forcing, MultipleForcings
 
-using ..AtmosphereModels: AtmosphereModels, materialize_atmosphere_model_forcing, compute_forcing!
+using ..AtmosphereModels: AtmosphereModels, materialize_atmosphere_model_forcing,
+                          compute_forcing!, is_density_tendency_forcing, wrap_specific_forcing
 
 include("geostrophic_forcings.jl")
 include("subsidence_forcing.jl")
@@ -40,5 +41,33 @@ function AtmosphereModels.compute_forcing!(mf::MultipleForcings)
     end
     return nothing
 end
+
+#####
+##### Density-tendency forcing trait: identifies Breeze forcings that already produce F_{ρϕ}
+##### so the atmosphere-model dispatch can reject misuse under specific keys.
+#####
+
+AtmosphereModels.is_density_tendency_forcing(::SubsidenceForcing) = true
+AtmosphereModels.is_density_tendency_forcing(::GeostrophicForcing) = true
+
+#####
+##### Specific-key wrapping: build a SpecificForcing for a user value supplied under a
+##### specific name (`θ`, `u`, ...). Tuples recurse; density-tendency forcings error.
+#####
+
+function AtmosphereModels.wrap_specific_forcing(value, density_name)
+    if is_density_tendency_forcing(value)
+        msg = string("Forcing of type ", nameof(typeof(value)),
+                     " produces a density-weighted tendency F_{ρϕ}; ",
+                     "supply it under the density-weighted key `", density_name,
+                     "` rather than its specific counterpart. ",
+                     "Auto-wrapping it in SpecificForcing would multiply by ρ a second time.")
+        throw(ArgumentError(msg))
+    end
+    return SpecificForcing(value)
+end
+
+AtmosphereModels.wrap_specific_forcing(values::Tuple, density_name) =
+    map(v -> wrap_specific_forcing(v, density_name), values)
 
 end

--- a/src/Forcings/geostrophic_forcings.jl
+++ b/src/Forcings/geostrophic_forcings.jl
@@ -1,28 +1,25 @@
 using ..AtmosphereModels: AtmosphereModels
 using Oceananigans: Field, set!, compute!
 using Oceananigans.Grids: Center, XDirection, YDirection
-using Oceananigans.Operators: ℑxᶠᵃᵃ, ℑyᵃᶠᵃ
 using Oceananigans.Utils: prettysummary
 using Adapt: Adapt
 
 #####
-##### Geostrophic forcing types
+##### Geostrophic forcing
 #####
 
-struct GeostrophicForcing{S, V, R, F}
+struct GeostrophicForcing{S, V, F}
     geostrophic_velocity :: V
-    density :: R
-    direction :: S  # +1 for v-forcing, -1 for u-forcing
+    direction :: S  # XDirection for u-forcing, YDirection for v-forcing
     coriolis_parameter :: F
 end
 
-Adapt.adapt_structure(to,gf::GeostrophicForcing) =
+Adapt.adapt_structure(to, gf::GeostrophicForcing) =
     GeostrophicForcing(Adapt.adapt(to, gf.geostrophic_velocity),
-                       Adapt.adapt(to, gf.density),
                        Adapt.adapt(to, gf.direction),
                        Adapt.adapt(to, gf.coriolis_parameter))
 
-GeostrophicForcing(u, dir) = GeostrophicForcing(u, nothing, dir, nothing)
+GeostrophicForcing(u, dir) = GeostrophicForcing(u, dir, nothing)
 
 const XGeostrophicForcing = GeostrophicForcing{XDirection}
 const YGeostrophicForcing = GeostrophicForcing{YDirection}
@@ -68,29 +65,36 @@ function Base.show(io::IO, ft::NamedGeostrophicForcingTuple)
     print(io, "    └── geostrophic_velocity: ", prettysummary(forcing.geostrophic_velocity))
 end
 
-@inline geostrophic_momentum(i, j, k, grid, ρ, uᵍ) = @inbounds ρ[i, j, k] * uᵍ[i, j, k]
+#####
+##### Kernel: returns the specific geostrophic-adjustment tendency
+##### (the ρ-multiply and horizontal interpolation happen in SpecificForcing).
+##### The 1×1×Center storage is horizontally uniform, so [i, j, k] is well-defined.
+#####
 
 @inline function (forcing::XGeostrophicForcing)(i, j, k, grid, clock, fields)
     f = forcing.coriolis_parameter
-    ρvᵍ = ℑxᶠᵃᵃ(i, j, k, grid, geostrophic_momentum, forcing.density, forcing.geostrophic_velocity)
-    return - f * ρvᵍ
+    vᵍ = @inbounds forcing.geostrophic_velocity[i, j, k]
+    return - f * vᵍ
 end
 
 @inline function (forcing::YGeostrophicForcing)(i, j, k, grid, clock, fields)
     f = forcing.coriolis_parameter
-    ρuᵍ = ℑyᵃᶠᵃ(i, j, k, grid, geostrophic_momentum, forcing.density, forcing.geostrophic_velocity)
-    return + f * ρuᵍ
+    uᵍ = @inbounds forcing.geostrophic_velocity[i, j, k]
+    return + f * uᵍ
 end
 
 """
 $(TYPEDSIGNATURES)
 
-Create a pair of geostrophic forcings for the x- and y-momentum equations.
+Create a pair of geostrophic forcings for the x- and y-momentum equations,
+keyed under specific names `u` and `v`. Each [`GeostrophicForcing`](@ref)
+returns a specific tendency; the model's density factor `ρ` is applied
+automatically via [`SpecificForcing`](@ref) when the forcing is dispatched
+under a specific key, with the correct horizontal interpolation of ρ to
+the appropriate cell face.
 
 The Coriolis parameter is extracted from the model's `coriolis` during
-model construction. The geostrophic velocity is stored separately from the
-model density, so compressible models form ``ρ uᵍ`` from the live prognostic
-density after initialization.
+model construction.
 
 Arguments
 =========
@@ -98,7 +102,7 @@ Arguments
 - `uᵍ`: Function of `z` specifying the x-component of the geostrophic velocity.
 - `vᵍ`: Function of `z` specifying the y-component of the geostrophic velocity.
 
-Returns a `NamedTuple` with `ρu` and `ρv` forcing entries that can be merged
+Returns a `NamedTuple` with `u` and `v` forcing entries that can be merged
 into the model forcing.
 
 Example
@@ -115,23 +119,33 @@ forcing = geostrophic_forcings(uᵍ, vᵍ)
 
 # output
 NamedTuple with 2 GeostrophicForcings:
-├── ρu: GeostrophicForcing{XDirection}
+├── u: GeostrophicForcing{XDirection}
 │   └── geostrophic_velocity: vᵍ (generic function with 1 method)
-└── ρv: GeostrophicForcing{YDirection}
+└── v: GeostrophicForcing{YDirection}
     └── geostrophic_velocity: uᵍ (generic function with 1 method)
 ```
 """
 function geostrophic_forcings(uᵍ, vᵍ)
-    Fρu = GeostrophicForcing(vᵍ, XDirection())
-    Fρv = GeostrophicForcing(uᵍ, YDirection())
-    return (; ρu=Fρu, ρv=Fρv)
+    Fu = GeostrophicForcing(vᵍ, XDirection())
+    Fv = GeostrophicForcing(uᵍ, YDirection())
+    return (; u=Fu, v=Fv)
 end
 
 #####
-##### Materialization functions for geostrophic forcings
+##### Materialization: store geostrophic velocity profile and the Coriolis parameter
 #####
 
-function AtmosphereModels.materialize_atmosphere_model_forcing(forcing::GeostrophicForcing, field, name, model_field_names, context)
+function AtmosphereModels.materialize_atmosphere_model_forcing(forcing::GeostrophicForcing,
+                                                               field, name, model_field_names,
+                                                               context::NamedTuple)
+    if startswith(string(name), "ρ")
+        msg = string("GeostrophicForcing now returns a specific tendency (e.g. -f vᵍ for u) and ",
+                     "must be supplied under the specific prognostic name (`u` or `v`). ",
+                     "Use `geostrophic_forcings(uᵍ, vᵍ)` to build the `(; u, v)` pair; ",
+                     "Breeze applies the density factor ρ automatically via SpecificForcing.")
+        throw(ArgumentError(msg))
+    end
+
     grid = field.grid
 
     forcing_uᵍ = forcing.geostrophic_velocity
@@ -145,7 +159,6 @@ function AtmosphereModels.materialize_atmosphere_model_forcing(forcing::Geostrop
 
     FT = eltype(grid)
     f = context.coriolis.f |> FT
-    ρ = context.density
 
-    return GeostrophicForcing(uᵍ, ρ, forcing.direction, f)
+    return GeostrophicForcing(uᵍ, forcing.direction, f)
 end

--- a/src/Forcings/geostrophic_forcings.jl
+++ b/src/Forcings/geostrophic_forcings.jl
@@ -87,11 +87,11 @@ end
 $(TYPEDSIGNATURES)
 
 Create a pair of geostrophic forcings for the x- and y-momentum equations,
-keyed under specific names `u` and `v`. Each [`GeostrophicForcing`](@ref)
-returns a specific tendency; the model's density factor `ρ` is applied
-automatically via [`SpecificForcing`](@ref) when the forcing is dispatched
-under a specific key, with the correct horizontal interpolation of ρ to
-the appropriate cell face.
+keyed under specific names `u` and `v`. Each `GeostrophicForcing` returns a
+specific tendency; the model's density factor `ρ` is applied automatically via
+[`SpecificForcing`](@ref Breeze.Forcings.SpecificForcing) when the forcing is
+dispatched under a specific key, with the correct horizontal interpolation of
+ρ to the appropriate cell face.
 
 The Coriolis parameter is extracted from the model's `coriolis` during
 model construction.

--- a/src/Forcings/specific_forcing.jl
+++ b/src/Forcings/specific_forcing.jl
@@ -35,11 +35,11 @@ the same wrapper handles both.
 
 Users typically supply specific forcings directly through specific-named keys
 (`u`, `v`, `w`, `θ`, `e`, `qᵉ`, `qᵛ`, …) in the `forcing` `NamedTuple` passed to
-[`AtmosphereModel`](@ref), and the dispatch wraps each entry in `SpecificForcing`
+[`AtmosphereModel`](@ref Breeze.AtmosphereModels.AtmosphereModel), and the dispatch wraps each entry in `SpecificForcing`
 automatically. The wrapper can also be constructed directly when finer control is needed.
 
 The inner `forcing` can be anything accepted by Oceananigans' `materialize_forcing`:
-a function `(x, y, z, t)`, a [`Returns`](@ref) callable, a `Field`, an
+a function `(x, y, z, t)`, a `Returns` callable, a `Field`, an
 `Oceananigans.Forcing`, or a tuple of these.
 """
 SpecificForcing(forcing) = SpecificForcing(forcing, nothing, nothing)

--- a/src/Forcings/specific_forcing.jl
+++ b/src/Forcings/specific_forcing.jl
@@ -1,0 +1,86 @@
+using ..AtmosphereModels: AtmosphereModels
+using Oceananigans.Fields: location
+using Oceananigans.Forcings: materialize_forcing
+using Oceananigans.Grids: Center, Face
+using Oceananigans.Operators: ℑzᵃᵃᶠ
+using Oceananigans.Utils: prettysummary
+using Adapt: Adapt
+
+#####
+##### SpecificForcing
+#####
+
+struct SpecificForcing{F, D, LZ}
+    forcing :: F            # materialized inner forcing (kernel callable)
+    density :: D            # ρᵣ(z) for anelastic, ρ(x, y, z, t) for compressible
+    target_z_location :: LZ # Center for u, v, scalars; Face for w
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Wrap a user-supplied forcing that produces a *specific* (per-unit-mass) tendency so that
+Breeze applies the density multiply ``ρ`` at kernel time. After materialization, the
+kernel callable returns
+
+```math
+ρ(i, j, k) \\, F_ϕ(i, j, k, t)
+```
+
+for fields located at `Center`, and interpolates ``ρ`` to the target vertical face via
+``ℑzᵃᵃᶠ`` for forcings on `w` (or any `Face`-located target). `ρ` is `ρᵣ(z)` under
+[`AnelasticDynamics`](@ref Breeze.AnelasticEquations.AnelasticDynamics) and the prognostic
+`ρ(x, y, z, t)` under [`CompressibleDynamics`](@ref Breeze.CompressibleEquations.CompressibleDynamics);
+the same wrapper handles both.
+
+Users typically supply specific forcings directly through specific-named keys
+(`u`, `v`, `w`, `θ`, `e`, `qᵉ`, `qᵛ`, …) in the `forcing` `NamedTuple` passed to
+[`AtmosphereModel`](@ref), and the dispatch wraps each entry in `SpecificForcing`
+automatically. The wrapper can also be constructed directly when finer control is needed.
+
+The inner `forcing` can be anything accepted by Oceananigans' `materialize_forcing`:
+a function `(x, y, z, t)`, a [`Returns`](@ref) callable, a `Field`, an
+`Oceananigans.Forcing`, or a tuple of these.
+"""
+SpecificForcing(forcing) = SpecificForcing(forcing, nothing, nothing)
+
+Adapt.adapt_structure(to, sf::SpecificForcing) =
+    SpecificForcing(Adapt.adapt(to, sf.forcing),
+                    Adapt.adapt(to, sf.density),
+                    sf.target_z_location)
+
+#####
+##### Kernel callables: dispatch on vertical location of target field
+#####
+
+@inline function (sf::SpecificForcing{<:Any, <:Any, <:Center})(i, j, k, grid, clock, fields)
+    Fϕ = sf.forcing(i, j, k, grid, clock, fields)
+    return @inbounds sf.density[i, j, k] * Fϕ
+end
+
+@inline function (sf::SpecificForcing{<:Any, <:Any, <:Face})(i, j, k, grid, clock, fields)
+    ρᶠ = ℑzᵃᵃᶠ(i, j, k, grid, sf.density)
+    Fϕ = sf.forcing(i, j, k, grid, clock, fields)
+    return ρᶠ * Fϕ
+end
+
+#####
+##### Materialization: resolve density and vertical location from context + target field
+#####
+
+function AtmosphereModels.materialize_atmosphere_model_forcing(forcing::SpecificForcing,
+                                                               field, name, model_field_names,
+                                                               context::NamedTuple)
+    inner = materialize_forcing(forcing.forcing, field, name, model_field_names)
+    ρ = context.density
+    _, _, LZ = location(field)
+    return SpecificForcing(inner, ρ, LZ())
+end
+
+#####
+##### Show
+#####
+
+Base.summary(sf::SpecificForcing) = string("SpecificForcing with forcing: ", prettysummary(sf.forcing))
+
+Base.show(io::IO, sf::SpecificForcing) = print(io, summary(sf))

--- a/src/Forcings/specific_forcing.jl
+++ b/src/Forcings/specific_forcing.jl
@@ -40,9 +40,9 @@ automatically. The wrapper can also be constructed directly when finer control i
 
 The inner `forcing` can be anything accepted by Breeze's
 `materialize_atmosphere_model_forcing`: a function `(x, y, z, t)`, a `Returns`
-callable, a `Field`, an `Oceananigans.Forcing`, a Breeze forcing type like
-[`SubsidenceForcing`](@ref Breeze.Forcings.SubsidenceForcing) or
-[`GeostrophicForcing`](@ref Breeze.Forcings.GeostrophicForcing), or a tuple of these.
+callable, a `Field`, an `Oceananigans.Forcing`, a Breeze forcing such as
+[`SubsidenceForcing`](@ref Breeze.Forcings.SubsidenceForcing) or one produced by
+[`geostrophic_forcings`](@ref Breeze.Forcings.geostrophic_forcings), or a tuple of these.
 """
 SpecificForcing(forcing) = SpecificForcing(forcing, nothing, nothing)
 

--- a/src/Forcings/specific_forcing.jl
+++ b/src/Forcings/specific_forcing.jl
@@ -1,5 +1,5 @@
 using ..AtmosphereModels: AtmosphereModels
-using Oceananigans.Fields: instantiated_location
+using Oceananigans: instantiated_location
 using Oceananigans.Forcings: materialize_forcing
 using Oceananigans.Grids: Center, Face
 using Oceananigans.Operators: ℑzᵃᵃᶠ

--- a/src/Forcings/specific_forcing.jl
+++ b/src/Forcings/specific_forcing.jl
@@ -77,6 +77,13 @@ end
 ##### Materialization: resolve density and target field location from context + target field
 #####
 
+#####
+##### compute_forcing! recurses into the inner so wrapped forcings (e.g. SubsidenceForcing,
+##### which precomputes a horizontal average each step) refresh their auxiliary fields.
+#####
+
+AtmosphereModels.compute_forcing!(sf::SpecificForcing) = AtmosphereModels.compute_forcing!(sf.forcing)
+
 function AtmosphereModels.materialize_atmosphere_model_forcing(forcing::SpecificForcing,
                                                                field, name, model_field_names,
                                                                context::NamedTuple)

--- a/src/Forcings/specific_forcing.jl
+++ b/src/Forcings/specific_forcing.jl
@@ -1,6 +1,5 @@
-using ..AtmosphereModels: AtmosphereModels
+using ..AtmosphereModels: AtmosphereModels, materialize_atmosphere_model_forcing
 using Oceananigans: instantiated_location
-using Oceananigans.Forcings: materialize_forcing
 using Oceananigans.Grids: Center, Face
 using Oceananigans.Operators: ℑxᶠᵃᵃ, ℑyᵃᶠᵃ, ℑzᵃᵃᶠ
 using Oceananigans.Utils: prettysummary
@@ -81,7 +80,14 @@ end
 function AtmosphereModels.materialize_atmosphere_model_forcing(forcing::SpecificForcing,
                                                                field, name, model_field_names,
                                                                context::NamedTuple)
-    inner = materialize_forcing(forcing.forcing, field, name, model_field_names)
+    # SpecificForcing wraps a forcing that produces a specific tendency, so propagate
+    # the specific (un-prefixed) prognostic name to the inner materializer — Breeze
+    # forcing types like SubsidenceForcing and GeostrophicForcing expect the specific
+    # name to look up the field they advect or apply at.
+    specific_name = startswith(string(name), "ρ") ?
+                    Symbol(string(name)[nextind(string(name), 1):end]) : name
+    inner = materialize_atmosphere_model_forcing(forcing.forcing, field, specific_name,
+                                                 model_field_names, context)
     ρ = context.density
     target_location = instantiated_location(field)
     return SpecificForcing(inner, ρ, target_location)

--- a/src/Forcings/specific_forcing.jl
+++ b/src/Forcings/specific_forcing.jl
@@ -77,13 +77,6 @@ end
 ##### Materialization: resolve density and target field location from context + target field
 #####
 
-#####
-##### compute_forcing! recurses into the inner so wrapped forcings (e.g. SubsidenceForcing,
-##### which precomputes a horizontal average each step) refresh their auxiliary fields.
-#####
-
-AtmosphereModels.compute_forcing!(sf::SpecificForcing) = AtmosphereModels.compute_forcing!(sf.forcing)
-
 function AtmosphereModels.materialize_atmosphere_model_forcing(forcing::SpecificForcing,
                                                                field, name, model_field_names,
                                                                context::NamedTuple)
@@ -99,6 +92,13 @@ function AtmosphereModels.materialize_atmosphere_model_forcing(forcing::Specific
     target_location = instantiated_location(field)
     return SpecificForcing(inner, ρ, target_location)
 end
+
+#####
+##### compute_forcing! recurses into the inner so wrapped forcings (e.g. SubsidenceForcing,
+##### which precomputes a horizontal average each step) refresh their auxiliary fields.
+#####
+
+AtmosphereModels.compute_forcing!(sf::SpecificForcing) = AtmosphereModels.compute_forcing!(sf.forcing)
 
 #####
 ##### Show

--- a/src/Forcings/specific_forcing.jl
+++ b/src/Forcings/specific_forcing.jl
@@ -2,7 +2,7 @@ using ..AtmosphereModels: AtmosphereModels
 using Oceananigans: instantiated_location
 using Oceananigans.Forcings: materialize_forcing
 using Oceananigans.Grids: Center, Face
-using Oceananigans.Operators: ℑzᵃᵃᶠ
+using Oceananigans.Operators: ℑxᶠᵃᵃ, ℑyᵃᶠᵃ, ℑzᵃᵃᶠ
 using Oceananigans.Utils: prettysummary
 using Adapt: Adapt
 
@@ -10,10 +10,10 @@ using Adapt: Adapt
 ##### SpecificForcing
 #####
 
-struct SpecificForcing{F, D, LZ}
-    forcing :: F            # materialized inner forcing (kernel callable)
-    density :: D            # ρᵣ(z) for anelastic, ρ(x, y, z, t) for compressible
-    target_z_location :: LZ # Center for u, v, scalars; Face for w
+struct SpecificForcing{F, D, L}
+    forcing :: F          # materialized inner forcing (kernel callable)
+    density :: D          # ρᵣ(z) for anelastic, ρ(x, y, z, t) for compressible
+    target_location :: L  # (LX, LY, LZ) tuple of instances for the target prognostic field
 end
 
 """
@@ -27,8 +27,9 @@ kernel callable returns
 ρ(i, j, k) \\, F_ϕ(i, j, k, t)
 ```
 
-for fields located at `Center`, and interpolates ``ρ`` to the target vertical face via
-``ℑzᵃᵃᶠ`` for forcings on `w` (or any `Face`-located target). `ρ` is `ρᵣ(z)` under
+interpolating ``ρ`` to the appropriate cell face for fields whose target prognostic
+lives at `Face` in any direction (e.g. ``ρ`` is interpolated to x-Face for `u`-forcings
+via ``ℑxᶠᵃᵃ``, to z-Face for `w` via ``ℑzᵃᵃᶠ``). `ρ` is `ρᵣ(z)` under
 [`AnelasticDynamics`](@ref Breeze.AnelasticEquations.AnelasticDynamics) and the prognostic
 `ρ(x, y, z, t)` under [`CompressibleDynamics`](@ref Breeze.CompressibleEquations.CompressibleDynamics);
 the same wrapper handles both.
@@ -38,34 +39,43 @@ Users typically supply specific forcings directly through specific-named keys
 [`AtmosphereModel`](@ref Breeze.AtmosphereModels.AtmosphereModel), and the dispatch wraps each entry in `SpecificForcing`
 automatically. The wrapper can also be constructed directly when finer control is needed.
 
-The inner `forcing` can be anything accepted by Oceananigans' `materialize_forcing`:
-a function `(x, y, z, t)`, a `Returns` callable, a `Field`, an
-`Oceananigans.Forcing`, or a tuple of these.
+The inner `forcing` can be anything accepted by Breeze's
+`materialize_atmosphere_model_forcing`: a function `(x, y, z, t)`, a `Returns`
+callable, a `Field`, an `Oceananigans.Forcing`, a Breeze forcing type like
+[`SubsidenceForcing`](@ref Breeze.Forcings.SubsidenceForcing) or
+[`GeostrophicForcing`](@ref Breeze.Forcings.GeostrophicForcing), or a tuple of these.
 """
 SpecificForcing(forcing) = SpecificForcing(forcing, nothing, nothing)
 
 Adapt.adapt_structure(to, sf::SpecificForcing) =
     SpecificForcing(Adapt.adapt(to, sf.forcing),
                     Adapt.adapt(to, sf.density),
-                    sf.target_z_location)
+                    sf.target_location)
 
 #####
-##### Kernel callables: dispatch on vertical location of target field
+##### Density at the target prognostic location: dispatch on (LX, LY, LZ).
+##### Only the four staggered locations that appear in the Breeze prognostic state are
+##### handled (Center,Center,Center for scalars; Face,Center,Center for u;
+##### Center,Face,Center for v; Center,Center,Face for w).
 #####
 
-@inline function (sf::SpecificForcing{<:Any, <:Any, <:Center})(i, j, k, grid, clock, fields)
+@inline density_at_target(::Tuple{Center, Center, Center}, ρ, i, j, k, grid) = @inbounds ρ[i, j, k]
+@inline density_at_target(::Tuple{Face,   Center, Center}, ρ, i, j, k, grid) = ℑxᶠᵃᵃ(i, j, k, grid, ρ)
+@inline density_at_target(::Tuple{Center, Face,   Center}, ρ, i, j, k, grid) = ℑyᵃᶠᵃ(i, j, k, grid, ρ)
+@inline density_at_target(::Tuple{Center, Center, Face},   ρ, i, j, k, grid) = ℑzᵃᵃᶠ(i, j, k, grid, ρ)
+
+#####
+##### Kernel callable
+#####
+
+@inline function (sf::SpecificForcing)(i, j, k, grid, clock, fields)
     Fϕ = sf.forcing(i, j, k, grid, clock, fields)
-    return @inbounds sf.density[i, j, k] * Fϕ
+    ρ = density_at_target(sf.target_location, sf.density, i, j, k, grid)
+    return ρ * Fϕ
 end
 
-@inline function (sf::SpecificForcing{<:Any, <:Any, <:Face})(i, j, k, grid, clock, fields)
-    ρᶠ = ℑzᵃᵃᶠ(i, j, k, grid, sf.density)
-    Fϕ = sf.forcing(i, j, k, grid, clock, fields)
-    return ρᶠ * Fϕ
-end
-
 #####
-##### Materialization: resolve density and vertical location from context + target field
+##### Materialization: resolve density and target field location from context + target field
 #####
 
 function AtmosphereModels.materialize_atmosphere_model_forcing(forcing::SpecificForcing,
@@ -73,8 +83,8 @@ function AtmosphereModels.materialize_atmosphere_model_forcing(forcing::Specific
                                                                context::NamedTuple)
     inner = materialize_forcing(forcing.forcing, field, name, model_field_names)
     ρ = context.density
-    LZ = instantiated_location(field)[3]
-    return SpecificForcing(inner, ρ, LZ)
+    target_location = instantiated_location(field)
+    return SpecificForcing(inner, ρ, target_location)
 end
 
 #####

--- a/src/Forcings/specific_forcing.jl
+++ b/src/Forcings/specific_forcing.jl
@@ -1,5 +1,5 @@
 using ..AtmosphereModels: AtmosphereModels
-using Oceananigans.Fields: location
+using Oceananigans.Fields: instantiated_location
 using Oceananigans.Forcings: materialize_forcing
 using Oceananigans.Grids: Center, Face
 using Oceananigans.Operators: ℑzᵃᵃᶠ
@@ -73,8 +73,8 @@ function AtmosphereModels.materialize_atmosphere_model_forcing(forcing::Specific
                                                                context::NamedTuple)
     inner = materialize_forcing(forcing.forcing, field, name, model_field_names)
     ρ = context.density
-    _, _, LZ = location(field)
-    return SpecificForcing(inner, ρ, LZ())
+    LZ = instantiated_location(field)[3]
+    return SpecificForcing(inner, ρ, LZ)
 end
 
 #####

--- a/src/Forcings/subsidence_forcing.jl
+++ b/src/Forcings/subsidence_forcing.jl
@@ -8,32 +8,33 @@ using Oceananigans.Utils: prettysummary
 using Adapt: Adapt
 
 #####
-##### Subsidence forcing types (unmaterialized stubs)
+##### Subsidence forcing
 #####
 
-struct SubsidenceForcing{W, R, A}
+struct SubsidenceForcing{W, A}
     subsidence_vertical_velocity :: W
-    density :: R
     averaged_field :: A
 end
 
 Adapt.adapt_structure(to, sf::SubsidenceForcing) =
     SubsidenceForcing(Adapt.adapt(to, sf.subsidence_vertical_velocity),
-                      Adapt.adapt(to, sf.density),
                       Adapt.adapt(to, sf.averaged_field))
 
 """
 $(TYPEDSIGNATURES)
 
 Forcing that represents large-scale subsidence advecting horizontally-averaged
-fields downward:
+fields downward. The kernel returns the *specific* tendency
 
 ```math
-F_{ρ ϕ} = - ρᵣ wˢ ∂_z \\overline{ϕ}
+F_ϕ = - w^s \\, ∂_z \\overline{ϕ}
 ```
 
-where ``wˢ`` is the `subsidence_vertical_velocity`, ``ρᵣ`` is the reference density,
-and ``\\overline{ϕ}`` is the horizontal average of the field being forced.
+where ``w^s`` is the `subsidence_vertical_velocity` and ``\\overline{ϕ}`` is the
+horizontal average of the field being forced. Supply `SubsidenceForcing` under
+the specific prognostic name (e.g. `θ`, `qᵉ`, `u`); the `AtmosphereModel` dispatch
+wraps it in [`SpecificForcing`](@ref) so the density factor ``ρ`` is applied
+automatically at kernel time.
 
 # Fields
 - `wˢ`: Either a function of `z` specifying the subsidence velocity profile,
@@ -50,18 +51,18 @@ grid = RectilinearGrid(size=(64, 64, 75), x=(0, 6400), y=(0, 6400), z=(0, 3000))
 
 wˢ(z) = z < 1500 ? -0.0065 * z / 1500 : -0.0065 * (1 - (z - 1500) / 600)
 subsidence = SubsidenceForcing(wˢ)
-forcing = (; ρθ=subsidence, ρqᵛ=subsidence)
+forcing = (; θ=subsidence, qᵛ=subsidence)
 
 model = AtmosphereModel(grid; forcing)
 
-model.forcing.ρθ
+model.forcing.ρθ.forcing
 
 # output
 SubsidenceForcing with wˢ: 1×1×76 Field{Nothing, Nothing, Face} reduced over dims = (1, 2) on RectilinearGrid on CPU
 └── averaged_field: 1×1×75 Field{Nothing, Nothing, Center} reduced over dims = (1, 2) on RectilinearGrid on CPU
 ```
 """
-SubsidenceForcing(wˢ) = SubsidenceForcing(wˢ, nothing, nothing)
+SubsidenceForcing(wˢ) = SubsidenceForcing(wˢ, nothing)
 
 function Base.summary(forcing::SubsidenceForcing)
     wˢ = forcing.subsidence_vertical_velocity
@@ -77,10 +78,9 @@ function Base.show(io::IO, forcing::SubsidenceForcing)
 end
 
 #####
-##### Materialized subsidence forcing
+##### Kernel: returns the specific subsidence tendency (the ρ-multiply happens in SpecificForcing)
 #####
 
-# Kernel function for subsidence forcing
 @inline w_dz_ϕᵃᵃᶠ(i, j, k, grid, w, ϕ) = @inbounds w[1, 1, k] * ∂zᶜᶜᶠ(1, 1, k, grid, ϕ)
 
 @inline function ℑzbᵃᵃᶜ(i, j, k, grid, w_dz_ϕᵃᵃᶠ, wˢ, ϕ_avg)
@@ -92,32 +92,27 @@ end
     return ifelse(top, w_dz_ϕᵏ, ifelse(bottom, w_dz_ϕ⁺, ℑz_w_dz_ϕ))
 end
 
- function (forcing::SubsidenceForcing)(i, j, k, grid, clock, fields)
+@inline function (forcing::SubsidenceForcing)(i, j, k, grid, clock, fields)
     wˢ = forcing.subsidence_vertical_velocity
     ϕ_avg = forcing.averaged_field
-    ρ = @inbounds forcing.density[1, 1, k]
     w_dz_ϕ_avg = ℑzbᵃᵃᶜ(i, j, k, grid, w_dz_ϕᵃᵃᶠ, wˢ, ϕ_avg)
-    return - ρ * w_dz_ϕ_avg
+    return - w_dz_ϕ_avg
 end
 
 #####
-##### Materialization function for subsidence forcing
+##### Materialization: build the horizontal average of the specific field
 #####
 
-# This is called from AtmosphereModels.atmosphere_model_forcing
-# The `averaged_field` is determined by the field name (e.g., :ρu → u, :ρθ → θ)
-# and passed in from atmosphere_model_forcing
+function AtmosphereModels.materialize_atmosphere_model_forcing(forcing::SubsidenceForcing,
+                                                               field, name, model_field_names,
+                                                               context::NamedTuple)
+    if startswith(string(name), "ρ")
+        msg = string("SubsidenceForcing now returns a specific tendency F_ϕ = -wˢ ∂_z ϕ̄ and ",
+                     "must be supplied under the specific prognostic name (e.g. `θ` instead of `ρθ`). ",
+                     "Breeze applies the density factor ρ automatically via SpecificForcing.")
+        throw(ArgumentError(msg))
+    end
 
-# Strip the ρ prefix from density variable names
-# e.g., :ρu → :u, :ρθ → :θ, :ρe → :e
-function strip_density_prefix(name::Symbol)
-    chars = string(name) |> collect
-    popfirst!(chars)
-    return Symbol(chars...)
-end
-
-function AtmosphereModels.materialize_atmosphere_model_forcing(forcing::SubsidenceForcing, field, name,
-                                                               model_field_names, context::NamedTuple)
     grid = field.grid
 
     if forcing.subsidence_vertical_velocity isa AbstractField
@@ -128,18 +123,11 @@ function AtmosphereModels.materialize_atmosphere_model_forcing(forcing::Subsiden
         fill_halo_regions!(wˢ)
     end
 
-    if name ∈ (:ρu, :ρv, :ρw, :ρθ, :ρe, :ρqᵗ, :ρqᵛ, :ρqᵉ)
-        specific_name = strip_density_prefix(name)
-        specific_field = context.specific_fields[specific_name]
-    else
-        # Note that tracers are converted from density to specific within
-        # update_state!, before `compute_forcing!` is called.
-        specific_field = field
-    end
-
+    # `name` is the specific prognostic name (e.g. :θ); look up the matching field directly.
+    specific_field = haskey(context.specific_fields, name) ? context.specific_fields[name] : field
     averaged_field = Average(specific_field, dims=(1, 2)) |> Field
-    ρ = context.density
-    return SubsidenceForcing(wˢ, ρ, averaged_field)
+
+    return SubsidenceForcing(wˢ, averaged_field)
 end
 
 #####

--- a/test/atmosphere_model_construction.jl
+++ b/test/atmosphere_model_construction.jl
@@ -46,7 +46,7 @@ end
         forced_model = AtmosphereModel(grid; coriolis, forcing=geostrophic_forcings(uᵍ, vᵍ))
         shown_forced_model = sprint(show, forced_model)
 
-        @test occursin("forcing: ρu=>GeostrophicForcing, ρv=>GeostrophicForcing", shown_forced_model)
+        @test occursin("forcing: ρu=>SpecificForcing, ρv=>SpecificForcing", shown_forced_model)
     end
 
     @testset "Basic tests for set!" begin

--- a/test/forcing_and_boundary_conditions.jl
+++ b/test/forcing_and_boundary_conditions.jl
@@ -58,6 +58,28 @@ increment_tolerance(::Type{Float64}) = 1e-10
     end
 end
 
+@testset "Forcing field_dependencies resolve consistently at materialize and runtime [$FT]" for FT in test_float_types()
+    # ContinuousForcing resolves `field_dependencies` to positional indices into the
+    # materialize-time `model_fields`, then dereferences those positions against the
+    # runtime `fields(model)` tuple. The two orderings must agree, or a forcing reads
+    # the wrong field. This test catches the order drift via a forcing that returns
+    # its `:u` dependency: under a misaligned ordering Gρθ would equal `θ` instead.
+    Oceananigans.defaults.FloatType = FT
+    grid = RectilinearGrid(default_arch; size=(4, 4, 4), x=(0, 100), y=(0, 100), z=(0, 100))
+
+    @inline u_dep(x, y, z, t, u) = u
+    u_forcing = Forcing(u_dep, field_dependencies=(:u,))
+    model = AtmosphereModel(grid; forcing=(; ρθ=u_forcing))
+
+    θ₀ = model.dynamics.reference_state.potential_temperature
+    u_value = 13
+    set!(model; θ=θ₀, u=u_value)
+    update_state!(model)
+
+    Gρθ = interior(model.timestepper.Gⁿ.ρθ) |> Array
+    @test all(isapprox.(Gρθ, u_value))
+end
+
 #####
 ##### Bulk boundary condition tests
 #####

--- a/test/forcing_and_boundary_conditions.jl
+++ b/test/forcing_and_boundary_conditions.jl
@@ -51,7 +51,9 @@ increment_tolerance(::Type{Float64}) = 1e-10
     end
 
     @testset "Forcing on non-existing field errors" begin
-        bad = (; u=forcings[1])
+        # `:u` is the specific alias of `:ρu`, so it's a valid key. Use a name that is
+        # neither a prognostic ρ-name nor a known specific alias.
+        bad = (; bogus=forcings[1])
         @test_throws ArgumentError AtmosphereModel(grid; forcing=bad)
     end
 end

--- a/test/geostrophic_subsidence_forcings.jl
+++ b/test/geostrophic_subsidence_forcings.jl
@@ -174,6 +174,112 @@ end
 ##### Analytical subsidence forcing tests
 #####
 
+@testset "GeostrophicForcing equivalence to manual ρᵣ * vᵍ Forcing reference [$(FT)]" for FT in test_float_types()
+    # Path A (new): geostrophic_forcings under specific keys u, v, wrapped by SpecificForcing.
+    # Path B (reference): Forcing(field) under ρu, ρv where the field stores the exact output
+    # of the old GeostrophicForcing kernel, ±f * ℑxᶠᵃᵃ(ρᵣ * vᵍ) or ±f * ℑyᵃᶠᵃ(ρᵣ * uᵍ).
+    # With ρᵣ anelastic (time-invariant) and uᵍ/vᵍ horizontally uniform, the two paths
+    # must be bit-for-bit identical at every step. Running for several steps stresses
+    # the per-step ρ-multiply in SpecificForcing.
+    Oceananigans.defaults.FloatType = FT
+    grid = RectilinearGrid(default_arch; size=(4, 4, 4), x=(0, 100), y=(0, 100), z=(0, 100))
+    coriolis = FPlane(f=FT(1e-4))
+    f = FT(coriolis.f)
+
+    uᵍ_func(z) = FT(-10 + FT(0.05) * z)
+    vᵍ_func(z) = FT(2 - FT(0.02) * z)
+
+    # Path A: new-style specific keys.
+    model_new = AtmosphereModel(grid; coriolis,
+                                      forcing = geostrophic_forcings(uᵍ_func, vᵍ_func))
+
+    # Path B: reference forcings built as fields storing the old-kernel output.
+    ρᵣ = model_new.dynamics.reference_state.density
+    uᵍ_field = Field{Nothing, Nothing, Center}(grid)
+    vᵍ_field = Field{Nothing, Nothing, Center}(grid)
+    set!(uᵍ_field, z -> uᵍ_func(z))
+    set!(vᵍ_field, z -> vᵍ_func(z))
+
+    ρu_ref_field = Field{Face, Center, Center}(grid)
+    ρv_ref_field = Field{Center, Face, Center}(grid)
+    set!(ρu_ref_field, -f * ρᵣ * vᵍ_field)
+    set!(ρv_ref_field, +f * ρᵣ * uᵍ_field)
+    model_ref = AtmosphereModel(grid; coriolis,
+                                      forcing = (; ρu = Forcing(ρu_ref_field),
+                                                   ρv = Forcing(ρv_ref_field)))
+
+    θ₀ = model_new.dynamics.reference_state.potential_temperature
+    set!(model_new; θ=θ₀)
+    set!(model_ref; θ=θ₀)
+
+    Δt = FT(1e-3)
+    N = 10
+    for _ in 1:N
+        time_step!(model_new, Δt)
+        time_step!(model_ref, Δt)
+    end
+
+    ρu_new = interior(model_new.momentum.ρu) |> Array
+    ρu_ref = interior(model_ref.momentum.ρu) |> Array
+    ρv_new = interior(model_new.momentum.ρv) |> Array
+    ρv_ref = interior(model_ref.momentum.ρv) |> Array
+
+    @test maximum(abs.(ρu_new .- ρu_ref)) < eps(FT) * 1000 * max(maximum(abs, ρu_new), one(FT))
+    @test maximum(abs.(ρv_new .- ρv_ref)) < eps(FT) * 1000 * max(maximum(abs, ρv_new), one(FT))
+end
+
+@testset "SubsidenceForcing multi-step linear accumulation [$FT]" for FT in test_float_types()
+    # A constant z-gradient profile is preserved under uniform subsidence (the advected
+    # gradient is itself the gradient), so Gρϕ = -ρᵣ wˢ Γ is constant in time and ρϕ
+    # should change linearly with N. Running N steps catches per-step bugs in the
+    # SpecificForcing ρ-multiply that wouldn't show up in a single-step check.
+    Oceananigans.defaults.FloatType = FT
+    grid = RectilinearGrid(default_arch; size=(1, 1, 4), x=(0, 10), y=(0, 10), z=(0, 16))
+    reference_state = ReferenceState(grid)
+    dynamics = AnelasticDynamics(reference_state)
+
+    wˢ = 1
+    Γ = 1e-2
+    ϕᵢ(x, y, z) = Γ * z
+    Δt = 1e-2
+    N = 5
+    Δϕ_per_step = - Δt * wˢ * Γ |> FT
+    subsidence = SubsidenceForcing(FT(wˢ))
+
+    for (specific_name, density_name) in ((:θ, :ρθ), (:qᵛ, :ρqᵛ))
+        forcing = (; specific_name => subsidence)
+        kw = (; advection=nothing, dynamics, formulation=:LiquidIcePotentialTemperature, forcing)
+        model = AtmosphereModel(grid; tracers=:ρc, kw...)
+        θ₀ = model.dynamics.reference_state.potential_temperature
+
+        ρᵣ = model.dynamics.reference_state.density
+        ρϕ = CenterField(grid)
+        set!(ρϕ, ϕᵢ)
+        set!(ρϕ, ρᵣ * ρϕ)
+
+        kw_set = (; density_name => ρϕ)
+        if density_name == :ρθ
+            set!(model; kw_set...)
+        else
+            set!(model; θ=θ₀, kw_set...)
+        end
+
+        ρϕ_field = prognostic_fields(model)[density_name]
+        ρϕ₀ = interior(ρϕ_field) |> Array
+        for _ in 1:N
+            time_step!(model, Δt)
+        end
+        ρϕ₁ = interior(ρϕ_field) |> Array
+        ρᵣ_int = interior(ρᵣ) |> Array
+
+        expected_change = N .* ρᵣ_int .* Δϕ_per_step
+        actual_change = ρϕ₁ .- ρϕ₀
+        # Loose tolerance — anelastic projection and other dynamics introduce small numerical drift.
+        @test maximum(abs.(actual_change .- expected_change)) <
+              FT(1e-3) * maximum(abs.(expected_change))
+    end
+end
+
 @testset "Subsidence forcing gradient [$FT]" for FT in test_float_types()
     Oceananigans.defaults.FloatType = FT
     grid = RectilinearGrid(default_arch; size=(1, 1, 4), x=(0, 10), y=(0, 10), z=(0, 16))

--- a/test/geostrophic_subsidence_forcings.jl
+++ b/test/geostrophic_subsidence_forcings.jl
@@ -1,5 +1,6 @@
 using Breeze
-using Breeze: ReferenceState, AnelasticDynamics, LiquidIcePotentialTemperatureFormulation, GeostrophicForcing
+using Breeze: ReferenceState, AnelasticDynamics, LiquidIcePotentialTemperatureFormulation,
+              GeostrophicForcing, SpecificForcing
 using Oceananigans: Oceananigans, prognostic_fields
 using Oceananigans.Fields: interior
 using Oceananigans.Grids: znodes, Center
@@ -13,13 +14,20 @@ using Test
     uᵍ(z) = -10
     vᵍ(z) = 0
     geostrophic = geostrophic_forcings(uᵍ, vᵍ)
+    @test haskey(geostrophic, :u)
+    @test haskey(geostrophic, :v)
+
     coriolis = FPlane(f=1e-4)
     model = AtmosphereModel(grid; coriolis, forcing=geostrophic)
 
+    # Geostrophic forcings are now keyed under specific names; the dispatch wraps each
+    # in SpecificForcing and stores it under the corresponding ρ-key.
     @test haskey(model.forcing, :ρu)
     @test haskey(model.forcing, :ρv)
-    @test model.forcing.ρu isa GeostrophicForcing
-    @test model.forcing.ρv isa GeostrophicForcing
+    @test model.forcing.ρu isa SpecificForcing
+    @test model.forcing.ρv isa SpecificForcing
+    @test model.forcing.ρu.forcing isa GeostrophicForcing
+    @test model.forcing.ρv.forcing isa GeostrophicForcing
 
     Δt = 1e-6
     time_step!(model, Δt)
@@ -68,11 +76,12 @@ end
     wˢ(z) = -0.01
     subsidence = SubsidenceForcing(wˢ)
 
-    model = AtmosphereModel(grid; forcing=(; ρθ=subsidence))
+    model = AtmosphereModel(grid; forcing=(; θ=subsidence))
 
     @test haskey(model.forcing, :ρθ)
-    @test model.forcing.ρθ isa SubsidenceForcing
-    @test !isnothing(model.forcing.ρθ.subsidence_vertical_velocity)
+    @test model.forcing.ρθ isa SpecificForcing
+    @test model.forcing.ρθ.forcing isa SubsidenceForcing
+    @test !isnothing(model.forcing.ρθ.forcing.subsidence_vertical_velocity)
 
     Δt = 1e-6
     time_step!(model, Δt)
@@ -90,7 +99,7 @@ end
 
     reference_state = ReferenceState(grid)
     dynamics = AnelasticDynamics(reference_state)
-    model = AtmosphereModel(grid; dynamics, formulation=:LiquidIcePotentialTemperature, forcing=(; ρqᵛ=subsidence))
+    model = AtmosphereModel(grid; dynamics, formulation=:LiquidIcePotentialTemperature, forcing=(; qᵛ=subsidence))
 
     θ₀ = model.dynamics.reference_state.potential_temperature
 
@@ -100,7 +109,8 @@ end
     set!(model, θ=θ₀, qᵗ=qᵗ_profile)
 
     @test haskey(model.forcing, :ρqᵛ)
-    @test model.forcing.ρqᵛ isa SubsidenceForcing
+    @test model.forcing.ρqᵛ isa SpecificForcing
+    @test model.forcing.ρqᵛ.forcing isa SubsidenceForcing
 
     ρqᵛ_initial = sum(model.moisture_density)
 
@@ -145,11 +155,10 @@ end
     subsidence = SubsidenceForcing(wˢ)
 
     forcing = (;
-        ρu = (subsidence, geostrophic.ρu),
-        ρv = (subsidence, geostrophic.ρv)
+        u = (subsidence, geostrophic.u),
+        v = (subsidence, geostrophic.v)
     )
 
-    coriolis = FPlane(f=1e-4)
     model = AtmosphereModel(grid; coriolis, forcing)
 
     @test haskey(model.forcing, :ρu)
@@ -178,10 +187,11 @@ end
     Δϕ = - Δt * wˢ * Γ |> FT
     subsidence = SubsidenceForcing(FT(wˢ))
 
-    # Test a representative subset of fields (reduced from 5 to 3)
-    @testset "Subsidence forcing with constant gradient [$name, $FT]" for name in (:ρu, :ρθ, :ρqᵛ)
-        # Test solo configuration only (combined is tested above)
-        forcing = (; name => subsidence)
+    # Test a representative subset of fields. The specific name keys the forcing
+    # (e.g. `:θ`), while the ρ-prefixed name keys the prognostic field used to
+    # check the predicted tendency.
+    @testset "Subsidence forcing with constant gradient [$specific_name, $FT]" for (specific_name, density_name) in ((:u, :ρu), (:θ, :ρθ), (:qᵛ, :ρqᵛ))
+        forcing = (; specific_name => subsidence)
 
         kw = (; advection=nothing, dynamics, formulation=:LiquidIcePotentialTemperature, forcing)
         model = AtmosphereModel(grid; tracers=:ρc, kw...)
@@ -192,14 +202,14 @@ end
         set!(ρϕ, ϕᵢ)
         set!(ρϕ, ρᵣ * ρϕ)
 
-        kw = (; name => ρϕ)
-        if name == :ρθ
+        kw = (; density_name => ρϕ)
+        if density_name == :ρθ
             set!(model; kw...)
         else
             set!(model; θ=θ₀, kw...)
         end
 
-        ρϕ = prognostic_fields(model)[name]
+        ρϕ = prognostic_fields(model)[density_name]
         ρϕ₀ = interior(ρϕ) |> Array
         time_step!(model, Δt)
         ρϕ₁ = interior(ρϕ) |> Array

--- a/test/specific_forcing.jl
+++ b/test/specific_forcing.jl
@@ -92,6 +92,45 @@ end
     @test Gρw[1, 1, 2] ≈ ρ_face_2 * F_w rtol=10 * eps(FT)
 end
 
+@testset "Specific-key path matches manual ρᵣ * field under ρ-key [$(FT)]" for FT in test_float_types()
+    # Verifies that the new ergonomic
+    #     forcing = (; θ = Forcing(field))
+    # produces bit-identical model evolution to the old pattern
+    #     set!(field, ρᵣ * field); forcing = (; ρθ = Forcing(field)).
+    Oceananigans.defaults.FloatType = FT
+    grid = RectilinearGrid(default_arch; size=(4, 4, 4), x=(0, 100), y=(0, 100), z=(0, 100))
+
+    # A nontrivial height-varying specific tendency (K/s).
+    F_specific_profile(z) = FT(-1e-5) * (1 + z / 100)
+
+    # Path A: manual ρᵣ multiply, supplied under :ρθ (the pre-change idiom)
+    model_A = AtmosphereModel(grid; forcing = (; ρθ = (x, y, z, t) -> 0))  # placeholder
+    ρᵣ = model_A.dynamics.reference_state.density
+    F_density_field = Field{Nothing, Nothing, Center}(grid)
+    set!(F_density_field, z -> F_specific_profile(z))
+    set!(F_density_field, ρᵣ * F_density_field)
+    model_A = AtmosphereModel(grid; forcing = (; ρθ = Forcing(F_density_field)))
+
+    # Path B: specific tendency supplied under :θ
+    F_specific_field = Field{Nothing, Nothing, Center}(grid)
+    set!(F_specific_field, z -> F_specific_profile(z))
+    model_B = AtmosphereModel(grid; forcing = (; θ = Forcing(F_specific_field)))
+
+    θ₀ = model_A.dynamics.reference_state.potential_temperature
+    set!(model_A; θ=θ₀)
+    set!(model_B; θ=θ₀)
+
+    Δt = FT(1)
+    for _ in 1:5
+        time_step!(model_A, Δt)
+        time_step!(model_B, Δt)
+    end
+
+    ρθ_A = interior(prognostic_fields(model_A).ρθ) |> Array
+    ρθ_B = interior(prognostic_fields(model_B).ρθ) |> Array
+    @test maximum(abs.(ρθ_A .- ρθ_B)) < eps(FT) * 1000 * maximum(abs.(ρθ_A))
+end
+
 @testset "Mixed θ + ρθ contributions sum [$(FT)]" for FT in test_float_types()
     Oceananigans.defaults.FloatType = FT
     grid = RectilinearGrid(default_arch; size=(4, 4, 4), x=(0, 100), y=(0, 100), z=(0, 100))

--- a/test/specific_forcing.jl
+++ b/test/specific_forcing.jl
@@ -1,0 +1,175 @@
+using Breeze
+using Breeze: SpecificForcing
+using Breeze.AtmosphereModels: is_density_tendency_forcing
+using Oceananigans: Oceananigans, prognostic_fields
+using Oceananigans.Forcings: MultipleForcings
+using Oceananigans.Fields: interior
+using Oceananigans.TimeSteppers: update_state!
+using Test
+
+#####
+##### Construction and dispatch
+#####
+
+@testset "SpecificForcing construction [$(FT)]" for FT in test_float_types()
+    Oceananigans.defaults.FloatType = FT
+    grid = RectilinearGrid(default_arch; size=(4, 4, 4), x=(0, 100), y=(0, 100), z=(0, 100))
+
+    # Specific key wraps user value in SpecificForcing and stores under the ρ-key
+    model = AtmosphereModel(grid; forcing=(; θ=Returns(FT(-1e-5))))
+    @test haskey(model.forcing, :ρθ)
+    @test model.forcing.ρθ isa SpecificForcing
+    @test !haskey(model.forcing, :θ)
+
+    # Density key keeps current behavior (no wrap)
+    model = AtmosphereModel(grid; forcing=(; ρθ=Returns(FT(-1e-5))))
+    @test !(model.forcing.ρθ isa SpecificForcing)
+
+    # Explicit SpecificForcing under a ρ-key materializes correctly
+    sf = SpecificForcing(Returns(FT(-1e-5)))
+    model = AtmosphereModel(grid; forcing=(; ρθ=sf))
+    @test model.forcing.ρθ isa SpecificForcing
+end
+
+@testset "Mixed specific + density keys merge into MultipleForcings [$(FT)]" for FT in test_float_types()
+    Oceananigans.defaults.FloatType = FT
+    grid = RectilinearGrid(default_arch; size=(4, 4, 4), x=(0, 100), y=(0, 100), z=(0, 100))
+
+    model = AtmosphereModel(grid; forcing=(; θ=Returns(FT(-1e-5)),
+                                             ρθ=Returns(FT(-1e-5))))
+    @test model.forcing.ρθ isa MultipleForcings
+    @test length(model.forcing.ρθ.forcings) == 2
+end
+
+@testset "Tuple under specific key wraps each element [$(FT)]" for FT in test_float_types()
+    Oceananigans.defaults.FloatType = FT
+    grid = RectilinearGrid(default_arch; size=(4, 4, 4), x=(0, 100), y=(0, 100), z=(0, 100))
+
+    f1 = Returns(FT(-1e-5))
+    f2 = Returns(FT(-2e-5))
+    model = AtmosphereModel(grid; forcing=(; θ=(f1, f2)))
+    @test model.forcing.ρθ isa MultipleForcings
+    @test length(model.forcing.ρθ.forcings) == 2
+    @test all(f isa SpecificForcing for f in model.forcing.ρθ.forcings)
+end
+
+#####
+##### Numerical correctness: anelastic Center- and Face-located forcings
+#####
+
+@testset "Specific θ forcing produces ρᵣ * F tendency [$(FT)]" for FT in test_float_types()
+    Oceananigans.defaults.FloatType = FT
+    grid = RectilinearGrid(default_arch; size=(4, 4, 4), x=(0, 100), y=(0, 100), z=(0, 100))
+
+    F_θ = FT(-1e-5)  # specific potential-temperature tendency, K/s
+    model = AtmosphereModel(grid; forcing=(; θ=Returns(F_θ)))
+    θ₀ = model.dynamics.reference_state.potential_temperature
+    set!(model; θ=θ₀)
+
+    # The kernel writes ρᵣ * F_θ into Gρθ
+    update_state!(model)
+    Gρθ = interior(model.timestepper.Gⁿ.ρθ) |> Array
+    ρᵣ = interior(model.dynamics.reference_state.density) |> Array
+    expected = ρᵣ .* F_θ
+    @test maximum(abs.(Gρθ .- expected)) < eps(FT) * 100
+end
+
+@testset "Specific w forcing interpolates ρᵣ to Face [$(FT)]" for FT in test_float_types()
+    Oceananigans.defaults.FloatType = FT
+    grid = RectilinearGrid(default_arch; size=(4, 4, 4), x=(0, 100), y=(0, 100), z=(0, 100))
+
+    F_w = FT(1e-3)  # specific vertical-momentum tendency, m/s²
+    model = AtmosphereModel(grid; forcing=(; w=Returns(F_w)))
+    θ₀ = model.dynamics.reference_state.potential_temperature
+    set!(model; θ=θ₀)
+
+    update_state!(model)
+    Gρw = interior(model.timestepper.Gⁿ.ρw) |> Array
+    ρᵣ = interior(model.dynamics.reference_state.density) |> Array
+
+    # ρᵣ lives at Center; interpolate to Face for interior k = 2, 3 (away from boundaries)
+    ρ_face_2 = (ρᵣ[1, 1, 1] + ρᵣ[1, 1, 2]) / 2
+    @test Gρw[1, 1, 2] ≈ ρ_face_2 * F_w rtol=10 * eps(FT)
+end
+
+@testset "Mixed θ + ρθ contributions sum [$(FT)]" for FT in test_float_types()
+    Oceananigans.defaults.FloatType = FT
+    grid = RectilinearGrid(default_arch; size=(4, 4, 4), x=(0, 100), y=(0, 100), z=(0, 100))
+
+    F_θ_specific = FT(-1e-5)              # gets multiplied by ρᵣ
+    F_ρθ_density = FT(-1e-5)              # added directly
+    model = AtmosphereModel(grid; forcing=(; θ=Returns(F_θ_specific),
+                                             ρθ=Returns(F_ρθ_density)))
+    θ₀ = model.dynamics.reference_state.potential_temperature
+    set!(model; θ=θ₀)
+
+    update_state!(model)
+    Gρθ = interior(model.timestepper.Gⁿ.ρθ) |> Array
+    ρᵣ = interior(model.dynamics.reference_state.density) |> Array
+    expected = ρᵣ .* F_θ_specific .+ F_ρθ_density
+    @test maximum(abs.(Gρθ .- expected)) < eps(FT) * 100
+end
+
+#####
+##### Compressible: ρ varies in (x, y, z, t)
+#####
+
+@testset "Specific θ forcing under compressible dynamics [$(FT)]" for FT in test_float_types()
+    Oceananigans.defaults.FloatType = FT
+    grid = RectilinearGrid(default_arch;
+                           size = (8, 8, 8), halo = (5, 5, 5),
+                           x = (0, 100), y = (0, 100), z = (0, 100),
+                           topology = (Periodic, Periodic, Bounded))
+
+    dynamics = CompressibleDynamics(SplitExplicitTimeDiscretization(substeps = 2,
+                                                                    damping = NoDivergenceDamping());
+                                    reference_potential_temperature = FT(300),
+                                    surface_pressure = FT(1e5),
+                                    standard_pressure = FT(1e5))
+
+    F_θ = FT(-1e-5)
+    model = AtmosphereModel(grid; dynamics, forcing=(; θ=Returns(F_θ)))
+    @test model.forcing.ρθ isa SpecificForcing
+
+    set!(model, ρ = (x, y, z) -> FT(1.2),
+                θ = (x, y, z) -> FT(300))
+    update_state!(model)
+
+    Gρθ = interior(model.timestepper.Gⁿ.ρθ) |> Array
+    ρ = interior(Breeze.AtmosphereModels.dynamics_density(model.dynamics)) |> Array
+    expected = ρ .* F_θ
+    @test maximum(abs.(Gρθ .- expected)) < eps(FT) * 100
+end
+
+#####
+##### Error paths
+#####
+
+@testset "Density-tendency forcing under specific key errors" begin
+    Oceananigans.defaults.FloatType = Float64
+    grid = RectilinearGrid(default_arch; size=(4, 4, 4), x=(0, 100), y=(0, 100), z=(0, 100))
+
+    subsidence = SubsidenceForcing(z -> -0.01)
+    @test_throws ArgumentError AtmosphereModel(grid; forcing=(; θ=subsidence))
+
+    # Same check inside a tuple
+    @test_throws ArgumentError AtmosphereModel(grid; forcing=(; θ=(subsidence, Returns(0.0))))
+
+    # GeostrophicForcing too
+    geostrophic = geostrophic_forcings(z -> -10.0, z -> 0.0).ρu
+    @test_throws ArgumentError AtmosphereModel(grid;
+                                               coriolis=FPlane(f=1e-4),
+                                               forcing=(; u=geostrophic))
+
+    # Trait sanity
+    @test is_density_tendency_forcing(subsidence)
+    @test is_density_tendency_forcing(geostrophic)
+    @test !is_density_tendency_forcing(Returns(0.0))
+end
+
+@testset "Unknown specific key errors" begin
+    Oceananigans.defaults.FloatType = Float64
+    grid = RectilinearGrid(default_arch; size=(4, 4, 4), x=(0, 100), y=(0, 100), z=(0, 100))
+
+    @test_throws ArgumentError AtmosphereModel(grid; forcing=(; foo=Returns(0.0)))
+end

--- a/test/specific_forcing.jl
+++ b/test/specific_forcing.jl
@@ -184,26 +184,43 @@ end
 ##### Error paths
 #####
 
-@testset "Density-tendency forcing under specific key errors" begin
+# A user-defined density-tendency forcing — Breeze should reject it under a specific key.
+struct ExampleDensityTendency end
+@inline (::ExampleDensityTendency)(i, j, k, grid, clock, fields) = zero(grid)
+Breeze.AtmosphereModels.is_density_tendency_forcing(::ExampleDensityTendency) = true
+
+@testset "User-defined density-tendency forcing under specific key errors" begin
+    Oceananigans.defaults.FloatType = Float64
+    grid = RectilinearGrid(default_arch; size=(4, 4, 4), x=(0, 100), y=(0, 100), z=(0, 100))
+
+    bad = ExampleDensityTendency()
+    @test is_density_tendency_forcing(bad)
+    @test_throws ArgumentError AtmosphereModel(grid; forcing=(; θ=bad))
+    # Same check inside a tuple
+    @test_throws ArgumentError AtmosphereModel(grid; forcing=(; θ=(bad, Returns(0.0))))
+end
+
+@testset "Built-in Breeze forcings are not density-tendency forcings" begin
+    # After the refactor SubsidenceForcing and GeostrophicForcing both return specific
+    # tendencies (the ρ multiply happens in SpecificForcing), so the trait must be false.
+    subsidence = SubsidenceForcing(z -> -0.01)
+    geostrophic_u = geostrophic_forcings(z -> -10.0, z -> 0.0).u
+    @test !is_density_tendency_forcing(subsidence)
+    @test !is_density_tendency_forcing(geostrophic_u)
+    @test !is_density_tendency_forcing(Returns(0.0))
+end
+
+@testset "Built-in Breeze forcings under ρ-key error with migration message" begin
     Oceananigans.defaults.FloatType = Float64
     grid = RectilinearGrid(default_arch; size=(4, 4, 4), x=(0, 100), y=(0, 100), z=(0, 100))
 
     subsidence = SubsidenceForcing(z -> -0.01)
-    @test_throws ArgumentError AtmosphereModel(grid; forcing=(; θ=subsidence))
+    @test_throws ArgumentError AtmosphereModel(grid; forcing=(; ρθ=subsidence))
 
-    # Same check inside a tuple
-    @test_throws ArgumentError AtmosphereModel(grid; forcing=(; θ=(subsidence, Returns(0.0))))
-
-    # GeostrophicForcing too
-    geostrophic = geostrophic_forcings(z -> -10.0, z -> 0.0).ρu
+    geostrophic_u = geostrophic_forcings(z -> -10.0, z -> 0.0).u
     @test_throws ArgumentError AtmosphereModel(grid;
                                                coriolis=FPlane(f=1e-4),
-                                               forcing=(; u=geostrophic))
-
-    # Trait sanity
-    @test is_density_tendency_forcing(subsidence)
-    @test is_density_tendency_forcing(geostrophic)
-    @test !is_density_tendency_forcing(Returns(0.0))
+                                               forcing=(; ρu=geostrophic_u))
 end
 
 @testset "Unknown specific key errors" begin

--- a/test/specific_forcing.jl
+++ b/test/specific_forcing.jl
@@ -74,6 +74,26 @@ end
     @test maximum(abs.(Gρθ .- expected)) < eps(FT) * 100
 end
 
+@testset "Unprefixed-tracer forcing wraps in SpecificForcing [$(FT)]" for FT in test_float_types()
+    # A user tracer named `:c` (no `ρ` prefix) is itself in specific form, so any forcing
+    # supplied under that name is wrapped in SpecificForcing and Breeze applies ρᵣ at
+    # kernel time — same convention as the specific alias of a ρ-prefixed prognostic.
+    Oceananigans.defaults.FloatType = FT
+    grid = RectilinearGrid(default_arch; size=(4, 4, 4), x=(0, 100), y=(0, 100), z=(0, 100))
+
+    F = FT(1e-5)
+    model = AtmosphereModel(grid; tracers=:c, forcing=(; c=Returns(F)))
+    @test model.forcing.c isa SpecificForcing
+
+    θ₀ = model.dynamics.reference_state.potential_temperature
+    set!(model; θ=θ₀)
+    update_state!(model)
+
+    Gρc = interior(model.timestepper.Gⁿ.c) |> Array
+    ρᵣ = interior(model.dynamics.reference_state.density) |> Array
+    @test maximum(abs.(Gρc .- ρᵣ .* F)) < eps(FT) * 100
+end
+
 @testset "Specific w forcing interpolates ρᵣ to Face [$(FT)]" for FT in test_float_types()
     Oceananigans.defaults.FloatType = FT
     grid = RectilinearGrid(default_arch; size=(4, 4, 4), x=(0, 100), y=(0, 100), z=(0, 100))


### PR DESCRIPTION
Closes #703.

## Summary

Breeze forcings can now be supplied under specific (per-unit-mass) prognostic names — `u`, `v`, `w`, `θ`, `e`, `qᵉ`, `qᵛ`, … — and Breeze applies the density factor `ρ` automatically at kernel time. The existing density-weighted keys (`ρu`, `ρθ`, …) continue to work for forcings whose kernels produce density tendencies directly.

- **New `SpecificForcing{F, D, L}` in `src/Forcings/`**: stores a user-supplied specific tendency, the model density, and the target prognostic's `(LX, LY, LZ)` location. The kernel returns `ρ(at target location) * F`, with `ρ` interpolated to the appropriate cell face for `u` (x-Face), `v` (y-Face), and `w` (z-Face) via `ℑxᶠᵃᵃ` / `ℑyᵃᶠᵃ` / `ℑzᵃᵃᶠ`. One code path for anelastic `ρᵣ(z)` and compressible `ρ(x, y, z, t)`.

- **`atmosphere_model_forcing` accepts specific names alongside ρ-prefixed ones**: specific entries are auto-wrapped in `SpecificForcing`. When the same prognostic gets both forms (`θ=…, ρθ=…`), contributions are summed via `MultipleForcings`. User-defined density-tendency forcings supplied under a specific key are rejected by the `is_density_tendency_forcing` trait to prevent double-counting ρ.

- **`SubsidenceForcing` and `GeostrophicForcing` rewritten to return specific tendencies** (the ρ-multiply and horizontal interpolation for `u`/`v` now happen in `SpecificForcing` instead of inside their own kernels). `geostrophic_forcings(uᵍ, vᵍ)` returns `(; u, v)`. Supplying either type under a ρ-prefixed key errors with a migration message — this is the user-visible breaking change.

- **`examples/bomex.jl` and `examples/rico.jl`** drop the manual `ρᵣ * field` boilerplate; all forcings are keyed by specific name.

### Breaking change

Code that previously supplied `SubsidenceForcing` under `ρθ`/`ρu`/`ρqᵉ`/…, or `geostrophic_forcings(...).ρu` / `.ρv`, must move to the specific keys. The construction-time error message describes the migration. The plain ρ-keyed `Forcing(...)` API is unchanged.

## Test plan

- [x] `test/specific_forcing.jl` (new, 28 tests): construction & dispatch, anelastic Center/Face numerical correctness, compressible numerical correctness, mixed θ + ρθ summation, A/B equivalence with the manual `ρᵣ * field` pattern, user-defined-density-tendency-under-specific-key errors, built-in Breeze forcings under ρ-key error with migration message, tuple composition, unknown-key error.
- [x] `test/geostrophic_subsidence_forcings.jl` (updated, 29 tests): all usages migrated to specific keys; new **multi-step equivalence test** asserts that `geostrophic_forcings` produces bit-for-bit identical `ρu`/`ρv` to a hand-rolled `Forcing(ρᵣ * vᵍ)` reference over 10 anelastic time steps; new **multi-step subsidence accumulation test** verifies `ρϕ` evolves linearly under a constant-gradient profile over 5 steps for both `θ` and `qᵛ`.
- [x] `test/forcing_and_boundary_conditions.jl` (66 tests) still pass; one bogus-key test updated since `:u` is now a valid specific alias.
- [ ] BOMEX and RICO examples build / run on CPU.
- [x] CI green.