### PR TITLE
Support backward integration in split-explicit acoustic substepping

### DIFF
--- a/src/CompressibleEquations/acoustic_substepping.jl
+++ b/src/CompressibleEquations/acoustic_substepping.jl
@@ -489,7 +489,7 @@ acoustic CFL:
 
 ```math
 N \\approx
-\\left\\lceil \\frac{\\Delta t \\, \\mathbb{C}^{ac}}{\\nu \\, \\Delta x_\\min} \\right\\rceil ,
+\\left\\lceil \\frac{|\\Delta t| \\, \\mathbb{C}^{ac}}{\\nu \\, \\Delta x_\\min} \\right\\rceil ,
 ```
 
 with ``\\mathbb{C}^{ac} = \\sqrt{γ^d R^d T_r}`` for a nominal reference
@@ -512,7 +512,7 @@ function compute_acoustic_substeps(grid, Δt, thermodynamic_constants, acoustic_
         min(Δx, Δy)
     end
 
-    return max(1, ceil(Int, FT(Δt) * ℂᵃᶜ / (ν * Δx_min)))
+    return max(1, ceil(Int, abs(FT(Δt)) * ℂᵃᶜ / (ν * Δx_min)))
 end
 
 @inline acoustic_substeps(N::Int, grid, Δt, constants, acoustic_cfl) = N
@@ -647,15 +647,22 @@ end
 # Implicit upper Rayleigh sponge contribution to the column tridiag's
 # diagonal. Klemp, Dudhia & Hassiotis (2008): a layer of thickness `depth`
 # below the lid where ``(ρw)′`` is damped at peak rate `damping_rate` (1/s)
-# scaled by the configured ramp shape. CN-weighted: `δτᵐ⁺ × rate × ramp`
-# on the LHS diagonal, matched by `δτˢ⁻ × rate × ramp × ρw_old` subtracted
+# scaled by the configured ramp shape. CN-weighted: `|δτᵐ⁺| × rate × ramp`
+# on the LHS diagonal, matched by `|δτˢ⁻| × rate × ramp × ρw_old` subtracted
 # on the RHS in `_build_predictors_and_vertical_rhs!`. Local in z, so no
 # off-diagonal coupling.
+#
+# `|δτ|` rather than `δτ` so the sponge acts as a one-sided dissipative
+# regularizer in either integration direction (Δt > 0 or Δt < 0). The
+# tradeoff: backward integration through a sponge layer does not exactly
+# invert the forward integration there, since the sponge is intentionally
+# irreversible. Outside the sponge layer the ramp vanishes and the column
+# tridiag is unaffected.
 @inline sponge_term_diag(i, j, k, grid, ::Nothing, δτᵐ⁺) = zero(grid)
 
 @inline function sponge_term_diag(i, j, k, grid, sponge::UpperSponge, δτᵐ⁺)
     z = znode(i, j, k, grid, Center(), Center(), Face())
-    return δτᵐ⁺ * sponge.damping_rate *
+    return abs(δτᵐ⁺) * sponge.damping_rate *
            sponge.ramp(z, grid.Lz, sponge.depth)
 end
 
@@ -663,7 +670,7 @@ end
 
 @inline function sponge_rhs(i, j, k, grid, sponge::UpperSponge, δτˢ⁻, ρw_old)
     z = znode(i, j, k, grid, Center(), Center(), Face())
-    @inbounds return δτˢ⁻ * sponge.damping_rate *
+    @inbounds return abs(δτˢ⁻) * sponge.damping_rate *
                      sponge.ramp(z, grid.Lz, sponge.depth) * ρw_old[i, j, k]
 end
 

--- a/src/CompressibleEquations/time_discretizations.jl
+++ b/src/CompressibleEquations/time_discretizations.jl
@@ -295,6 +295,20 @@ Fields
 - `substep_distribution`: How acoustic substeps are distributed across the
   three WS-RK3 stages.
 
+# Backward integration
+
+Backward integration (`Δt < 0`) is supported. The off-centered
+Crank–Nicolson vertical solve with ``ω ∈ [0.5, 1]`` has amplification
+factor ``|A|^2 = (1 + ((1-ω) ω_0 Δτ)^2) / (1 + (ω ω_0 Δτ)^2) \\le 1``
+for either sign of ``Δτ``, so the linearized acoustic substep is A-stable
+in both directions. Horizontal divergence damping is sign-self-consistent
+(``γ \\propto Δτ^{-1}`` and ``(ρθ)' - (ρθ)'_\\mathrm{old} \\propto Δτ``
+both flip sign with `Δt`). The adaptive substep count uses ``|Δt|``, and
+the optional [`UpperSponge`](@ref) keeps its dissipative sign so it acts
+as a one-sided regularizer in both directions (i.e. backward integration
+through a sponge layer is stable but not an exact inverse of the forward
+step inside the sponge).
+
 See also [`ExplicitTimeStepping`](@ref).
 """
 convert_acoustic_parameter(::Type{FT}, damping::NoDivergenceDamping) where FT = damping
@@ -449,6 +463,12 @@ number of acoustic substeps, a `forward_weight` for off-centering the acoustic
 solve, an acoustic `damping` strategy such as
 [`ThermalDivergenceDamping`](@ref), an optional [`UpperSponge`](@ref), and a
 `substep_distribution` such as [`ProportionalSubsteps`](@ref).
+
+Backward integration (`time_step!(model, Δt)` with `Δt < 0`) is supported
+for the linearized acoustic substep loop. See the field-documentation
+docstring for the A-stability argument, sign-handling of the adaptive
+substep count, and the irreversibility caveat for the optional
+[`UpperSponge`](@ref).
 """
 struct SplitExplicitTimeDiscretization{N, FT, D, US, AD <: AcousticSubstepDistribution}
     substeps :: N

--- a/test/acoustic_substepping.jl
+++ b/test/acoustic_substepping.jl
@@ -256,6 +256,15 @@ for arch in arches
             @test N_loose  == ceil(Int, 12 * sqrt(1.4 * 287.0 * 300) / (1.0  * 1000))
             @test N_strict > N_default > N_loose
         end
+
+        @testset "Backward Δt yields same substep count" begin
+            grid = RectilinearGrid(arch; size=(100, 6, 10), halo=(5, 5, 5),
+                                   x=(0, 100kilometers), y=(0, 6kilometers), z=(0, 10kilometers))
+            N_fwd = compute_acoustic_substeps(grid, +12, constants, ν)
+            N_bwd = compute_acoustic_substeps(grid, -12, constants, ν)
+            @test N_fwd ≥ 1
+            @test N_bwd == N_fwd
+        end
     end
 
     @testset "acoustic_cfl plumbed to AcousticSubstepper [$(arch), $(FT)]" for FT in as_test_float_types(arch)
@@ -337,6 +346,62 @@ for arch in arches
         @test !any(isnan, parent(model.momentum.ρu))
         @test !any(isnan, parent(model.momentum.ρw))
         @test !any(isnan, parent(model.dynamics.density))
+    end
+
+    #####
+    ##### Backward integration: one step forward, one step back
+    #####
+    ##### A coarse sanity test that `time_step!(model, -Δt)` does not blow
+    ##### up and produces a state close to the initial one. Exact
+    ##### reversibility is not expected: off-centered Crank–Nicolson, the
+    ##### Klemp 2018 horizontal divergence damping, and WENO upwinding in
+    ##### the slow tendency all introduce one-sided dissipation. We only
+    ##### check that the round-trip stays bounded and finite.
+    #####
+
+    @testset "Backward integration: one step forward and back [$(arch), $(FT)]" for FT in as_test_float_types(arch)
+        Oceananigans.defaults.FloatType = FT
+        grid = RectilinearGrid(arch; size=(8, 8, 8), halo=(5, 5, 5),
+                               x=(0, 8kilometers), y=(0, 8kilometers), z=(0, 8kilometers))
+
+        dynamics = CompressibleDynamics(SplitExplicitTimeDiscretization();
+                                        reference_potential_temperature=300)
+        model = AtmosphereModel(grid; advection=WENO(), dynamics,
+                                timestepper=:AcousticRungeKutta3)
+
+        ref = model.dynamics.reference_state
+        # Small smooth θ anomaly so the forward step produces non-trivial
+        # dynamics; the reverse step is what the new code path exercises.
+        Lz = grid.Lz
+        θ₀(x, y, z) = FT(300) + FT(0.1) * sin(π * z / Lz)
+        set!(model; θ=θ₀, u=0, qᵗ=0, ρ=ref.density)
+
+        ρ_init  = Array(parent(model.dynamics.density))
+        ρu_init = Array(parent(model.momentum.ρu))
+        ρw_init = Array(parent(model.momentum.ρw))
+
+        Δt = FT(6)
+        time_step!(model, +Δt)
+        time_step!(model, -Δt)
+
+        # Clock counts both steps but net time returns to zero.
+        @test model.clock.iteration == 2
+        @test model.clock.time ≈ 0 atol=sqrt(eps(FT))
+
+        # Doesn't blow up.
+        for field in (model.dynamics.density, model.momentum.ρu, model.momentum.ρw)
+            @test !any(isnan, parent(field))
+            @test !any(isinf, parent(field))
+        end
+
+        # "Random notion of error" — generous bounds; the round-trip is
+        # not exact but must stay bounded for the small perturbation.
+        ρ_final  = Array(parent(model.dynamics.density))
+        ρu_final = Array(parent(model.momentum.ρu))
+        ρw_final = Array(parent(model.momentum.ρw))
+        @test maximum(abs, ρ_final  .- ρ_init)  < 1
+        @test maximum(abs, ρu_final .- ρu_init) < 1
+        @test maximum(abs, ρw_final .- ρw_init) < 1
     end
 
     #####

--- a/test/acoustic_substepping.jl
+++ b/test/acoustic_substepping.jl
@@ -394,14 +394,16 @@ for arch in arches
             @test !any(isinf, parent(field))
         end
 
-        # "Random notion of error" — generous bounds; the round-trip is
-        # not exact but must stay bounded for the small perturbation.
+        # Round-trip is dissipative but tight: residuals are orders of
+        # magnitude smaller than the disturbance produced by the forward step.
+        # Use a relative tolerance for ρ (which has a meaningful baseline)
+        # and an absolute tolerance for ρu, ρw (which start from rest).
         ρ_final  = Array(parent(model.dynamics.density))
         ρu_final = Array(parent(model.momentum.ρu))
         ρw_final = Array(parent(model.momentum.ρw))
-        @test maximum(abs, ρ_final  .- ρ_init)  < 1
-        @test maximum(abs, ρu_final .- ρu_init) < 1
-        @test maximum(abs, ρw_final .- ρw_init) < 1
+        @test isapprox(ρ_final,  ρ_init;  rtol=1e-3)
+        @test isapprox(ρu_final, ρu_init; atol=1e-3)
+        @test isapprox(ρw_final, ρw_init; atol=1e-3)
     end
 
     #####


### PR DESCRIPTION
## Summary

- Use `|Δt|` for the adaptive acoustic substep count in `compute_acoustic_substeps`, so the count stays positive when `Δt < 0`.
- Use `|δτ|` in the `UpperSponge` LHS-diagonal and RHS contributions so the sponge stays dissipative regardless of integration direction (one-sided regularizer; backward integration through a sponge layer is stable but not an exact inverse of the forward step inside the sponge).
- Document backward integration support on `SplitExplicitTimeDiscretization`: the A-stability argument for the off-centered CN vertical solve (``|A|^2 \le 1`` for either sign of ``Δτ``), the sign-self-consistency of horizontal divergence damping, and the sponge irreversibility caveat.

No behavior change for `Δt > 0`.

## Test plan

- [ ] Forward-only regression: existing CompressibleEquations tests still pass (substep count, sponge tridiag).
- [ ] Backward step smoke test: integrate a smooth state forward then backward with `Δt → -Δt` and confirm acoustic substep loop runs without NaNs and recovers the initial state outside any sponge layer to acoustic-truncation accuracy.
- [ ] Sponge-on backward test: confirm stability (no blow-up) when integrating backward through a configured `UpperSponge`, and that the in-sponge state is damped (not amplified).
- [ ] Doctests / docs build pass with the new docstring sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)