### PR TITLE
Add `number_concentration(model, species)` lazy diagnostic

### DIFF
--- a/docs/src/breeze.bib
+++ b/docs/src/breeze.bib
@@ -106,6 +106,19 @@
   doi={10.1002/2015MS000496}
 }
 
+@article{Kaul2015,
+  author={Kaul, Colleen M. and Teixeira, João and Suzuki, Kentaroh},
+  title={Sensitivities in Large-Eddy Simulations of Mixed-Phase Arctic Stratocumulus Clouds Using a Simple Microphysics Approach},
+  journal={Monthly Weather Review},
+  year={2015},
+  publisher={American Meteorological Society},
+  volume={143},
+  number={11},
+  pages={4393--4421},
+  doi={10.1175/MWR-D-14-00319.1},
+  url={https://journals.ametsoc.org/view/journals/mwre/143/11/mwr-d-14-00319.1.xml}
+}
+
 @article{Maxwell2020,
     author = {Kelley, Maxwell and Schmidt, Gavin A. and Nazarenko, Larissa S. and Bauer, Susanne E. and Ruedy, Reto and Russell, Gary L. and Ackerman, Andrew S. and Aleinov, Igor and Bauer, Michael and Bleck, Rainer and Canuto, Vittorio and Cesana, Grégory and Cheng, Ye and Clune, Thomas L. and Cook, Ben I. and Cruz, Carlos A. and Del Genio, Anthony D. and Elsaesser, Gregory S. and Faluvegi, Greg and Kiang, Nancy Y. and Kim, Daehyun and Lacis, Andrew A. and Leboissetier, Anthony and LeGrande, Allegra N. and Lo, Ken K. and Marshall, John and Matthews, Elaine E. and McDermid, Sonali and Mezuman, Keren and Miller, Ron L. and Murray, Lee T. and Oinas, Valdar and Orbe, Clara and García-Pando, Carlos Pérez and Perlwitz, Jan P. and Puma, Michael J. and Rind, David and Romanou, Anastasia and Shindell, Drew T. and Sun, Shan and Tausnev, Nick and Tsigaridis, Kostas and Tselioudis, George and Weng, Ensheng and Wu, Jingbo and Yao, Mao-Sung},
     title = {{GISS-E2.1: configurations and climatology}},

--- a/ext/BreezeCloudMicrophysicsExt/BreezeCloudMicrophysicsExt.jl
+++ b/ext/BreezeCloudMicrophysicsExt/BreezeCloudMicrophysicsExt.jl
@@ -21,7 +21,9 @@ using CloudMicrophysics.Microphysics1M:
     accretion,
     accretion_rain_sink,
     accretion_snow_rain,
-    terminal_velocity
+    terminal_velocity,
+    get_n0,
+    lambda_inverse
 
 # Two-moment microphysics
 using CloudMicrophysics: Microphysics2M as CM2
@@ -30,6 +32,7 @@ using CloudMicrophysics: MicrophysicsNonEq as CMNonEq
 
 using Breeze.AtmosphereModels: AtmosphereModels,
     AbstractNumberConcentrationCategories,
+    dynamics_density,
     materialize_microphysical_fields,
     update_microphysical_fields!,
     grid_moisture_fractions
@@ -49,6 +52,8 @@ using Breeze.Thermodynamics:
     mixture_gas_constant,
     mixture_heat_capacity
 
+using Breeze: Microphysics
+
 using Breeze.Microphysics:
     center_field_tuple,
     BulkMicrophysics,
@@ -59,6 +64,7 @@ using Breeze.Microphysics:
     AbstractCondensateFormation,
     ConstantRateCondensateFormation,
     NonEquilibriumCloudFormation,
+    NumberConcentrationKernelFunction,
     condensation_rate,
     deposition_rate,
     adjust_thermodynamic_state

--- a/ext/BreezeCloudMicrophysicsExt/one_moment_helpers.jl
+++ b/ext/BreezeCloudMicrophysicsExt/one_moment_helpers.jl
@@ -108,13 +108,6 @@ end
 # per Kaul et al. (2015), so this dispatch goes through the scheme's
 # `pdf` and `mass` to stay consistent with the model's actual DSD.
 
-"""
-$(TYPEDSIGNATURES)
-
-Build a lazy `number_concentration` for rain under
-`OneMomentCloudMicrophysics`. The returned `KernelFunctionOperation`
-computes `n₀ · λ⁻¹` from the scheme's rain pdf and mass parameters.
-"""
 function Microphysics.number_concentration(model, microphysics::OneMomentLiquidRain, ::Val{:rain})
     haskey(model.microphysical_fields, :ρqʳ) || return nothing
     pdf = microphysics.categories.rain.pdf
@@ -123,13 +116,6 @@ function Microphysics.number_concentration(model, microphysics::OneMomentLiquidR
     return build_number_concentration_op(model, pdf, mass, ρq)
 end
 
-"""
-$(TYPEDSIGNATURES)
-
-Build a lazy `number_concentration` for snow under
-`OneMomentCloudMicrophysics`. Snow's intercept `n₀` depends on `(q, ρ)` per
-Kaul et al. (2015), so a closed-form rain-style expression cannot substitute.
-"""
 function Microphysics.number_concentration(model, microphysics::OneMomentLiquidRain, ::Val{:snow})
     haskey(model.microphysical_fields, :ρqˢ) || return nothing
     pdf = microphysics.categories.snow.pdf

--- a/ext/BreezeCloudMicrophysicsExt/one_moment_helpers.jl
+++ b/ext/BreezeCloudMicrophysicsExt/one_moment_helpers.jl
@@ -112,23 +112,8 @@ end
 $(TYPEDSIGNATURES)
 
 Build a lazy [`NumberConcentration`](@ref) for rain under
-`OneMomentCloudMicrophysics`.
-
-```jldoctest n
-using Breeze
-using CloudMicrophysics  # loads BreezeCloudMicrophysicsExt
-grid = RectilinearGrid(size=(1, 1, 4), extent=(1e3, 1e3, 1e3))
-microphysics = OneMomentCloudMicrophysics()
-model = AtmosphereModel(grid; microphysics)
-set!(model, θ=300, qᵗ=0.02, qʳ=1e-3)
-ρnʳ = NumberConcentration(model, :rain)
-
-# output
-KernelFunctionOperation at (Center, Center, Center)
-├── grid: 1×1×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×3 halo
-├── kernel_function: NumberConcentrationKernelFunction
-└── arguments: ()
-```
+`OneMomentCloudMicrophysics`. The returned `KernelFunctionOperation`
+computes `n₀ · λ⁻¹` from the scheme's rain pdf and mass parameters.
 """
 function Microphysics.number_concentration(model, microphysics::OneMomentLiquidRain, ::Val{:rain})
     haskey(model.microphysical_fields, :ρqʳ) || return nothing

--- a/ext/BreezeCloudMicrophysicsExt/one_moment_helpers.jl
+++ b/ext/BreezeCloudMicrophysicsExt/one_moment_helpers.jl
@@ -99,6 +99,81 @@ Adapt.adapt_structure(to, k::SurfacePrecipitationFluxKernel) =
 end
 
 #####
+##### Number concentration diagnostic (1-moment)
+#####
+#
+# For 1-mom rain and snow, the total number concentration is reconstructed
+# from the prognostic mass density ρqˣ and the scheme's assumed size
+# distribution as ρnˣ = n₀ · λ⁻¹. Snow's intercept n₀ depends on (q, ρ)
+# per Kaul et al. (2015), so this dispatch goes through the scheme's
+# `pdf` and `mass` to stay consistent with the model's actual DSD.
+
+"""
+$(TYPEDSIGNATURES)
+
+Build a lazy [`NumberConcentration`](@ref) for rain under
+`OneMomentCloudMicrophysics`.
+
+```jldoctest n
+using Breeze
+using CloudMicrophysics  # loads BreezeCloudMicrophysicsExt
+grid = RectilinearGrid(size=(1, 1, 4), extent=(1e3, 1e3, 1e3))
+microphysics = OneMomentCloudMicrophysics()
+model = AtmosphereModel(grid; microphysics)
+set!(model, θ=300, qᵗ=0.02, qʳ=1e-3)
+ρnʳ = NumberConcentration(model, :rain)
+
+# output
+KernelFunctionOperation at (Center, Center, Center)
+├── grid: 1×1×4 RectilinearGrid{Float64, Periodic, Periodic, Bounded} on CPU with 1×1×3 halo
+├── kernel_function: NumberConcentrationKernelFunction
+└── arguments: ()
+```
+"""
+function Microphysics.number_concentration(model, microphysics::OneMomentLiquidRain, ::Val{:rain})
+    haskey(model.microphysical_fields, :ρqʳ) || return nothing
+    pdf = microphysics.categories.rain.pdf
+    mass = microphysics.categories.rain.mass
+    ρq = model.microphysical_fields.ρqʳ
+    return build_number_concentration_op(model, pdf, mass, ρq)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Build a lazy [`NumberConcentration`](@ref) for snow under
+`OneMomentCloudMicrophysics`. Snow's intercept `n₀` depends on `(q, ρ)` per
+Kaul et al. (2015), so a closed-form rain-style expression cannot substitute.
+"""
+function Microphysics.number_concentration(model, microphysics::OneMomentLiquidRain, ::Val{:snow})
+    haskey(model.microphysical_fields, :ρqˢ) || return nothing
+    pdf = microphysics.categories.snow.pdf
+    mass = microphysics.categories.snow.mass
+    ρq = model.microphysical_fields.ρqˢ
+    return build_number_concentration_op(model, pdf, mass, ρq)
+end
+
+# Species not carried by the 1-mom scheme (e.g. :hail, :graupel, :cloud_liquid).
+Microphysics.number_concentration(model, microphysics::OneMomentLiquidRain, ::Val) = nothing
+
+function build_number_concentration_op(model, pdf, mass, ρq)
+    ρ = dynamics_density(model.dynamics)
+    func = NumberConcentrationKernelFunction(pdf, mass, ρq, ρ)
+    return KernelFunctionOperation{Center, Center, Center}(func, model.grid)
+end
+
+@inline function (k::NumberConcentrationKernelFunction)(i, j, k_idx, grid)
+    @inbounds begin
+        ρq = max(k.ρq[i, j, k_idx], zero(eltype(k.ρq)))
+        ρ  = k.reference_density[i, j, k_idx]
+    end
+    q   = ρq / ρ
+    n0  = get_n0(k.pdf, q, ρ)
+    λ⁻¹ = lambda_inverse(k.pdf, k.mass, q, ρ)
+    return n0 * λ⁻¹
+end
+
+#####
 ##### show methods
 #####
 

--- a/ext/BreezeCloudMicrophysicsExt/one_moment_helpers.jl
+++ b/ext/BreezeCloudMicrophysicsExt/one_moment_helpers.jl
@@ -111,7 +111,7 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Build a lazy [`NumberConcentration`](@ref) for rain under
+Build a lazy [`number_concentration`](@ref) for rain under
 `OneMomentCloudMicrophysics`. The returned `KernelFunctionOperation`
 computes `n₀ · λ⁻¹` from the scheme's rain pdf and mass parameters.
 """
@@ -126,7 +126,7 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Build a lazy [`NumberConcentration`](@ref) for snow under
+Build a lazy [`number_concentration`](@ref) for snow under
 `OneMomentCloudMicrophysics`. Snow's intercept `n₀` depends on `(q, ρ)` per
 Kaul et al. (2015), so a closed-form rain-style expression cannot substitute.
 """

--- a/ext/BreezeCloudMicrophysicsExt/one_moment_helpers.jl
+++ b/ext/BreezeCloudMicrophysicsExt/one_moment_helpers.jl
@@ -111,7 +111,7 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Build a lazy [`number_concentration`](@ref) for rain under
+Build a lazy `number_concentration` for rain under
 `OneMomentCloudMicrophysics`. The returned `KernelFunctionOperation`
 computes `n₀ · λ⁻¹` from the scheme's rain pdf and mass parameters.
 """
@@ -126,7 +126,7 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Build a lazy [`number_concentration`](@ref) for snow under
+Build a lazy `number_concentration` for snow under
 `OneMomentCloudMicrophysics`. Snow's intercept `n₀` depends on `(q, ρ)` per
 Kaul et al. (2015), so a closed-form rain-style expression cannot substitute.
 """

--- a/ext/BreezeCloudMicrophysicsExt/two_moment_helpers.jl
+++ b/ext/BreezeCloudMicrophysicsExt/two_moment_helpers.jl
@@ -102,6 +102,22 @@ Adapt.adapt_structure(to, k::TwoMomentSurfacePrecipitationFluxKernel) =
 end
 
 #####
+##### Number concentration diagnostic (2-moment)
+#####
+#
+# For 2-mom microphysics, the total number concentration is the prognostic
+# ρnˣ field; the diagnostic just hands it back so consumers see the same
+# interface as the 1-mom case (build a `Field` if they need to compute).
+
+Microphysics.number_concentration(model, ::TwoMomentCloudMicrophysics, ::Val{:rain}) =
+    get(model.microphysical_fields, :ρnʳ, nothing)
+
+Microphysics.number_concentration(model, ::TwoMomentCloudMicrophysics, ::Val{:cloud_liquid}) =
+    get(model.microphysical_fields, :ρnᶜˡ, nothing)
+
+Microphysics.number_concentration(model, ::TwoMomentCloudMicrophysics, ::Val) = nothing
+
+#####
 ##### show methods for two-moment microphysics
 #####
 

--- a/src/Breeze.jl
+++ b/src/Breeze.jl
@@ -99,6 +99,8 @@ export
     equilibrium_saturation_specific_humidity,
     RelativeHumidity,
     RelativeHumidityField,
+    NumberConcentration,
+    NumberConcentrationField,
     BulkMicrophysics,
     initial_aerosol_number,
     compute_hydrostatic_pressure!,

--- a/src/Breeze.jl
+++ b/src/Breeze.jl
@@ -99,7 +99,7 @@ export
     equilibrium_saturation_specific_humidity,
     RelativeHumidity,
     RelativeHumidityField,
-    NumberConcentration,
+    number_concentration,
     NumberConcentrationField,
     BulkMicrophysics,
     initial_aerosol_number,

--- a/src/Breeze.jl
+++ b/src/Breeze.jl
@@ -100,7 +100,7 @@ export
     RelativeHumidity,
     RelativeHumidityField,
     number_concentration,
-    NumberConcentrationField,
+    number_concentration_field,
     BulkMicrophysics,
     initial_aerosol_number,
     compute_hydrostatic_pressure!,

--- a/src/Microphysics/Microphysics.jl
+++ b/src/Microphysics/Microphysics.jl
@@ -21,7 +21,7 @@ export
     saturation_adjustment_coefficient,
     RelativeHumidity,
     RelativeHumidityField,
-    NumberConcentration,
+    number_concentration,
     NumberConcentrationField
 
 using ..AtmosphereModels: AtmosphereModels, moisture_fractions, grid_moisture_fractions,

--- a/src/Microphysics/Microphysics.jl
+++ b/src/Microphysics/Microphysics.jl
@@ -20,7 +20,9 @@ export
     kessler_terminal_velocity,
     saturation_adjustment_coefficient,
     RelativeHumidity,
-    RelativeHumidityField
+    RelativeHumidityField,
+    NumberConcentration,
+    NumberConcentrationField
 
 using ..AtmosphereModels: AtmosphereModels, moisture_fractions, grid_moisture_fractions,
     materialize_microphysical_fields, update_microphysical_fields!,

--- a/src/Microphysics/Microphysics.jl
+++ b/src/Microphysics/Microphysics.jl
@@ -22,7 +22,7 @@ export
     RelativeHumidity,
     RelativeHumidityField,
     number_concentration,
-    NumberConcentrationField
+    number_concentration_field
 
 using ..AtmosphereModels: AtmosphereModels, moisture_fractions, grid_moisture_fractions,
     materialize_microphysical_fields, update_microphysical_fields!,

--- a/src/Microphysics/microphysics_diagnostics.jl
+++ b/src/Microphysics/microphysics_diagnostics.jl
@@ -171,3 +171,83 @@ end
 
 const RelativeHumidityField = Field{C, C, C, <:RelativeHumidityOp}
 RelativeHumidityField(model) = Field(RelativeHumidity(model))
+
+#####
+##### Number Concentration
+#####
+
+"""
+    NumberConcentrationKernelFunction{P, M, Q, R}
+
+Kernel callable for the lazy total number concentration ``ρnˣ`` (m⁻³) of a
+one-moment microphysics species, computed from the prognostic mass density
+``ρqˣ`` and the species' assumed Marshall–Palmer size distribution as
+``ρnˣ = n_0 \\, λ^{-1}``.
+
+# Fields
+- `pdf`: size distribution (`ParticlePDFIceRain` or `ParticlePDFSnow`)
+- `mass`: mass(radius) parameters (`ParticleMass`)
+- `ρq`: prognostic mass density field for the species [kg/m³]
+- `reference_density`: air density field [kg/m³]
+"""
+struct NumberConcentrationKernelFunction{P, M, Q, R}
+    pdf :: P
+    mass :: M
+    ρq :: Q
+    reference_density :: R
+end
+
+Utils.prettysummary(::NumberConcentrationKernelFunction) = "NumberConcentrationKernelFunction"
+
+Adapt.adapt_structure(to, k::NumberConcentrationKernelFunction) =
+    NumberConcentrationKernelFunction(adapt(to, k.pdf),
+                                      adapt(to, k.mass),
+                                      adapt(to, k.ρq),
+                                      adapt(to, k.reference_density))
+
+const NumberConcentrationOp = KernelFunctionOperation{C, C, C, <:Any, <:Any, <:NumberConcentrationKernelFunction}
+
+"""
+$(TYPEDSIGNATURES)
+
+Lazy diagnostic returning the total number concentration ``ρnˣ`` (m⁻³) for the
+requested `species`.
+
+For `OneMomentCloudMicrophysics`, `species ∈ (:rain, :snow)` returns a
+`KernelFunctionOperation` that computes ``n_0 \\, λ^{-1}`` from the prognostic
+``ρqˣ`` and the scheme's size distribution. Snow's intercept ``n_0`` depends on
+``(q, ρ)`` per [Kaul et al. (2015)](@cite Kaul2015) — so this diagnostic stays
+consistent with the scheme's actual DSD without re-encoding species-specific
+physics at every call site.
+
+For `TwoMomentCloudMicrophysics`, returns the prognostic ``ρnˣ`` field directly
+(e.g., `:rain` → `ρnʳ`, `:cloud_liquid` → `ρnᶜˡ`).
+
+Returns `nothing` if the species is not carried by the model (e.g., `:hail` for
+a 1-mom scheme without hail). Errors for microphysics schemes that do not
+define a DSD-based number concentration (e.g., `SaturationAdjustment`).
+
+See [`NumberConcentrationField`](@ref) for a convenience constructor that
+wraps the result in a `Field`.
+"""
+NumberConcentration(model, species::Symbol) =
+    number_concentration(model, model.microphysics, Val(species))
+
+# Default fallback: unsupported microphysics scheme.
+number_concentration(model, microphysics, ::Val{species}) where {species} =
+    error("NumberConcentration is not defined for microphysics scheme of type ",
+          typeof(microphysics), " (species = :", species, "). ",
+          "Supported schemes: OneMomentCloudMicrophysics (species ∈ (:rain, :snow)) ",
+          "and TwoMomentCloudMicrophysics.")
+
+"""
+$(TYPEDSIGNATURES)
+
+Convenience constructor that wraps [`NumberConcentration`](@ref) in a `Field`.
+Returns `nothing` when the requested species is not carried by the model.
+"""
+function NumberConcentrationField(model, species::Symbol)
+    op = NumberConcentration(model, species)
+    op === nothing && return nothing
+    return Field(op)
+end

--- a/src/Microphysics/microphysics_diagnostics.jl
+++ b/src/Microphysics/microphysics_diagnostics.jl
@@ -229,8 +229,8 @@ define a DSD-based number concentration (e.g., `SaturationAdjustment`).
 
 The return shape is therefore polymorphic — a lazy `KernelFunctionOperation` for
 1-mom and a stored `Field` for 2-mom — so the function is snake-cased rather
-than PascalCased. Use `NumberConcentrationField` when you want a uniformly
-Field-typed handle.
+than PascalCased. Use [`NumberConcentrationField`](@ref) when you want a
+uniformly Field-typed handle.
 """
 number_concentration(model, species::Symbol) =
     number_concentration(model, model.microphysics, Val(species))
@@ -245,7 +245,7 @@ number_concentration(model, microphysics, ::Val{species}) where {species} =
 """
 $(TYPEDSIGNATURES)
 
-Field-typed handle for the `number_concentration` diagnostic. For 1-mom,
+Field-typed handle for the [`number_concentration`](@ref) diagnostic. For 1-mom,
 allocates a `Field` shell around the lazy `KernelFunctionOperation` (use
 `compute!` to populate it). For 2-mom, returns the prognostic ``ρnˣ`` field
 directly. Returns `nothing` when the requested species is not carried by the

--- a/src/Microphysics/microphysics_diagnostics.jl
+++ b/src/Microphysics/microphysics_diagnostics.jl
@@ -227,15 +227,17 @@ Returns `nothing` if the species is not carried by the model (e.g., `:hail` for
 a 1-mom scheme without hail). Errors for microphysics schemes that do not
 define a DSD-based number concentration (e.g., `SaturationAdjustment`).
 
-See [`NumberConcentrationField`](@ref) for a convenience constructor that
-wraps the result in a `Field`.
+The return shape is therefore polymorphic — a lazy `KernelFunctionOperation` for
+1-mom and a stored `Field` for 2-mom — so the function is snake-cased rather
+than PascalCased. Use [`NumberConcentrationField`](@ref) when you want a
+uniformly Field-typed handle.
 """
-NumberConcentration(model, species::Symbol) =
+number_concentration(model, species::Symbol) =
     number_concentration(model, model.microphysics, Val(species))
 
 # Default fallback: unsupported microphysics scheme.
 number_concentration(model, microphysics, ::Val{species}) where {species} =
-    error("NumberConcentration is not defined for microphysics scheme of type ",
+    error("number_concentration is not defined for microphysics scheme of type ",
           typeof(microphysics), " (species = :", species, "). ",
           "Supported schemes: OneMomentCloudMicrophysics (species ∈ (:rain, :snow)) ",
           "and TwoMomentCloudMicrophysics.")
@@ -243,11 +245,15 @@ number_concentration(model, microphysics, ::Val{species}) where {species} =
 """
 $(TYPEDSIGNATURES)
 
-Convenience constructor that wraps [`NumberConcentration`](@ref) in a `Field`.
-Returns `nothing` when the requested species is not carried by the model.
+Field-typed handle for the [`number_concentration`](@ref) diagnostic. For 1-mom,
+allocates a `Field` shell around the lazy `KernelFunctionOperation` (use
+`compute!` to populate it). For 2-mom, returns the prognostic ``ρnˣ`` field
+directly. Returns `nothing` when the requested species is not carried by the
+model.
 """
 function NumberConcentrationField(model, species::Symbol)
-    op = NumberConcentration(model, species)
-    op === nothing && return nothing
-    return Field(op)
+    result = number_concentration(model, species)
+    result === nothing && return nothing
+    result isa Field && return result
+    return Field(result)
 end

--- a/src/Microphysics/microphysics_diagnostics.jl
+++ b/src/Microphysics/microphysics_diagnostics.jl
@@ -229,7 +229,7 @@ define a DSD-based number concentration (e.g., `SaturationAdjustment`).
 
 The return shape is therefore polymorphic — a lazy `KernelFunctionOperation` for
 1-mom and a stored `Field` for 2-mom — so the function is snake-cased rather
-than PascalCased. Use [`NumberConcentrationField`](@ref) when you want a
+than PascalCased. Use [`number_concentration_field`](@ref) when you want a
 uniformly Field-typed handle.
 """
 number_concentration(model, species::Symbol) =
@@ -251,7 +251,7 @@ allocates a `Field` shell around the lazy `KernelFunctionOperation` (use
 directly. Returns `nothing` when the requested species is not carried by the
 model.
 """
-function NumberConcentrationField(model, species::Symbol)
+function number_concentration_field(model, species::Symbol)
     result = number_concentration(model, species)
     result === nothing && return nothing
     result isa Field && return result

--- a/src/Microphysics/microphysics_diagnostics.jl
+++ b/src/Microphysics/microphysics_diagnostics.jl
@@ -229,8 +229,8 @@ define a DSD-based number concentration (e.g., `SaturationAdjustment`).
 
 The return shape is therefore polymorphic — a lazy `KernelFunctionOperation` for
 1-mom and a stored `Field` for 2-mom — so the function is snake-cased rather
-than PascalCased. Use [`NumberConcentrationField`](@ref) when you want a
-uniformly Field-typed handle.
+than PascalCased. Use `NumberConcentrationField` when you want a uniformly
+Field-typed handle.
 """
 number_concentration(model, species::Symbol) =
     number_concentration(model, model.microphysics, Val(species))
@@ -245,7 +245,7 @@ number_concentration(model, microphysics, ::Val{species}) where {species} =
 """
 $(TYPEDSIGNATURES)
 
-Field-typed handle for the [`number_concentration`](@ref) diagnostic. For 1-mom,
+Field-typed handle for the `number_concentration` diagnostic. For 1-mom,
 allocates a `Field` shell around the lazy `KernelFunctionOperation` (use
 `compute!` to populate it). For 2-mom, returns the prognostic ``ρnˣ`` field
 directly. Returns `nothing` when the requested species is not carried by the

--- a/test/number_concentration.jl
+++ b/test/number_concentration.jl
@@ -44,8 +44,8 @@ using .BreezeCloudMicrophysicsExt: OneMomentCloudMicrophysics, TwoMomentCloudMic
 
     @test @allowscalar isapprox(ρnʳ[1, 1, 1], expected, rtol=100eps(FT))
 
-    # NumberConcentrationField convenience wrapper.
-    ρnʳ_field = NumberConcentrationField(model, :rain)
+    # number_concentration_field convenience wrapper.
+    ρnʳ_field = number_concentration_field(model, :rain)
     @test ρnʳ_field isa Field
     compute!(ρnʳ_field)
     @test @allowscalar isapprox(ρnʳ_field[1, 1, 1], expected, rtol=100eps(FT))
@@ -100,7 +100,7 @@ end
     @test number_concentration(model, :hail) === nothing
     @test number_concentration(model, :graupel) === nothing
     @test number_concentration(model, :snow) === nothing
-    @test NumberConcentrationField(model, :hail) === nothing
+    @test number_concentration_field(model, :hail) === nothing
 end
 
 @testset "NumberConcentration: two-moment returns prognostic field [$FT]" for FT in test_float_types()
@@ -129,5 +129,5 @@ end
     model = AtmosphereModel(grid; microphysics)
 
     @test_throws ErrorException number_concentration(model, :rain)
-    @test_throws ErrorException NumberConcentrationField(model, :rain)
+    @test_throws ErrorException number_concentration_field(model, :rain)
 end

--- a/test/number_concentration.jl
+++ b/test/number_concentration.jl
@@ -1,0 +1,133 @@
+using Test
+using Breeze
+using CloudMicrophysics
+using CloudMicrophysics.Microphysics1M: get_n0, lambda_inverse
+using CloudMicrophysics.Parameters: CloudLiquid, CloudIce
+using GPUArraysCore: @allowscalar
+using Oceananigans
+
+BreezeCloudMicrophysicsExt = Base.get_extension(Breeze, :BreezeCloudMicrophysicsExt)
+using .BreezeCloudMicrophysicsExt: OneMomentCloudMicrophysics, TwoMomentCloudMicrophysics
+
+#####
+##### Number concentration diagnostic
+#####
+
+@testset "NumberConcentration: one-moment rain [$FT]" for FT in test_float_types()
+    Oceananigans.defaults.FloatType = FT
+    grid = RectilinearGrid(default_arch; size=(2, 2, 2), x=(0, 100), y=(0, 100), z=(0, 100))
+
+    constants = ThermodynamicConstants()
+    reference_state = ReferenceState(grid, constants, surface_pressure=101325, potential_temperature=300)
+    dynamics = AnelasticDynamics(reference_state)
+
+    microphysics = OneMomentCloudMicrophysics()
+    model = AtmosphereModel(grid; dynamics, thermodynamic_constants=constants, microphysics)
+
+    qʳ_value = FT(1e-3)
+    set!(model; θ=300, qᵗ=FT(0.020), qᶜˡ=FT(0), qʳ=qʳ_value)
+
+    op = NumberConcentration(model, :rain)
+    @test op isa Oceananigans.AbstractOperations.KernelFunctionOperation
+
+    ρnʳ = Field(op)
+    compute!(ρnʳ)
+    @test all(isfinite.(interior(ρnʳ)))
+
+    # Compare with n0 · λ⁻¹ computed directly from the scheme's DSD.
+    rain = microphysics.categories.rain
+    ρ = @allowscalar reference_state.density[1, 1, 1]
+    q = qʳ_value
+    n0 = get_n0(rain.pdf, q, ρ)
+    λ⁻¹ = lambda_inverse(rain.pdf, rain.mass, q, ρ)
+    expected = n0 * λ⁻¹
+
+    @test @allowscalar isapprox(ρnʳ[1, 1, 1], expected, rtol=100eps(FT))
+
+    # NumberConcentrationField convenience wrapper.
+    ρnʳ_field = NumberConcentrationField(model, :rain)
+    @test ρnʳ_field isa Field
+    compute!(ρnʳ_field)
+    @test @allowscalar isapprox(ρnʳ_field[1, 1, 1], expected, rtol=100eps(FT))
+end
+
+@testset "NumberConcentration: one-moment snow (mixed phase) [$FT]" for FT in test_float_types()
+    Oceananigans.defaults.FloatType = FT
+    grid = RectilinearGrid(default_arch; size=(2, 2, 2), x=(0, 100), y=(0, 100), z=(0, 100))
+
+    constants = ThermodynamicConstants()
+    reference_state = ReferenceState(grid, constants, surface_pressure=101325, potential_temperature=260)
+    dynamics = AnelasticDynamics(reference_state)
+
+    cloud_formation = NonEquilibriumCloudFormation(CloudLiquid(FT), CloudIce(FT))
+    microphysics = OneMomentCloudMicrophysics(FT; cloud_formation)
+    model = AtmosphereModel(grid; dynamics, thermodynamic_constants=constants, microphysics)
+
+    qˢ_value = FT(5e-4)
+    set!(model; θ=260, qᵗ=FT(0.005), qˢ=qˢ_value)
+
+    op = NumberConcentration(model, :snow)
+    @test op isa Oceananigans.AbstractOperations.KernelFunctionOperation
+
+    ρnˢ = Field(op)
+    compute!(ρnˢ)
+    @test all(isfinite.(interior(ρnˢ)))
+
+    # Snow's n₀ depends on (q, ρ), so the closed-form rain expression cannot
+    # substitute. Compare against CloudMicrophysics directly.
+    snow = microphysics.categories.snow
+    ρ = @allowscalar reference_state.density[1, 1, 1]
+    q = qˢ_value
+    n0 = get_n0(snow.pdf, q, ρ)
+    λ⁻¹ = lambda_inverse(snow.pdf, snow.mass, q, ρ)
+    expected = n0 * λ⁻¹
+
+    @test @allowscalar isapprox(ρnˢ[1, 1, 1], expected, rtol=100eps(FT))
+end
+
+@testset "NumberConcentration: unsupported species returns nothing [$FT]" for FT in test_float_types()
+    Oceananigans.defaults.FloatType = FT
+    grid = RectilinearGrid(default_arch; size=(2, 2, 2), x=(0, 100), y=(0, 100), z=(0, 100))
+
+    constants = ThermodynamicConstants()
+    reference_state = ReferenceState(grid, constants, surface_pressure=101325, potential_temperature=300)
+    dynamics = AnelasticDynamics(reference_state)
+
+    # Warm-phase 1-mom carries rain but not snow, hail, or graupel.
+    microphysics = OneMomentCloudMicrophysics()
+    model = AtmosphereModel(grid; dynamics, thermodynamic_constants=constants, microphysics)
+
+    @test NumberConcentration(model, :hail) === nothing
+    @test NumberConcentration(model, :graupel) === nothing
+    @test NumberConcentration(model, :snow) === nothing
+    @test NumberConcentrationField(model, :hail) === nothing
+end
+
+@testset "NumberConcentration: two-moment returns prognostic field [$FT]" for FT in test_float_types()
+    Oceananigans.defaults.FloatType = FT
+    grid = RectilinearGrid(default_arch; size=(2, 2, 2), x=(0, 100), y=(0, 100), z=(0, 100))
+
+    constants = ThermodynamicConstants()
+    reference_state = ReferenceState(grid, constants, surface_pressure=101325, potential_temperature=300)
+    dynamics = AnelasticDynamics(reference_state)
+
+    microphysics = TwoMomentCloudMicrophysics()
+    model = AtmosphereModel(grid; dynamics, thermodynamic_constants=constants, microphysics)
+
+    set!(model; θ=300, qᵗ=FT(0.015))
+
+    @test NumberConcentration(model, :rain) === model.microphysical_fields.ρnʳ
+    @test NumberConcentration(model, :cloud_liquid) === model.microphysical_fields.ρnᶜˡ
+    @test NumberConcentration(model, :snow) === nothing
+end
+
+@testset "NumberConcentration: SaturationAdjustment errors [$FT]" for FT in test_float_types()
+    Oceananigans.defaults.FloatType = FT
+    grid = RectilinearGrid(default_arch; size=(2, 2, 2), x=(0, 100), y=(0, 100), z=(0, 100))
+
+    microphysics = SaturationAdjustment()
+    model = AtmosphereModel(grid; microphysics)
+
+    @test_throws ErrorException NumberConcentration(model, :rain)
+    @test_throws ErrorException NumberConcentrationField(model, :rain)
+end

--- a/test/number_concentration.jl
+++ b/test/number_concentration.jl
@@ -27,7 +27,7 @@ using .BreezeCloudMicrophysicsExt: OneMomentCloudMicrophysics, TwoMomentCloudMic
     qʳ_value = FT(1e-3)
     set!(model; θ=300, qᵗ=FT(0.020), qᶜˡ=FT(0), qʳ=qʳ_value)
 
-    op = NumberConcentration(model, :rain)
+    op = number_concentration(model, :rain)
     @test op isa Oceananigans.AbstractOperations.KernelFunctionOperation
 
     ρnʳ = Field(op)
@@ -66,7 +66,7 @@ end
     qˢ_value = FT(5e-4)
     set!(model; θ=260, qᵗ=FT(0.005), qˢ=qˢ_value)
 
-    op = NumberConcentration(model, :snow)
+    op = number_concentration(model, :snow)
     @test op isa Oceananigans.AbstractOperations.KernelFunctionOperation
 
     ρnˢ = Field(op)
@@ -97,9 +97,9 @@ end
     microphysics = OneMomentCloudMicrophysics()
     model = AtmosphereModel(grid; dynamics, thermodynamic_constants=constants, microphysics)
 
-    @test NumberConcentration(model, :hail) === nothing
-    @test NumberConcentration(model, :graupel) === nothing
-    @test NumberConcentration(model, :snow) === nothing
+    @test number_concentration(model, :hail) === nothing
+    @test number_concentration(model, :graupel) === nothing
+    @test number_concentration(model, :snow) === nothing
     @test NumberConcentrationField(model, :hail) === nothing
 end
 
@@ -116,9 +116,9 @@ end
 
     set!(model; θ=300, qᵗ=FT(0.015))
 
-    @test NumberConcentration(model, :rain) === model.microphysical_fields.ρnʳ
-    @test NumberConcentration(model, :cloud_liquid) === model.microphysical_fields.ρnᶜˡ
-    @test NumberConcentration(model, :snow) === nothing
+    @test number_concentration(model, :rain) === model.microphysical_fields.ρnʳ
+    @test number_concentration(model, :cloud_liquid) === model.microphysical_fields.ρnᶜˡ
+    @test number_concentration(model, :snow) === nothing
 end
 
 @testset "NumberConcentration: SaturationAdjustment errors [$FT]" for FT in test_float_types()
@@ -128,6 +128,6 @@ end
     microphysics = SaturationAdjustment()
     model = AtmosphereModel(grid; microphysics)
 
-    @test_throws ErrorException NumberConcentration(model, :rain)
+    @test_throws ErrorException number_concentration(model, :rain)
     @test_throws ErrorException NumberConcentrationField(model, :rain)
 end


### PR DESCRIPTION
## Summary

- Add `number_concentration(model, species)` and `number_concentration_field(model, species)` — a lazy diagnostic exposing total number concentration ρnˣ uniformly across 1-mom and 2-mom microphysics.
- For `OneMomentCloudMicrophysics`, build a `KernelFunctionOperation` over a new `NumberConcentrationKernelFunction` that computes `n₀ · λ⁻¹` directly from the scheme's `pdf` and `mass`. This routes through `get_n0` / `lambda_inverse` so snow uses Kaul et al.'s `(q, ρ)`-dependent intercept rather than a rain-style closed form.
- For `TwoMomentCloudMicrophysics`, return the prognostic `ρnˣ` field directly (e.g., `:rain` → `ρnʳ`, `:cloud_liquid` → `ρnᶜˡ`).
- Return `nothing` for species not carried by the scheme (e.g., `:hail`); error for microphysics without a DSD-based ρnˣ (e.g., `SaturationAdjustment`).
- Follows the `RelativeHumidity` pattern in `src/Microphysics/microphysics_diagnostics.jl`.

Closes #710.

## Test plan

- [x] `test/number_concentration.jl`:
  - 1-mom warm-phase NE rain matches `n₀ · λ⁻¹` to machine precision (compared against `CloudMicrophysics.Microphysics1M.get_n0`/`lambda_inverse`).
  - 1-mom mixed-phase NE snow matches `n₀ · λ⁻¹` — the case where the snow PDF's `(q, ρ)` dependence matters.
  - 1-mom species not in scheme (`:hail`, `:graupel`, warm-phase `:snow`) returns `nothing`.
  - 2-mom returns the prognostic `ρnʳ` / `ρnᶜˡ` field directly.
  - `SaturationAdjustment` errors with a clear message.
  - `number_concentration_field` convenience wrapper.
- [x] `quality_assurance` (explicit imports, Aqua) passes.
- [x] Existing `diagnostics` tests pass.
- [x] `doctests` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)