### PR TITLE
Propagate momentum open boundary conditions to derived velocities

### DIFF
--- a/src/AnelasticEquations/AnelasticEquations.jl
+++ b/src/AnelasticEquations/AnelasticEquations.jl
@@ -26,7 +26,7 @@ using Oceananigans: Oceananigans, CenterField, XFaceField, YFaceField, ZFaceFiel
 using Oceananigans.Architectures: architecture
 using Oceananigans.BoundaryConditions: FieldBoundaryConditions, regularize_field_boundary_conditions, fill_halo_regions!
 using Oceananigans.Fields: set!
-using Oceananigans.Grids: ZDirection, inactive_cell
+using Oceananigans.Grids: ZDirection, inactive_cell, Bounded, topology
 using Oceananigans.ImmersedBoundaries: mask_immersed_field!
 using Oceananigans.Operators: Δzᵃᵃᶜ, Δzᵃᵃᶠ, divᶜᶜᶜ, Δzᶜᶜᶜ, ℑzᵃᵃᶠ, ∂xᶠᶜᶜ, ∂yᶜᶠᶜ, ∂zᶜᶜᶠ
 using Oceananigans.Solvers: Solvers, solve!, FourierTridiagonalPoissonSolver, AbstractHomogeneousNeumannFormulation

--- a/src/AnelasticEquations/AnelasticEquations.jl
+++ b/src/AnelasticEquations/AnelasticEquations.jl
@@ -26,7 +26,7 @@ using Oceananigans: Oceananigans, CenterField, XFaceField, YFaceField, ZFaceFiel
 using Oceananigans.Architectures: architecture
 using Oceananigans.BoundaryConditions: FieldBoundaryConditions, regularize_field_boundary_conditions, fill_halo_regions!
 using Oceananigans.Fields: set!
-using Oceananigans.Grids: ZDirection, inactive_cell, Bounded, topology
+using Oceananigans.Grids: ZDirection, inactive_cell
 using Oceananigans.ImmersedBoundaries: mask_immersed_field!
 using Oceananigans.Operators: Δzᵃᵃᶜ, Δzᵃᵃᶠ, divᶜᶜᶜ, Δzᶜᶜᶜ, ℑzᵃᵃᶠ, ∂xᶠᶜᶜ, ∂yᶜᶠᶜ, ∂zᶜᶜᶠ
 using Oceananigans.Solvers: Solvers, solve!, FourierTridiagonalPoissonSolver, AbstractHomogeneousNeumannFormulation

--- a/src/AnelasticEquations/AnelasticEquations.jl
+++ b/src/AnelasticEquations/AnelasticEquations.jl
@@ -24,7 +24,7 @@ using KernelAbstractions: @kernel, @index
 
 using Oceananigans: Oceananigans, CenterField, XFaceField, YFaceField, ZFaceField, fields
 using Oceananigans.Architectures: architecture
-using Oceananigans.BoundaryConditions: FieldBoundaryConditions, regularize_field_boundary_conditions, fill_halo_regions!
+using Oceananigans.BoundaryConditions: fill_halo_regions!
 using Oceananigans.Fields: set!
 using Oceananigans.Grids: ZDirection, inactive_cell
 using Oceananigans.ImmersedBoundaries: mask_immersed_field!

