### PR TITLE
Recursively test for type piracy

### DIFF
--- a/src/BoundaryConditions/polynomial_bulk_coefficient.jl
+++ b/src/BoundaryConditions/polynomial_bulk_coefficient.jl
@@ -502,7 +502,6 @@ end
 
 Base.summary(coef::PolynomialCoefficient) =
     string("PolynomialCoefficient(", coef.polynomial, ")")
-Base.summary(::Nothing) = "Nothing"
 
 #####
 ##### Neutral coefficient computation (Large & Yeager 2009 form)

--- a/test/quality_assurance.jl
+++ b/test/quality_assurance.jl
@@ -36,7 +36,8 @@ function walk_submodules!(result, visited, mod::Module)
         end
     end
 end
-function get_submodules(mod::Module)
+function get_submodules(mod::Module; self=true)
+    result = self ? Module[mod] : Module[]
     result = Module[]
     visited = Set{Module}()
 

--- a/test/quality_assurance.jl
+++ b/test/quality_assurance.jl
@@ -20,8 +20,37 @@ else
     ()
 end
 
+# Copy from `docs/make.jl`, where we also need to find all submodules of a given module.
+function walk_submodules!(result, visited, mod::Module)
+    for name in sort(names(mod; all=true, imported=false))
+        isdefined(mod, name) || continue
+        value = getproperty(mod, name)
+        if value isa Module &&
+            parentmodule(value) === mod &&
+            !(value in visited) &&
+            value !== mod
+
+            push!(visited, value)
+            push!(result, value)
+            walk_submodules!(result, visited, value)
+        end
+    end
+end
+function get_submodules(mod::Module)
+    result = Module[]
+    visited = Set{Module}()
+
+    walk_submodules!(result, visited, mod)
+    return result
+end
+
 @testset "Aqua" begin
-    Aqua.test_all(Breeze)
+    Aqua.test_all(Breeze; piracies=false)
+
+    # `test_piracies` doesn't recurse in inner modules, so we have to test that manually.
+    @testset "No type piracy in $(mod)" for mod in get_submodules(Breeze)
+        Aqua.test_piracies(mod)
+    end
 end
 
 @testset "ExplicitImports" begin


### PR DESCRIPTION
Ref: https://github.com/NumericalEarth/Breeze.jl/pull/395#discussion_r3255465678.  This detected an existing type piracy (which is also useless because it does the same as what `Base` would do anyway)