### PR TITLE
Reserve underscore prefix for kernels in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,9 @@ and interfaces with ClimaOcean for coupled atmosphere-ocean simulations.
 - **Files**: snake_case — `atmosphere_model.jl`
 - **Types/Constructors**: PascalCase — `AtmosphereModel`
 - **Functions**: snake_case — `compute_pressure!`
-- **Kernels**: may prefix with underscore — `_kernel_function`
+- **Kernels**: may prefix with underscore — `_kernel_function`. The underscore
+  prefix is **reserved** for kernel functions; do not use it to mark plain
+  helpers as "internal" (we do not follow the Python convention).
 - **Variables**: English long name or unicode from `notation.md`. Add new variables to that table.
 - **Avoid abbreviations**: `latitude` not `lat`, `temperature` not `temp`
 
@@ -111,6 +113,9 @@ Planned: fully compressible formulation, `EntropyThermodynamics` (prognostic `ρ
     in the root `Project.toml` unless the task absolutely requires it. Dependency changes have
     wide-reaching consequences — they affect CI, load time, and downstream compatibility.
     Only touch `[compat]` bounds when explicitly asked.
+11. **Underscore-prefixed helpers**: an underscore prefix on a function name
+    signals "kernel" in this codebase. Plain helper functions stay snake_case
+    with no leading underscore.
 
 ## Git Workflow & Whitespace
 


### PR DESCRIPTION
## Summary

The existing Naming Conventions bullet in `AGENTS.md` says kernels *may* prefix with underscore, which leaves room for plain helpers to drift into the Python-style `_internal_helper` convention. Tightens the rule to make the underscore prefix explicitly reserved for kernels, and adds a matching entry to Common Pitfalls so it surfaces in auto-loaded `src/` context.

## Test plan

- [x] Docs-only change; no code touched.