### PR TITLE
[CI] Run default anelastic benchmarks for longer

### DIFF
--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -42,7 +42,7 @@ jobs:
             advection: 'WENO5, WENO9'
             backend: 'vanilla'
             topology: 'PPB'
-            extra_flags: '--warmup_steps 5 --time_steps 100'
+            extra_flags: '--warmup_steps 5 --time_steps 160'
           - dynamics: 'compressible_splitexplicit'
             microphysics: 'nothing'
             grid: '512x512x256'

--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -42,7 +42,7 @@ jobs:
             advection: 'WENO5, WENO9'
             backend: 'vanilla'
             topology: 'PPB'
-            extra_flags: ''
+            extra_flags: '--warmup_steps 5 --time_steps 100'
           - dynamics: 'compressible_splitexplicit'
             microphysics: 'nothing'
             grid: '512x512x256'

--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -42,7 +42,7 @@ jobs:
             advection: 'WENO5, WENO9'
             backend: 'vanilla'
             topology: 'PPB'
-            extra_flags: '--warmup_steps 5 --time_steps 160'
+            extra_flags: '--warmup_steps 5 --time_steps 150'
           - dynamics: 'compressible_splitexplicit'
             microphysics: 'nothing'
             grid: '512x512x256'


### PR DESCRIPTION
I'm wondering if this will help with https://github.com/NumericalEarth/Breeze.jl/pull/718#issuecomment-4482873293 (but it'll be hard to tell with a single run)