### PR TITLE
Fix definition of `get_submodules` in tests

### DIFF
--- a/test/quality_assurance.jl
+++ b/test/quality_assurance.jl
@@ -38,7 +38,6 @@ function walk_submodules!(result, visited, mod::Module)
 end
 function get_submodules(mod::Module; self=true)
     result = self ? Module[mod] : Module[]
-    result = Module[]
     visited = Set{Module}()
 
     walk_submodules!(result, visited, mod)


### PR DESCRIPTION
`result` was defined twice, the second time incorrectly.