--- a/src/AnelasticEquations/anelastic_dynamics.jl
+++ b/src/AnelasticEquations/anelastic_dynamics.jl
@@ -158,8 +158,14 @@ function AtmosphereModels.materialize_momentum_and_velocities(dynamics::Anelasti
     ρw = ZFaceField(grid, boundary_conditions=boundary_conditions.ρw)
     momentum = (; ρu, ρv, ρw)
 
-    velocity_bcs = NamedTuple(name => FieldBoundaryConditions() for name in (:u, :v, :w))
-    velocity_bcs = regularize_field_boundary_conditions(velocity_bcs, grid, (:u, :v, :w))
+    # Velocity is diagnostic (u = ρu/ρ via compute_velocities!). On the normal-component
+    # face in a `Bounded` direction we use `nothing` so `fill_halo_regions!(velocities)`
+    # does not overwrite the kernel-computed boundary face — momentum carries the wall BC.
+    TX, TY, TZ = topology(grid)
+    u_bcs = TX === Bounded ? FieldBoundaryConditions(west=nothing,   east=nothing)  : FieldBoundaryConditions()
+    v_bcs = TY === Bounded ? FieldBoundaryConditions(south=nothing,  north=nothing) : FieldBoundaryConditions()
+    w_bcs = TZ === Bounded ? FieldBoundaryConditions(bottom=nothing, top=nothing)   : FieldBoundaryConditions()
+    velocity_bcs = regularize_field_boundary_conditions((u=u_bcs, v=v_bcs, w=w_bcs), grid, (:u, :v, :w))
     u = XFaceField(grid, boundary_conditions=velocity_bcs.u)
     v = YFaceField(grid, boundary_conditions=velocity_bcs.v)
     w = ZFaceField(grid, boundary_conditions=velocity_bcs.w)

--- a/src/AnelasticEquations/anelastic_dynamics.jl
+++ b/src/AnelasticEquations/anelastic_dynamics.jl
@@ -158,17 +158,14 @@ function AtmosphereModels.materialize_momentum_and_velocities(dynamics::Anelasti
     ρw = ZFaceField(grid, boundary_conditions=boundary_conditions.ρw)
     momentum = (; ρu, ρv, ρw)
 
-    # Velocity is diagnostic (u = ρu/ρ via compute_velocities!). On the normal-component
-    # face in a `Bounded` direction we use `nothing` so `fill_halo_regions!(velocities)`
-    # does not overwrite the kernel-computed boundary face — momentum carries the wall BC.
-    TX, TY, TZ = topology(grid)
-    u_bcs = TX === Bounded ? FieldBoundaryConditions(west=nothing,   east=nothing)  : FieldBoundaryConditions()
-    v_bcs = TY === Bounded ? FieldBoundaryConditions(south=nothing,  north=nothing) : FieldBoundaryConditions()
-    w_bcs = TZ === Bounded ? FieldBoundaryConditions(bottom=nothing, top=nothing)   : FieldBoundaryConditions()
-    velocity_bcs = regularize_field_boundary_conditions((u=u_bcs, v=v_bcs, w=w_bcs), grid, (:u, :v, :w))
-    u = XFaceField(grid, boundary_conditions=velocity_bcs.u)
-    v = YFaceField(grid, boundary_conditions=velocity_bcs.v)
-    w = ZFaceField(grid, boundary_conditions=velocity_bcs.w)
+    # Velocity is diagnostic (u = ρu/ρ via compute_velocities!). Use the auxiliary-field
+    # default BCs (`nothing` on Bounded-Face sides, Periodic on Periodic sides), which
+    # is what XFaceField gives us when constructed with no `boundary_conditions=` kwarg.
+    # `nothing` on Bounded-Face prevents `fill_halo_regions!(velocities)` from clobbering
+    # the kernel-computed boundary face — momentum carries the wall BC.
+    u = XFaceField(grid)
+    v = YFaceField(grid)
+    w = ZFaceField(grid)
     velocities = (; u, v, w)
 
     return momentum, velocities

--- a/src/AtmosphereModels/update_atmosphere_model_state.jl
+++ b/src/AtmosphereModels/update_atmosphere_model_state.jl
@@ -2,7 +2,8 @@ using ..Thermodynamics: Thermodynamics, mixture_gas_constant
 
 using Oceananigans.BoundaryConditions: fill_halo_regions!, compute_x_bcs!, compute_y_bcs!, compute_z_bcs!,
                                        update_boundary_conditions!
-using Oceananigans.Grids: Flat, topology
+using Oceananigans: Face
+using Oceananigans.Grids: topology
 using Oceananigans.ImmersedBoundaries: mask_immersed_field!
 using Oceananigans.TimeSteppers: TimeSteppers
 using Oceananigans.TurbulenceClosures: compute_closure_fields!
@@ -82,15 +83,14 @@ function compute_velocities!(model::AtmosphereModel)
     fill_halo_regions!(density)
     fill_halo_regions!(model.momentum)
 
-    # Launch over `(1:Nx+1, 1:Ny+1, 1:Nz+1)` for `Bounded`/`Periodic` dims — the N+1
-    # face is the boundary face (Bounded) or a halo cell (Periodic, refilled by the
-    # trailing `fill_halo_regions!(model.velocities)`). `Flat` dims have no Face and
-    # no halo, so stay at `1:N` to avoid out-of-bounds writes.
+    # Per-dim launch size from `Base.length(::Face, ::AbstractTopology, N)`:
+    # N+1 for Bounded (covers the boundary face), N for Periodic (halo refilled by
+    # the trailing `fill_halo_regions!(model.velocities)`), N for Flat.
     Nx, Ny, Nz = size(grid)
     TX, TY, TZ = topology(grid)
-    launch!(arch, grid, KernelParameters(1:face_extent(TX, Nx),
-                                         1:face_extent(TY, Ny),
-                                         1:face_extent(TZ, Nz)),
+    launch!(arch, grid, KernelParameters(1:length(Face(), TX(), Nx),
+                                         1:length(Face(), TY(), Ny),
+                                         1:length(Face(), TZ(), Nz)),
             _compute_velocities!,
             model.velocities.u, model.velocities.v, model.velocities.w,
             model.momentum.ρu,   model.momentum.ρv,   model.momentum.ρw,
@@ -192,11 +192,6 @@ function compute_auxiliary_thermodynamic_variables!(model::AtmosphereModel)
 
     return nothing
 end
-
-# Launch range per dim: N+1 for Bounded/Periodic (covers the N+1 Face or halo cell),
-# N for Flat (no Face, no halo).
-@inline face_extent(::Type{Flat}, N) = N
-@inline face_extent(_, N) = N + 1
 
 @kernel function _compute_velocities!(u, v, w, ρu, ρv, ρw, grid, dynamics)
     i, j, k = @index(Global, NTuple)

--- a/src/AtmosphereModels/update_atmosphere_model_state.jl
+++ b/src/AtmosphereModels/update_atmosphere_model_state.jl
@@ -2,11 +2,11 @@ using ..Thermodynamics: Thermodynamics, mixture_gas_constant
 
 using Oceananigans.BoundaryConditions: fill_halo_regions!, compute_x_bcs!, compute_y_bcs!, compute_z_bcs!,
                                        update_boundary_conditions!
-using Oceananigans.Grids: Bounded, Periodic, Flat # , topology, halo_size
+using Oceananigans.Grids: Bounded, Periodic, Flat, topology # , halo_size
 using Oceananigans.ImmersedBoundaries: mask_immersed_field!
 using Oceananigans.TimeSteppers: TimeSteppers
 using Oceananigans.TurbulenceClosures: compute_closure_fields!
-using Oceananigans.Utils: launch! # , KernelParameters
+using Oceananigans.Utils: launch!, KernelParameters
 using Oceananigans.Operators: ℑxᶠᵃᵃ, ℑyᵃᶠᵃ, ℑzᵃᵃᶠ
 
 function TimeSteppers.update_state!(model::AtmosphereModel, callbacks=[]; compute_tendencies=true)
@@ -82,32 +82,27 @@ function compute_velocities!(model::AtmosphereModel)
     grid = model.grid
     arch = grid.architecture
 
-    #TODO: Better support OffsetStaticSize in KernalAbstractions
-    # For now, just use :xyz instead of KernelParameters
-    # See: https://github.com/NumericalEarth/Breeze.jl/issues/433
-
-    # TX, TY, TZ = topology(grid)
-    # Nx, Ny, Nz = size(grid)
-    # Hx, Hy, Hz = halo_size(grid)
-
-    # ii = diagnostic_indices(TX(), Nx, Hx)
-    # jj = diagnostic_indices(TY(), Ny, Hy)
-    # kk = diagnostic_indices(TZ(), Nz, Hz)
-
-    # kp = KernelParameters(ii, jj, kk)
-
     # Ensure halos are filled before velocity computation
     # (prognostic field halo fill in update_state! is async)
     density = dynamics_density(model.dynamics)
     fill_halo_regions!(density)
     fill_halo_regions!(model.momentum)
 
-    launch!(arch, grid, :xyz,
-            _compute_velocities!,
-            model.velocities,
-            grid,
-            model.dynamics,
-            model.momentum)
+    # Extend the launch to include boundary faces (i=Nx+1, j=Ny+1, k=Nz+1) in
+    # `Bounded` directions so `model.velocities` stays consistent with
+    # `model.momentum` at the wall. See `velocity_boundary_conditions_from_momentum`.
+    Nx, Ny, Nz = size(grid)
+    TX, TY, TZ = topology(grid)
+    ix_u = TX === Bounded ? (1:Nx+1) : (1:Nx)
+    jy_v = TY === Bounded ? (1:Ny+1) : (1:Ny)
+    kz_w = TZ === Bounded ? (1:Nz+1) : (1:Nz)
+
+    launch!(arch, grid, KernelParameters(ix_u, 1:Ny, 1:Nz),
+            _compute_u!, model.velocities.u, grid, model.dynamics, model.momentum.ρu)
+    launch!(arch, grid, KernelParameters(1:Nx, jy_v, 1:Nz),
+            _compute_v!, model.velocities.v, grid, model.dynamics, model.momentum.ρv)
+    launch!(arch, grid, KernelParameters(1:Nx, 1:Ny, kz_w),
+            _compute_w!, model.velocities.w, grid, model.dynamics, model.momentum.ρw)
 
     foreach(mask_immersed_field!, model.velocities)
     fill_halo_regions!(model.velocities)
@@ -206,24 +201,22 @@ function compute_auxiliary_thermodynamic_variables!(model::AtmosphereModel)
     return nothing
 end
 
-@kernel function _compute_velocities!(velocities, grid, dynamics, momentum)
+@kernel function _compute_u!(u, grid, dynamics, ρu)
     i, j, k = @index(Global, NTuple)
-
     ρ = dynamics_density(dynamics)
+    @inbounds u[i, j, k] = ρu[i, j, k] / ℑxᶠᵃᵃ(i, j, k, grid, ρ)
+end
 
-    @inbounds begin
-        ρu = momentum.ρu[i, j, k]
-        ρv = momentum.ρv[i, j, k]
-        ρw = momentum.ρw[i, j, k]
+@kernel function _compute_v!(v, grid, dynamics, ρv)
+    i, j, k = @index(Global, NTuple)
+    ρ = dynamics_density(dynamics)
+    @inbounds v[i, j, k] = ρv[i, j, k] / ℑyᵃᶠᵃ(i, j, k, grid, ρ)
+end
 
-        ρᶠᶜᶜ = ℑxᶠᵃᵃ(i, j, k, grid, ρ)
-        ρᶜᶠᶜ = ℑyᵃᶠᵃ(i, j, k, grid, ρ)
-        ρᶜᶜᶠ = ℑzᵃᵃᶠ(i, j, k, grid, ρ)
-
-        velocities.u[i, j, k] = ρu / ρᶠᶜᶜ
-        velocities.v[i, j, k] = ρv / ρᶜᶠᶜ
-        velocities.w[i, j, k] = ρw / ρᶜᶜᶠ
-    end
+@kernel function _compute_w!(w, grid, dynamics, ρw)
+    i, j, k = @index(Global, NTuple)
+    ρ = dynamics_density(dynamics)
+    @inbounds w[i, j, k] = ρw[i, j, k] / ℑzᵃᵃᶠ(i, j, k, grid, ρ)
 end
 
 @kernel function _compute_auxiliary_thermodynamic_variables!(temperature,

--- a/src/AtmosphereModels/update_atmosphere_model_state.jl
+++ b/src/AtmosphereModels/update_atmosphere_model_state.jl
@@ -2,6 +2,7 @@ using ..Thermodynamics: Thermodynamics, mixture_gas_constant
 
 using Oceananigans.BoundaryConditions: fill_halo_regions!, compute_x_bcs!, compute_y_bcs!, compute_z_bcs!,
                                        update_boundary_conditions!
+using Oceananigans.Grids: Flat, topology
 using Oceananigans.ImmersedBoundaries: mask_immersed_field!
 using Oceananigans.TimeSteppers: TimeSteppers
 using Oceananigans.TurbulenceClosures: compute_closure_fields!
@@ -81,13 +82,15 @@ function compute_velocities!(model::AtmosphereModel)
     fill_halo_regions!(density)
     fill_halo_regions!(model.momentum)
 
-    # Launch over (1:Nx+1, 1:Ny+1, 1:Nz+1) regardless of topology — for `Bounded`
-    # directions, the N+1 face is the boundary face and needs the kernel-computed
-    # value to stay consistent with momentum at the wall; for `Periodic` directions,
-    # the N+1 index writes to a halo cell that gets refilled by the trailing
-    # `fill_halo_regions!(model.velocities)` call below.
+    # Launch over `(1:Nx+1, 1:Ny+1, 1:Nz+1)` for `Bounded`/`Periodic` dims — the N+1
+    # face is the boundary face (Bounded) or a halo cell (Periodic, refilled by the
+    # trailing `fill_halo_regions!(model.velocities)`). `Flat` dims have no Face and
+    # no halo, so stay at `1:N` to avoid out-of-bounds writes.
     Nx, Ny, Nz = size(grid)
-    launch!(arch, grid, KernelParameters(1:Nx+1, 1:Ny+1, 1:Nz+1),
+    TX, TY, TZ = topology(grid)
+    launch!(arch, grid, KernelParameters(1:face_extent(TX, Nx),
+                                         1:face_extent(TY, Ny),
+                                         1:face_extent(TZ, Nz)),
             _compute_velocities!,
             model.velocities.u, model.velocities.v, model.velocities.w,
             model.momentum.ρu,   model.momentum.ρv,   model.momentum.ρw,
@@ -189,6 +192,11 @@ function compute_auxiliary_thermodynamic_variables!(model::AtmosphereModel)
 
     return nothing
 end
+
+# Launch range per dim: N+1 for Bounded/Periodic (covers the N+1 Face or halo cell),
+# N for Flat (no Face, no halo).
+@inline face_extent(::Type{Flat}, N) = N
+@inline face_extent(_, N) = N + 1
 
 @kernel function _compute_velocities!(u, v, w, ρu, ρv, ρw, grid, dynamics)
     i, j, k = @index(Global, NTuple)

--- a/src/AtmosphereModels/update_atmosphere_model_state.jl
+++ b/src/AtmosphereModels/update_atmosphere_model_state.jl
@@ -2,7 +2,6 @@ using ..Thermodynamics: Thermodynamics, mixture_gas_constant
 
 using Oceananigans.BoundaryConditions: fill_halo_regions!, compute_x_bcs!, compute_y_bcs!, compute_z_bcs!,
                                        update_boundary_conditions!
-using Oceananigans.Grids: Bounded, Periodic, Flat, topology # , halo_size
 using Oceananigans.ImmersedBoundaries: mask_immersed_field!
 using Oceananigans.TimeSteppers: TimeSteppers
 using Oceananigans.TurbulenceClosures: compute_closure_fields!
@@ -63,12 +62,6 @@ function tracer_specific_to_density!(tracers, density)
     return nothing
 end
 
-diagnostic_indices(::Bounded, N, H) = 1:N+1
-# For Periodic, start at -H+2 because face-interpolation (ℑxᶠᵃᵃ) accesses i-1.
-# Starting at -H+1 would require accessing index -H which is out of bounds.
-diagnostic_indices(::Periodic, N, H) = -H+2:N+H
-diagnostic_indices(::Flat, N, H) = 1:N
-
 #####
 ##### Velocity and momentum computation
 #####
@@ -88,21 +81,17 @@ function compute_velocities!(model::AtmosphereModel)
     fill_halo_regions!(density)
     fill_halo_regions!(model.momentum)
 
-    # Extend the launch to include boundary faces (i=Nx+1, j=Ny+1, k=Nz+1) in
-    # `Bounded` directions so `model.velocities` stays consistent with
-    # `model.momentum` at the wall. See `velocity_boundary_conditions_from_momentum`.
+    # Launch over (1:Nx+1, 1:Ny+1, 1:Nz+1) regardless of topology — for `Bounded`
+    # directions, the N+1 face is the boundary face and needs the kernel-computed
+    # value to stay consistent with momentum at the wall; for `Periodic` directions,
+    # the N+1 index writes to a halo cell that gets refilled by the trailing
+    # `fill_halo_regions!(model.velocities)` call below.
     Nx, Ny, Nz = size(grid)
-    TX, TY, TZ = topology(grid)
-    ix_u = TX === Bounded ? (1:Nx+1) : (1:Nx)
-    jy_v = TY === Bounded ? (1:Ny+1) : (1:Ny)
-    kz_w = TZ === Bounded ? (1:Nz+1) : (1:Nz)
-
-    launch!(arch, grid, KernelParameters(ix_u, 1:Ny, 1:Nz),
-            _compute_u!, model.velocities.u, grid, model.dynamics, model.momentum.ρu)
-    launch!(arch, grid, KernelParameters(1:Nx, jy_v, 1:Nz),
-            _compute_v!, model.velocities.v, grid, model.dynamics, model.momentum.ρv)
-    launch!(arch, grid, KernelParameters(1:Nx, 1:Ny, kz_w),
-            _compute_w!, model.velocities.w, grid, model.dynamics, model.momentum.ρw)
+    launch!(arch, grid, KernelParameters(1:Nx+1, 1:Ny+1, 1:Nz+1),
+            _compute_velocities!,
+            model.velocities.u, model.velocities.v, model.velocities.w,
+            model.momentum.ρu,   model.momentum.ρv,   model.momentum.ρw,
+            grid, model.dynamics)
 
     foreach(mask_immersed_field!, model.velocities)
     fill_halo_regions!(model.velocities)
@@ -201,21 +190,11 @@ function compute_auxiliary_thermodynamic_variables!(model::AtmosphereModel)
     return nothing
 end
 
-@kernel function _compute_u!(u, grid, dynamics, ρu)
+@kernel function _compute_velocities!(u, v, w, ρu, ρv, ρw, grid, dynamics)
     i, j, k = @index(Global, NTuple)
     ρ = dynamics_density(dynamics)
     @inbounds u[i, j, k] = ρu[i, j, k] / ℑxᶠᵃᵃ(i, j, k, grid, ρ)
-end
-
-@kernel function _compute_v!(v, grid, dynamics, ρv)
-    i, j, k = @index(Global, NTuple)
-    ρ = dynamics_density(dynamics)
     @inbounds v[i, j, k] = ρv[i, j, k] / ℑyᵃᶠᵃ(i, j, k, grid, ρ)
-end
-
-@kernel function _compute_w!(w, grid, dynamics, ρw)
-    i, j, k = @index(Global, NTuple)
-    ρ = dynamics_density(dynamics)
     @inbounds w[i, j, k] = ρw[i, j, k] / ℑzᵃᵃᶠ(i, j, k, grid, ρ)
 end
 

--- a/src/CompressibleEquations/CompressibleEquations.jl
+++ b/src/CompressibleEquations/CompressibleEquations.jl
@@ -54,7 +54,7 @@ using Adapt: Adapt, adapt
 using KernelAbstractions: @kernel, @index
 
 using Oceananigans: Oceananigans, Center, Face, CenterField, XFaceField, YFaceField, ZFaceField, prognostic_fields
-using Oceananigans.Grids: rnode, znode, Bounded, topology
+using Oceananigans.Grids: rnode, znode
 using Oceananigans.Operators: ℑxᶜᵃᵃ, ℑxᶠᵃᵃ, ℑyᵃᶜᵃ, ℑyᵃᶠᵃ, ℑzᵃᵃᶜ, ℑzᵃᵃᶠ,
                                 ∂zᶜᶜᶜ, ∂zᶜᶜᶠ
 using Oceananigans.BoundaryConditions: FieldBoundaryConditions, regularize_field_boundary_conditions, fill_halo_regions!

--- a/src/CompressibleEquations/CompressibleEquations.jl
+++ b/src/CompressibleEquations/CompressibleEquations.jl
@@ -54,7 +54,7 @@ using Adapt: Adapt, adapt
 using KernelAbstractions: @kernel, @index
 
 using Oceananigans: Oceananigans, Center, Face, CenterField, XFaceField, YFaceField, ZFaceField, prognostic_fields
-using Oceananigans.Grids: rnode, znode
+using Oceananigans.Grids: rnode, znode, Bounded, topology
 using Oceananigans.Operators: ℑxᶜᵃᵃ, ℑxᶠᵃᵃ, ℑyᵃᶜᵃ, ℑyᵃᶠᵃ, ℑzᵃᵃᶜ, ℑzᵃᵃᶠ,
                                 ∂zᶜᶜᶜ, ∂zᶜᶜᶠ
 using Oceananigans.BoundaryConditions: FieldBoundaryConditions, regularize_field_boundary_conditions, fill_halo_regions!

--- a/src/CompressibleEquations/CompressibleEquations.jl
+++ b/src/CompressibleEquations/CompressibleEquations.jl
@@ -57,7 +57,7 @@ using Oceananigans: Oceananigans, Center, Face, CenterField, XFaceField, YFaceFi
 using Oceananigans.Grids: rnode, znode
 using Oceananigans.Operators: ℑxᶜᵃᵃ, ℑxᶠᵃᵃ, ℑyᵃᶜᵃ, ℑyᵃᶠᵃ, ℑzᵃᵃᶜ, ℑzᵃᵃᶠ,
                                 ∂zᶜᶜᶜ, ∂zᶜᶜᶠ
-using Oceananigans.BoundaryConditions: FieldBoundaryConditions, regularize_field_boundary_conditions, fill_halo_regions!
+using Oceananigans.BoundaryConditions: fill_halo_regions!
 using Oceananigans.Operators: divᶜᶜᶜ
 using Oceananigans.Utils: prettysummary, launch!
 

--- a/src/CompressibleEquations/compressible_dynamics.jl
+++ b/src/CompressibleEquations/compressible_dynamics.jl
@@ -399,8 +399,14 @@ function AtmosphereModels.materialize_momentum_and_velocities(::CompressibleDyna
     ρw = ZFaceField(grid, boundary_conditions=boundary_conditions.ρw)
     momentum = (; ρu, ρv, ρw)
 
-    velocity_bcs = NamedTuple(name => FieldBoundaryConditions() for name in (:u, :v, :w))
-    velocity_bcs = regularize_field_boundary_conditions(velocity_bcs, grid, (:u, :v, :w))
+    # Velocity is diagnostic (u = ρu/ρ via compute_velocities!). On the normal-component
+    # face in a `Bounded` direction we use `nothing` so `fill_halo_regions!(velocities)`
+    # does not overwrite the kernel-computed boundary face — momentum carries the wall BC.
+    TX, TY, TZ = topology(grid)
+    u_bcs = TX === Bounded ? FieldBoundaryConditions(west=nothing,   east=nothing)  : FieldBoundaryConditions()
+    v_bcs = TY === Bounded ? FieldBoundaryConditions(south=nothing,  north=nothing) : FieldBoundaryConditions()
+    w_bcs = TZ === Bounded ? FieldBoundaryConditions(bottom=nothing, top=nothing)   : FieldBoundaryConditions()
+    velocity_bcs = regularize_field_boundary_conditions((u=u_bcs, v=v_bcs, w=w_bcs), grid, (:u, :v, :w))
     u = XFaceField(grid, boundary_conditions=velocity_bcs.u)
     v = YFaceField(grid, boundary_conditions=velocity_bcs.v)
     w = ZFaceField(grid, boundary_conditions=velocity_bcs.w)

--- a/src/CompressibleEquations/compressible_dynamics.jl
+++ b/src/CompressibleEquations/compressible_dynamics.jl
@@ -399,17 +399,14 @@ function AtmosphereModels.materialize_momentum_and_velocities(::CompressibleDyna
     ρw = ZFaceField(grid, boundary_conditions=boundary_conditions.ρw)
     momentum = (; ρu, ρv, ρw)
 
-    # Velocity is diagnostic (u = ρu/ρ via compute_velocities!). On the normal-component
-    # face in a `Bounded` direction we use `nothing` so `fill_halo_regions!(velocities)`
-    # does not overwrite the kernel-computed boundary face — momentum carries the wall BC.
-    TX, TY, TZ = topology(grid)
-    u_bcs = TX === Bounded ? FieldBoundaryConditions(west=nothing,   east=nothing)  : FieldBoundaryConditions()
-    v_bcs = TY === Bounded ? FieldBoundaryConditions(south=nothing,  north=nothing) : FieldBoundaryConditions()
-    w_bcs = TZ === Bounded ? FieldBoundaryConditions(bottom=nothing, top=nothing)   : FieldBoundaryConditions()
-    velocity_bcs = regularize_field_boundary_conditions((u=u_bcs, v=v_bcs, w=w_bcs), grid, (:u, :v, :w))
-    u = XFaceField(grid, boundary_conditions=velocity_bcs.u)
-    v = YFaceField(grid, boundary_conditions=velocity_bcs.v)
-    w = ZFaceField(grid, boundary_conditions=velocity_bcs.w)
+    # Velocity is diagnostic (u = ρu/ρ via compute_velocities!). Use the auxiliary-field
+    # default BCs (`nothing` on Bounded-Face sides, Periodic on Periodic sides), which
+    # is what XFaceField gives us when constructed with no `boundary_conditions=` kwarg.
+    # `nothing` on Bounded-Face prevents `fill_halo_regions!(velocities)` from clobbering
+    # the kernel-computed boundary face — momentum carries the wall BC.
+    u = XFaceField(grid)
+    v = YFaceField(grid)
+    w = ZFaceField(grid)
     velocities = (; u, v, w)
 
     return momentum, velocities

--- a/test/open_boundary_momentum.jl
+++ b/test/open_boundary_momentum.jl
@@ -21,10 +21,11 @@ using Breeze.Thermodynamics: ReferenceState
 # drove a wall-mode instability that NaN'd the run within ~100 iters.
 #
 # After the fix:
-#   • velocity has `nothing` on the normal-component face of each Bounded direction,
-#     so `fill_halo_regions!` cannot clobber the boundary face
-#   • compute_velocities! covers the full Face range incl. boundary faces, so the
-#     kernel writes `u = ρu/ρ` at the wall each step
+#   • velocities are constructed via `XFaceField(grid)` etc. with no `boundary_conditions=`
+#     kwarg, picking up the *auxiliary* defaults (`nothing` on Bounded-Face sides,
+#     Periodic on Periodic sides). `fill_halo_regions!` cannot clobber the boundary face.
+#   • compute_velocities! launches a fused kernel over (1:Nx+1, 1:Ny+1, 1:Nz+1), so the
+#     kernel writes `u = ρu/ρ` at the wall each step.
 
 @testset "OBC on momentum propagates to derived velocities [$(FT)]" for FT in test_float_types()
     Oceananigans.defaults.FloatType = FT
@@ -163,8 +164,9 @@ using Breeze.Thermodynamics: ReferenceState
     end
 
     @testset "Periodic direction → velocity gets PeriodicBoundaryCondition (not nothing)" begin
-        # Critical regression: the narrow Bounded-only override must not strip periodic
-        # halo filling on tangential components in Periodic directions.
+        # Confirms the auxiliary defaults still install PeriodicBoundaryCondition on
+        # Periodic sides (vs `nothing` on Bounded-Face sides). Periodic halo filling
+        # must continue to work on tangential and normal components alike.
         reference_state = ReferenceState(grid_bpb; surface_pressure=FT(101325),
                                                     potential_temperature=FT(300))
         dynamics = AnelasticDynamics(reference_state)

--- a/test/open_boundary_momentum.jl
+++ b/test/open_boundary_momentum.jl
@@ -27,6 +27,11 @@ using Breeze.Thermodynamics: ReferenceState
 #   • compute_velocities! launches a fused kernel over (1:Nx+1, 1:Ny+1, 1:Nz+1), so the
 #     kernel writes `u = ρu/ρ` at the wall each step.
 
+# Wrap `interior(...)` views in `Array(...)` so boundary-face slice reductions like
+# `all(f, ...)` run on CPU. On GPU, `all(f, ::CuArray)` runs as a `mapreduce` that can't
+# infer the boolean element type from a closure predicate; pulling to CPU avoids it.
+boundary_slice(field, args...) = Array(interior(field, args...))
+
 @testset "OBC on momentum propagates to derived velocities [$(FT)]" for FT in test_float_types()
     Oceananigans.defaults.FloatType = FT
 
@@ -72,8 +77,8 @@ using Breeze.Thermodynamics: ReferenceState
 
         # u at west/east boundary face should equal ρu_value / ρ_face ≈ U_bg
         # (column ρ varies <1% over Lz=100m, so 10% rtol is comfortable).
-        u_west = @allowscalar interior(model.velocities.u, 1, :, :)
-        u_east = @allowscalar interior(model.velocities.u, Nx+1, :, :)
+        u_west = boundary_slice(model.velocities.u, 1,    :, :)
+        u_east = boundary_slice(model.velocities.u, Nx+1, :, :)
         @test all(u -> isapprox(u, U_bg; rtol=FT(0.1)), u_west)
         @test all(u -> isapprox(u, U_bg; rtol=FT(0.1)), u_east)
     end
@@ -100,8 +105,8 @@ using Breeze.Thermodynamics: ReferenceState
         fill_halo_regions!(model.momentum, model.clock, fields(model))
         compute_velocities!(model)
 
-        v_south = @allowscalar interior(model.velocities.v, :, 1, :)
-        v_north = @allowscalar interior(model.velocities.v, :, Ny+1, :)
+        v_south = boundary_slice(model.velocities.v, :, 1,    :)
+        v_north = boundary_slice(model.velocities.v, :, Ny+1, :)
         @test all(v -> isapprox(v, V_bg; rtol=FT(0.1)), v_south)
         @test all(v -> isapprox(v, V_bg; rtol=FT(0.1)), v_north)
     end
@@ -128,8 +133,8 @@ using Breeze.Thermodynamics: ReferenceState
         fill_halo_regions!(model.momentum, model.clock, fields(model))
         compute_velocities!(model)
 
-        w_bottom = @allowscalar interior(model.velocities.w, :, :, 1)
-        w_top    = @allowscalar interior(model.velocities.w, :, :, Nz+1)
+        w_bottom = boundary_slice(model.velocities.w, :, :, 1)
+        w_top    = boundary_slice(model.velocities.w, :, :, Nz+1)
         @test all(w -> isapprox(w, W_bg; rtol=FT(0.1)), w_bottom)
         @test all(w -> isapprox(w, W_bg; rtol=FT(0.1)), w_top)
     end
@@ -157,8 +162,8 @@ using Breeze.Thermodynamics: ReferenceState
         fill_halo_regions!(model.momentum, model.clock, fields(model))
         compute_velocities!(model)
 
-        u_west = @allowscalar interior(model.velocities.u, 1, :, :)
-        u_east = @allowscalar interior(model.velocities.u, Nx+1, :, :)
+        u_west = boundary_slice(model.velocities.u, 1,    :, :)
+        u_east = boundary_slice(model.velocities.u, Nx+1, :, :)
         @test all(u -> isapprox(u, U_bg; rtol=FT(0.1)), u_west)
         @test all(u -> isapprox(u, U_bg; rtol=FT(0.1)), u_east)
     end
@@ -206,13 +211,13 @@ using Breeze.Thermodynamics: ReferenceState
         fill_halo_regions!(model.momentum, model.clock, fields(model))
         compute_velocities!(model)
 
-        u_west_before = @allowscalar copy(interior(model.velocities.u, 1, :, :))
-        u_east_before = @allowscalar copy(interior(model.velocities.u, Nx+1, :, :))
+        u_west_before = boundary_slice(model.velocities.u, 1,    :, :)
+        u_east_before = boundary_slice(model.velocities.u, Nx+1, :, :)
 
         fill_halo_regions!(model.velocities)
 
-        u_west_after = @allowscalar interior(model.velocities.u, 1, :, :)
-        u_east_after = @allowscalar interior(model.velocities.u, Nx+1, :, :)
+        u_west_after = boundary_slice(model.velocities.u, 1,    :, :)
+        u_east_after = boundary_slice(model.velocities.u, Nx+1, :, :)
         @test u_west_before == u_west_after
         @test u_east_before == u_east_after
         # And both are still close to U_bg (sanity, in case both got clobbered identically).
@@ -236,8 +241,8 @@ using Breeze.Thermodynamics: ReferenceState
         fill_halo_regions!(model.momentum, model.clock, fields(model))
         compute_velocities!(model)
 
-        u_west = @allowscalar interior(model.velocities.u, 1, :, :)
-        u_east = @allowscalar interior(model.velocities.u, Nx+1, :, :)
+        u_west = boundary_slice(model.velocities.u, 1,    :, :)
+        u_east = boundary_slice(model.velocities.u, Nx+1, :, :)
         @test all(==(zero(FT)), u_west)
         @test all(==(zero(FT)), u_east)
     end

--- a/test/open_boundary_momentum.jl
+++ b/test/open_boundary_momentum.jl
@@ -2,7 +2,7 @@ using Test
 using Oceananigans
 using Oceananigans.Architectures: CPU
 using Oceananigans.BoundaryConditions: FieldBoundaryConditions, OpenBoundaryCondition,
-                                       fill_halo_regions!
+                                       PeriodicBoundaryCondition, fill_halo_regions!
 using GPUArraysCore: @allowscalar
 using Breeze
 using Breeze.AtmosphereModels: compute_velocities!
@@ -30,16 +30,26 @@ using Breeze.Thermodynamics: ReferenceState
     Oceananigans.defaults.FloatType = FT
 
     Nx, Ny, Nz = 8, 8, 4
-    grid = RectilinearGrid(default_arch, FT;
-                           size = (Nx, Ny, Nz),
-                           x = (0, 1000),
-                           y = (0, 1000),
-                           z = (0, 100),
-                           topology = (Bounded, Periodic, Bounded))
+    Lx, Ly, Lz = FT(1000), FT(1000), FT(100)
 
-    @testset "Anelastic — Open ρu propagates to u at boundary face" begin
-        reference_state = ReferenceState(grid; surface_pressure=FT(101325),
-                                                potential_temperature=FT(300))
+    # Mixed-topology grid: Bounded x and z, Periodic y. Tests west/east on u
+    # and bottom/top on w against Bounded, while south/north on v should stay
+    # PeriodicBoundaryCondition.
+    grid_bpb = RectilinearGrid(default_arch, FT;
+                               size = (Nx, Ny, Nz),
+                               x = (0, Lx), y = (0, Ly), z = (0, Lz),
+                               topology = (Bounded, Periodic, Bounded))
+
+    # All-Bounded grid: enables testing south/north (v) and bottom/top (w) as
+    # normal-component faces under Bounded.
+    grid_bbb = RectilinearGrid(default_arch, FT;
+                               size = (Nx, Ny, Nz),
+                               x = (0, Lx), y = (0, Ly), z = (0, Lz),
+                               topology = (Bounded, Bounded, Bounded))
+
+    @testset "Anelastic — Open ρu propagates to u at west/east" begin
+        reference_state = ReferenceState(grid_bpb; surface_pressure=FT(101325),
+                                                    potential_temperature=FT(300))
         dynamics = AnelasticDynamics(reference_state)
 
         ρ_b = FT(1.225)
@@ -48,11 +58,10 @@ using Breeze.Thermodynamics: ReferenceState
 
         ρu_bcs = FieldBoundaryConditions(west = OpenBoundaryCondition(ρu_value),
                                           east = OpenBoundaryCondition(ρu_value))
-        model = AtmosphereModel(grid; dynamics=dynamics,
-                                       formulation=:LiquidIcePotentialTemperature,
-                                       boundary_conditions=(; ρu=ρu_bcs))
+        model = AtmosphereModel(grid_bpb; dynamics=dynamics,
+                                           formulation=:LiquidIcePotentialTemperature,
+                                           boundary_conditions=(; ρu=ρu_bcs))
 
-        # Velocity BCs on west/east should be `nothing` (so fill_halo doesn't clobber)
         @test isnothing(model.velocities.u.boundary_conditions.west)
         @test isnothing(model.velocities.u.boundary_conditions.east)
 
@@ -60,14 +69,71 @@ using Breeze.Thermodynamics: ReferenceState
         fill_halo_regions!(model.momentum, model.clock, fields(model))
         compute_velocities!(model)
 
-        # u at the west and east boundary faces should NOT be zero
+        # u at west/east boundary face should equal ρu_value / ρ_face ≈ U_bg
+        # (column ρ varies <1% over Lz=100m, so 10% rtol is comfortable).
         u_west = @allowscalar interior(model.velocities.u, 1, :, :)
         u_east = @allowscalar interior(model.velocities.u, Nx+1, :, :)
-        @test all(>(FT(0.5) * U_bg), u_west)
-        @test all(>(FT(0.5) * U_bg), u_east)
+        @test all(u -> isapprox(u, U_bg; rtol=FT(0.1)), u_west)
+        @test all(u -> isapprox(u, U_bg; rtol=FT(0.1)), u_east)
     end
 
-    @testset "Compressible — Open ρu propagates to u at boundary face" begin
+    @testset "Anelastic — Open ρv propagates to v at south/north" begin
+        reference_state = ReferenceState(grid_bbb; surface_pressure=FT(101325),
+                                                    potential_temperature=FT(300))
+        dynamics = AnelasticDynamics(reference_state)
+
+        ρ_b = FT(1.225)
+        V_bg = FT(5.0)
+        ρv_value = ρ_b * V_bg
+
+        ρv_bcs = FieldBoundaryConditions(south = OpenBoundaryCondition(ρv_value),
+                                          north = OpenBoundaryCondition(ρv_value))
+        model = AtmosphereModel(grid_bbb; dynamics=dynamics,
+                                           formulation=:LiquidIcePotentialTemperature,
+                                           boundary_conditions=(; ρv=ρv_bcs))
+
+        @test isnothing(model.velocities.v.boundary_conditions.south)
+        @test isnothing(model.velocities.v.boundary_conditions.north)
+
+        set!(model; θ=FT(300), ρu=0, ρv=(x,y,z) -> ρ_b * V_bg, ρw=0)
+        fill_halo_regions!(model.momentum, model.clock, fields(model))
+        compute_velocities!(model)
+
+        v_south = @allowscalar interior(model.velocities.v, :, 1, :)
+        v_north = @allowscalar interior(model.velocities.v, :, Ny+1, :)
+        @test all(v -> isapprox(v, V_bg; rtol=FT(0.1)), v_south)
+        @test all(v -> isapprox(v, V_bg; rtol=FT(0.1)), v_north)
+    end
+
+    @testset "Anelastic — Open ρw propagates to w at bottom/top" begin
+        reference_state = ReferenceState(grid_bbb; surface_pressure=FT(101325),
+                                                    potential_temperature=FT(300))
+        dynamics = AnelasticDynamics(reference_state)
+
+        ρ_b = FT(1.225)
+        W_bg = FT(0.1)  # Small w to stay in hydrostatic-noise regime
+        ρw_value = ρ_b * W_bg
+
+        ρw_bcs = FieldBoundaryConditions(bottom = OpenBoundaryCondition(ρw_value),
+                                          top    = OpenBoundaryCondition(ρw_value))
+        model = AtmosphereModel(grid_bbb; dynamics=dynamics,
+                                           formulation=:LiquidIcePotentialTemperature,
+                                           boundary_conditions=(; ρw=ρw_bcs))
+
+        @test isnothing(model.velocities.w.boundary_conditions.bottom)
+        @test isnothing(model.velocities.w.boundary_conditions.top)
+
+        set!(model; θ=FT(300), ρu=0, ρv=0, ρw=(x,y,z) -> ρ_b * W_bg)
+        fill_halo_regions!(model.momentum, model.clock, fields(model))
+        compute_velocities!(model)
+
+        w_bottom = @allowscalar interior(model.velocities.w, :, :, 1)
+        w_top    = @allowscalar interior(model.velocities.w, :, :, Nz+1)
+        @test all(w -> isapprox(w, W_bg; rtol=FT(0.1)), w_bottom)
+        @test all(w -> isapprox(w, W_bg; rtol=FT(0.1)), w_top)
+    end
+
+    @testset "Compressible — Open ρu propagates to u at west/east" begin
         td = ExplicitTimeStepping()
         dynamics = CompressibleDynamics(td; reference_potential_temperature=FT(300))
 
@@ -77,9 +143,9 @@ using Breeze.Thermodynamics: ReferenceState
 
         ρu_bcs = FieldBoundaryConditions(west = OpenBoundaryCondition(ρu_value),
                                           east = OpenBoundaryCondition(ρu_value))
-        model = AtmosphereModel(grid; dynamics=dynamics,
-                                       formulation=:LiquidIcePotentialTemperature,
-                                       boundary_conditions=(; ρu=ρu_bcs))
+        model = AtmosphereModel(grid_bpb; dynamics=dynamics,
+                                           formulation=:LiquidIcePotentialTemperature,
+                                           boundary_conditions=(; ρu=ρu_bcs))
 
         @test isnothing(model.velocities.u.boundary_conditions.west)
         @test isnothing(model.velocities.u.boundary_conditions.east)
@@ -92,15 +158,37 @@ using Breeze.Thermodynamics: ReferenceState
 
         u_west = @allowscalar interior(model.velocities.u, 1, :, :)
         u_east = @allowscalar interior(model.velocities.u, Nx+1, :, :)
-        @test all(>(FT(0.5) * U_bg), u_west)
-        @test all(>(FT(0.5) * U_bg), u_east)
+        @test all(u -> isapprox(u, U_bg; rtol=FT(0.1)), u_west)
+        @test all(u -> isapprox(u, U_bg; rtol=FT(0.1)), u_east)
     end
 
-    @testset "Anelastic — uniform OBC inflow stays uniform under SSP-RK3" begin
-        # Pre-fix: this NaN'd within ~100 iters.
-        # Post-fix: max|u| should remain ≈ U_bg over a few iters.
-        reference_state = ReferenceState(grid; surface_pressure=FT(101325),
-                                                potential_temperature=FT(300))
+    @testset "Periodic direction → velocity gets PeriodicBoundaryCondition (not nothing)" begin
+        # Critical regression: the narrow Bounded-only override must not strip periodic
+        # halo filling on tangential components in Periodic directions.
+        reference_state = ReferenceState(grid_bpb; surface_pressure=FT(101325),
+                                                    potential_temperature=FT(300))
+        dynamics = AnelasticDynamics(reference_state)
+        model = AtmosphereModel(grid_bpb; dynamics=dynamics,
+                                           formulation=:LiquidIcePotentialTemperature)
+
+        # y is Periodic on grid_bpb. Tangential u south/north and normal v south/north
+        # should both be Periodic (not nothing).
+        pbc_type = typeof(PeriodicBoundaryCondition())
+        @test typeof(model.velocities.u.boundary_conditions.south) === pbc_type
+        @test typeof(model.velocities.u.boundary_conditions.north) === pbc_type
+        @test typeof(model.velocities.v.boundary_conditions.south) === pbc_type
+        @test typeof(model.velocities.v.boundary_conditions.north) === pbc_type
+        # x is Bounded → u west/east should be the override (nothing).
+        @test isnothing(model.velocities.u.boundary_conditions.west)
+        @test isnothing(model.velocities.u.boundary_conditions.east)
+    end
+
+    @testset "fill_halo_regions! on velocities does not clobber boundary face" begin
+        # Direct regression for the original bug mechanism: snapshot u at the boundary
+        # face after compute_velocities!, run fill_halo_regions!(velocities), and confirm
+        # the boundary face is unchanged. Pre-fix, this re-set u_west to zero.
+        reference_state = ReferenceState(grid_bpb; surface_pressure=FT(101325),
+                                                    potential_temperature=FT(300))
         dynamics = AnelasticDynamics(reference_state)
 
         ρ_b = FT(1.225)
@@ -109,34 +197,36 @@ using Breeze.Thermodynamics: ReferenceState
 
         ρu_bcs = FieldBoundaryConditions(west = OpenBoundaryCondition(ρu_value),
                                           east = OpenBoundaryCondition(ρu_value))
-        model = AtmosphereModel(grid; dynamics=dynamics,
-                                       formulation=:LiquidIcePotentialTemperature,
-                                       boundary_conditions=(; ρu=ρu_bcs))
+        model = AtmosphereModel(grid_bpb; dynamics=dynamics,
+                                           formulation=:LiquidIcePotentialTemperature,
+                                           boundary_conditions=(; ρu=ρu_bcs))
         set!(model; θ=FT(300), ρu=(x,y,z) -> ρ_b * U_bg, ρv=0, ρw=0)
+        fill_halo_regions!(model.momentum, model.clock, fields(model))
+        compute_velocities!(model)
 
-        simulation = Simulation(model; Δt=FT(0.5), stop_iteration=20, verbose=false)
-        run!(simulation)
+        u_west_before = @allowscalar copy(interior(model.velocities.u, 1, :, :))
+        u_east_before = @allowscalar copy(interior(model.velocities.u, Nx+1, :, :))
 
-        @test model.clock.iteration == 20
-        u_max = @allowscalar maximum(abs, interior(model.velocities.u))
-        @test isfinite(u_max)
-        # Should stay close to U_bg (cell-centered ρ slightly different from ρ_b makes
-        # the exact u value slightly off; 50% is a comfortable bound to detect blow-up).
-        @test u_max < FT(2) * U_bg
+        fill_halo_regions!(model.velocities)
+
+        u_west_after = @allowscalar interior(model.velocities.u, 1, :, :)
+        u_east_after = @allowscalar interior(model.velocities.u, Nx+1, :, :)
+        @test u_west_before == u_west_after
+        @test u_east_before == u_east_after
+        # And both are still close to U_bg (sanity, in case both got clobbered identically).
+        @test all(u -> isapprox(u, U_bg; rtol=FT(0.1)), u_west_after)
     end
 
     @testset "Default impenetrable wall (no user momentum BC) gives u = 0 at wall" begin
         # `nothing` on velocity is the catch-all override, but the default impenetrable
         # behavior must still hold: when momentum has the default OpenBoundaryCondition(0),
         # the kernel writes u = ρu/ρ = 0 at the wall and the wall stays impenetrable.
-        reference_state = ReferenceState(grid; surface_pressure=FT(101325),
-                                                potential_temperature=FT(300))
+        reference_state = ReferenceState(grid_bpb; surface_pressure=FT(101325),
+                                                    potential_temperature=FT(300))
         dynamics = AnelasticDynamics(reference_state)
-        model = AtmosphereModel(grid; dynamics=dynamics,
-                                       formulation=:LiquidIcePotentialTemperature)
+        model = AtmosphereModel(grid_bpb; dynamics=dynamics,
+                                           formulation=:LiquidIcePotentialTemperature)
 
-        # No user BC on ρu → default impenetrable (OpenBoundaryCondition(0))
-        # → velocity west/east set to `nothing`
         @test isnothing(model.velocities.u.boundary_conditions.west)
         @test isnothing(model.velocities.u.boundary_conditions.east)
 
@@ -148,5 +238,64 @@ using Breeze.Thermodynamics: ReferenceState
         u_east = @allowscalar interior(model.velocities.u, Nx+1, :, :)
         @test all(==(zero(FT)), u_west)
         @test all(==(zero(FT)), u_east)
+    end
+
+    @testset "Anelastic — uniform OBC inflow stays uniform under SSP-RK3" begin
+        # Pre-fix: this NaN'd within ~100 iters.
+        # Post-fix: max|u| should remain ≈ U_bg over a few iters.
+        reference_state = ReferenceState(grid_bpb; surface_pressure=FT(101325),
+                                                    potential_temperature=FT(300))
+        dynamics = AnelasticDynamics(reference_state)
+
+        ρ_b = FT(1.225)
+        U_bg = FT(5.0)
+        ρu_value = ρ_b * U_bg
+
+        ρu_bcs = FieldBoundaryConditions(west = OpenBoundaryCondition(ρu_value),
+                                          east = OpenBoundaryCondition(ρu_value))
+        model = AtmosphereModel(grid_bpb; dynamics=dynamics,
+                                           formulation=:LiquidIcePotentialTemperature,
+                                           boundary_conditions=(; ρu=ρu_bcs))
+        set!(model; θ=FT(300), ρu=(x,y,z) -> ρ_b * U_bg, ρv=0, ρw=0)
+
+        simulation = Simulation(model; Δt=FT(0.5), stop_iteration=20, verbose=false)
+        run!(simulation)
+
+        @test model.clock.iteration == 20
+        u_max = @allowscalar maximum(abs, interior(model.velocities.u))
+        @test isfinite(u_max)
+        @test u_max < FT(2) * U_bg
+    end
+
+    @testset "Compressible — uniform OBC inflow stays finite under SSP-RK3 (CFL≈0.05)" begin
+        # Companion to the anelastic stability test. Compressible Explicit needs a smaller
+        # CFL than the anelastic case (acoustic vs advective). At CFL=0.3 the noise grows
+        # to NaN within ~100 iters (Test 5 in the campaign); CFL=0.05 stays stable.
+        td = ExplicitTimeStepping()
+        dynamics = CompressibleDynamics(td; reference_potential_temperature=FT(300))
+
+        ρ_b = FT(1.225)
+        U_bg = FT(5.0)
+        ρu_value = ρ_b * U_bg
+
+        ρu_bcs = FieldBoundaryConditions(west = OpenBoundaryCondition(ρu_value),
+                                          east = OpenBoundaryCondition(ρu_value))
+        model = AtmosphereModel(grid_bpb; dynamics=dynamics,
+                                           formulation=:LiquidIcePotentialTemperature,
+                                           boundary_conditions=(; ρu=ρu_bcs))
+        ref = model.dynamics.reference_state
+        set!(model; θ=FT(300), ρ=ref.density,
+                     ρu=(x,y,z) -> ρ_b * U_bg, ρv=0, ρw=0)
+
+        Δx = Lx / Nx
+        c_sound = sqrt(FT(1.4) * FT(287) * FT(300))
+        Δt = FT(0.05) * Δx / c_sound
+        simulation = Simulation(model; Δt=Δt, stop_iteration=20, verbose=false)
+        run!(simulation)
+
+        @test model.clock.iteration == 20
+        u_max = @allowscalar maximum(abs, interior(model.velocities.u))
+        @test isfinite(u_max)
+        @test u_max < FT(2) * U_bg
     end
 end

--- a/test/open_boundary_momentum.jl
+++ b/test/open_boundary_momentum.jl
@@ -1,0 +1,152 @@
+using Test
+using Oceananigans
+using Oceananigans.Architectures: CPU
+using Oceananigans.BoundaryConditions: FieldBoundaryConditions, OpenBoundaryCondition,
+                                       fill_halo_regions!
+using GPUArraysCore: @allowscalar
+using Breeze
+using Breeze.AtmosphereModels: compute_velocities!
+using Breeze.AnelasticEquations: AnelasticDynamics
+using Breeze.CompressibleEquations: CompressibleDynamics, ExplicitTimeStepping
+using Breeze.Thermodynamics: ReferenceState
+
+# Regression tests for the OBC-on-momentum velocity-clobber bug.
+#
+# Prior to the fix, `model.velocities` (u, v, w) were constructed with
+# DEFAULT impenetrable BCs regardless of what the user set on momentum
+# (ρu, ρv, ρw). The call to `fill_halo_regions!(model.velocities)` after
+# `compute_velocities!` then overwrote the boundary face with zero, even
+# when the user prescribed a non-zero open boundary on momentum. The
+# inconsistency between ρu (=user value at wall) and u (=0 at wall)
+# drove a wall-mode instability that NaN'd the run within ~100 iters.
+#
+# After the fix:
+#   • velocity has `nothing` on the normal-component face of each Bounded direction,
+#     so `fill_halo_regions!` cannot clobber the boundary face
+#   • compute_velocities! covers the full Face range incl. boundary faces, so the
+#     kernel writes `u = ρu/ρ` at the wall each step
+
+@testset "OBC on momentum propagates to derived velocities [$(FT)]" for FT in test_float_types()
+    Oceananigans.defaults.FloatType = FT
+
+    Nx, Ny, Nz = 8, 8, 4
+    grid = RectilinearGrid(default_arch, FT;
+                           size = (Nx, Ny, Nz),
+                           x = (0, 1000),
+                           y = (0, 1000),
+                           z = (0, 100),
+                           topology = (Bounded, Periodic, Bounded))
+
+    @testset "Anelastic — Open ρu propagates to u at boundary face" begin
+        reference_state = ReferenceState(grid; surface_pressure=FT(101325),
+                                                potential_temperature=FT(300))
+        dynamics = AnelasticDynamics(reference_state)
+
+        ρ_b = FT(1.225)
+        U_bg = FT(5.0)
+        ρu_value = ρ_b * U_bg
+
+        ρu_bcs = FieldBoundaryConditions(west = OpenBoundaryCondition(ρu_value),
+                                          east = OpenBoundaryCondition(ρu_value))
+        model = AtmosphereModel(grid; dynamics=dynamics,
+                                       formulation=:LiquidIcePotentialTemperature,
+                                       boundary_conditions=(; ρu=ρu_bcs))
+
+        # Velocity BCs on west/east should be `nothing` (so fill_halo doesn't clobber)
+        @test isnothing(model.velocities.u.boundary_conditions.west)
+        @test isnothing(model.velocities.u.boundary_conditions.east)
+
+        set!(model; θ=FT(300), ρu=(x,y,z) -> ρ_b * U_bg, ρv=0, ρw=0)
+        fill_halo_regions!(model.momentum, model.clock, fields(model))
+        compute_velocities!(model)
+
+        # u at the west and east boundary faces should NOT be zero
+        u_west = @allowscalar interior(model.velocities.u, 1, :, :)
+        u_east = @allowscalar interior(model.velocities.u, Nx+1, :, :)
+        @test all(>(FT(0.5) * U_bg), u_west)
+        @test all(>(FT(0.5) * U_bg), u_east)
+    end
+
+    @testset "Compressible — Open ρu propagates to u at boundary face" begin
+        td = ExplicitTimeStepping()
+        dynamics = CompressibleDynamics(td; reference_potential_temperature=FT(300))
+
+        ρ_b = FT(1.225)
+        U_bg = FT(5.0)
+        ρu_value = ρ_b * U_bg
+
+        ρu_bcs = FieldBoundaryConditions(west = OpenBoundaryCondition(ρu_value),
+                                          east = OpenBoundaryCondition(ρu_value))
+        model = AtmosphereModel(grid; dynamics=dynamics,
+                                       formulation=:LiquidIcePotentialTemperature,
+                                       boundary_conditions=(; ρu=ρu_bcs))
+
+        @test isnothing(model.velocities.u.boundary_conditions.west)
+        @test isnothing(model.velocities.u.boundary_conditions.east)
+
+        ref = model.dynamics.reference_state
+        set!(model; θ=FT(300), ρ=ref.density,
+                     ρu=(x,y,z) -> ρ_b * U_bg, ρv=0, ρw=0)
+        fill_halo_regions!(model.momentum, model.clock, fields(model))
+        compute_velocities!(model)
+
+        u_west = @allowscalar interior(model.velocities.u, 1, :, :)
+        u_east = @allowscalar interior(model.velocities.u, Nx+1, :, :)
+        @test all(>(FT(0.5) * U_bg), u_west)
+        @test all(>(FT(0.5) * U_bg), u_east)
+    end
+
+    @testset "Anelastic — uniform OBC inflow stays uniform under SSP-RK3" begin
+        # Pre-fix: this NaN'd within ~100 iters.
+        # Post-fix: max|u| should remain ≈ U_bg over a few iters.
+        reference_state = ReferenceState(grid; surface_pressure=FT(101325),
+                                                potential_temperature=FT(300))
+        dynamics = AnelasticDynamics(reference_state)
+
+        ρ_b = FT(1.225)
+        U_bg = FT(5.0)
+        ρu_value = ρ_b * U_bg
+
+        ρu_bcs = FieldBoundaryConditions(west = OpenBoundaryCondition(ρu_value),
+                                          east = OpenBoundaryCondition(ρu_value))
+        model = AtmosphereModel(grid; dynamics=dynamics,
+                                       formulation=:LiquidIcePotentialTemperature,
+                                       boundary_conditions=(; ρu=ρu_bcs))
+        set!(model; θ=FT(300), ρu=(x,y,z) -> ρ_b * U_bg, ρv=0, ρw=0)
+
+        simulation = Simulation(model; Δt=FT(0.5), stop_iteration=20, verbose=false)
+        run!(simulation)
+
+        @test model.clock.iteration == 20
+        u_max = @allowscalar maximum(abs, interior(model.velocities.u))
+        @test isfinite(u_max)
+        # Should stay close to U_bg (cell-centered ρ slightly different from ρ_b makes
+        # the exact u value slightly off; 50% is a comfortable bound to detect blow-up).
+        @test u_max < FT(2) * U_bg
+    end
+
+    @testset "Default impenetrable wall (no user momentum BC) gives u = 0 at wall" begin
+        # `nothing` on velocity is the catch-all override, but the default impenetrable
+        # behavior must still hold: when momentum has the default OpenBoundaryCondition(0),
+        # the kernel writes u = ρu/ρ = 0 at the wall and the wall stays impenetrable.
+        reference_state = ReferenceState(grid; surface_pressure=FT(101325),
+                                                potential_temperature=FT(300))
+        dynamics = AnelasticDynamics(reference_state)
+        model = AtmosphereModel(grid; dynamics=dynamics,
+                                       formulation=:LiquidIcePotentialTemperature)
+
+        # No user BC on ρu → default impenetrable (OpenBoundaryCondition(0))
+        # → velocity west/east set to `nothing`
+        @test isnothing(model.velocities.u.boundary_conditions.west)
+        @test isnothing(model.velocities.u.boundary_conditions.east)
+
+        set!(model; θ=FT(300))
+        fill_halo_regions!(model.momentum, model.clock, fields(model))
+        compute_velocities!(model)
+
+        u_west = @allowscalar interior(model.velocities.u, 1, :, :)
+        u_east = @allowscalar interior(model.velocities.u, Nx+1, :, :)
+        @test all(==(zero(FT)), u_west)
+        @test all(==(zero(FT)), u_east)
+    end
+end


### PR DESCRIPTION
## Summary

Two-part fix:
1. Override velocity BCs to `nothing` on the normal-component face of each `Bounded` direction in `materialize_momentum_and_velocities` (anelastic + compressible), so `fill_halo_regions!(model.velocities)` no longer clobbers the kernel-computed boundary face. Default impenetrable case still works because `OpenBoundaryCondition(0)` on momentum yields `u = ρu/ρ = 0` at the wall.
2. Launch `compute_velocities!` over the full Face range via `KernelParameters`, so east/north/top boundary faces are written each step rather than left stale.

Fixes #721.

## Test plan

New `test/open_boundary_momentum.jl`:

- [x] Anelastic + Open `ρu` ⇒ `u.bcs.{west,east}` is `nothing`; `u` at boundary face ≈ `U_bg` after `compute_velocities!`.
- [x] Compressible — same.
- [x] Anelastic OBC inflow — 20 SSP-RK3 steps stay finite (pre-fix NaN'd within ~100 iters).
- [x] Default impenetrable wall — `u = 0` confirmed, no special-case needed.
- [x] 15/15 pass locally on CPU/Float64.
- [x] CI for GPU/Float32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)