### PR TITLE
Add BreezeLightfluxExt: streaming ecCKD optics + RT on GPU

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ examples/atsc-jas-d-18-0357*
 # Benchmarking output
 *.json
 benchmark_results.md
+*.nsys-rep
+*.ncu-rep

--- a/Project.toml
+++ b/Project.toml
@@ -19,6 +19,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [weakdeps]
+Lightflux = "cd8119b0-1744-44d6-9ede-6ad1ad750b26"
 CloudMicrophysics = "6a9e3e04-43cd-43ba-94b9-e8782df3c71b"
 RRTMGP = "a01a1ee8-cea4-48fc-987c-fc7878d79da1"
 ClimaComms = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"
@@ -26,12 +27,14 @@ Reactant = "3c362404-f566-11ee-1572-e11a4b42c853"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [extensions]
+BreezeLightfluxExt = "Lightflux"
 BreezeCloudMicrophysicsExt = ["CloudMicrophysics", "SpecialFunctions"]
 BreezeRRTMGPExt = ["ClimaComms", "RRTMGP"]
 BreezeReactantExt = "Reactant"
 
 [compat]
 Adapt = "4.3.0"
+Lightflux = "0.1"
 ClimaComms = "0.6"
 CloudMicrophysics = "0.31.4, 0.32, 0.33, 0.34, 0.35"
 Dates = "<0.0.1, 1"

--- a/benchmarking/Project.toml
+++ b/benchmarking/Project.toml
@@ -5,35 +5,51 @@ authors = ["NumericalEarth organization (github.com/NumericalEarth) and contribu
 
 [deps]
 AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+Lightflux = "cd8119b0-1744-44d6-9ede-6ad1ad750b26"
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
 Breeze = "660aa2fb-d4c8-4359-a52c-9c057bc511da"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+ClimaComms = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"
 CloudMicrophysics = "6a9e3e04-43cd-43ba-94b9-e8782df3c71b"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Metal = "dde4c033-4e86-420c-a63e-0dd931031962"
+NCDatasets = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
 Oceananigans = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+RRTMGP = "a01a1ee8-cea4-48fc-987c-fc7878d79da1"
 Reactant = "3c362404-f566-11ee-1572-e11a4b42c853"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [sources]
+# Three levels up from `Breeze.jl/benchmarking/`: out of `benchmarking/`,
+# out of `Breeze.jl/`, out of `BreezeRadiativeHeatingDev/`, then into the
+# sibling Lightflux source checkout (whose on-disk directory is still
+# `AnalyticBandRadiation.jl` because the GitHub repo hasn't been renamed
+# yet — the `Project.toml` inside it declares `name = "Lightflux"`).
+Lightflux = {path = "../../../AnalyticBandRadiation.jl"}
 Breeze = {path = ".."}
 
 [compat]
 AMDGPU = "2.3.0"
+Adapt = "4.3.0"
+Lightflux = "0.1"
 ArgParse = "1"
-CUDA = "5, 6.0"
+CUDA = "5, 6"
+ClimaComms = "0.6"
 CloudMicrophysics = "0.31.4, 0.32, 0.33, 0.34, 0.35"
 Dates = "<0.0.1, 1"
 Enzyme = "0.13.118"
 JLD2 = "0.5, 0.6"
 JSON = "1.4.0"
 Metal = "1.9.3"
+NCDatasets = "0.14"
 Oceananigans = "0.107"
 Printf = "1"
+RRTMGP = "0.21"
 Reactant = "0.2.203"
 Statistics = "<0.0.1, 1"
 julia = "1.10"

--- a/benchmarking/radiative_heating_gpu_environment_check.jl
+++ b/benchmarking/radiative_heating_gpu_environment_check.jl
@@ -1,0 +1,126 @@
+using Dates
+
+function json_escape(text)
+    return replace(String(text), "\\" => "\\\\", "\"" => "\\\"", "\n" => "\\n")
+end
+
+function json_value(value)
+    if value isa AbstractString
+        return "\"" * json_escape(value) * "\""
+    elseif value isa Bool
+        return value ? "true" : "false"
+    elseif value isa Integer || value isa AbstractFloat
+        return string(value)
+    elseif value isa AbstractDict
+        return json_object(value)
+    elseif value isa AbstractVector || value isa Tuple
+        return "[" * join(json_value.(value), ", ") * "]"
+    else
+        return "\"" * json_escape(sprint(show, value)) * "\""
+    end
+end
+
+function json_object(object)
+    pairs = collect(object)
+    lines = ["{"]
+    for (i, pair) in enumerate(pairs)
+        key, value = pair
+        comma = i == length(pairs) ? "" : ","
+        push!(lines, "  \"$(json_escape(key))\": $(json_value(value))$(comma)")
+    end
+    push!(lines, "}")
+    return join(lines, "\n")
+end
+
+function command_status(cmd)
+    try
+        output = read(cmd, String)
+        return true, strip(output)
+    catch err
+        return false, sprint(showerror, err)
+    end
+end
+
+function cuda_status()
+    try
+        cuda = Base.require(Base.PkgId(Base.UUID("052768ef-5323-5732-b1bb-66c8b64840ba"), "CUDA"))
+        functional = Base.invokelatest(getproperty(cuda, :functional))
+        devices = functional ? Base.invokelatest(() -> collect(getproperty(cuda, :devices)())) : []
+        names = String[]
+        for device in devices
+            push!(names, String(Base.invokelatest(getproperty(cuda, :name), device)))
+        end
+        return Dict(
+            "loadable" => true,
+            "functional" => functional,
+            "device_count" => length(devices),
+            "device_names" => names,
+        )
+    catch err
+        return Dict(
+            "loadable" => false,
+            "functional" => false,
+            "device_count" => 0,
+            "device_names" => String[],
+            "error" => sprint(showerror, err),
+        )
+    end
+end
+
+function main()
+    output_dir = get(ENV, "RADIATIVE_HEATING_GPU_ENV_DIR",
+                     joinpath(@__DIR__, "results", "gpu_environment"))
+    mkpath(output_dir)
+
+    nvidia_ok, nvidia_output = command_status(`nvidia-smi -L`)
+    nsys_ok, nsys_output = command_status(`nsys --version`)
+    ncu_ok, ncu_output = command_status(`ncu --version`)
+    cuda = cuda_status()
+
+    h100_detected = any(contains("H100"), get(cuda, "device_names", String[])) ||
+                    contains(nvidia_output, "H100")
+    ready = nvidia_ok &&
+            get(cuda, "functional", false) === true &&
+            h100_detected &&
+            nsys_ok &&
+            ncu_ok
+
+    result = Dict(
+        "status" => ready ? "ready_for_h100_nsight_gate" : "not_ready",
+        "timestamp_utc" => string(now(UTC)),
+        "host" => gethostname(),
+        "slurm_job_id" => get(ENV, "SLURM_JOB_ID", ""),
+        "slurm_step_id" => get(ENV, "SLURM_STEP_ID", ""),
+        "h100_detected" => h100_detected,
+        "nvidia_smi" => Dict("ok" => nvidia_ok, "output" => nvidia_output),
+        "cuda" => cuda,
+        "nsys" => Dict("ok" => nsys_ok, "output" => nsys_output),
+        "ncu" => Dict("ok" => ncu_ok, "output" => ncu_output),
+    )
+
+    json_path = joinpath(output_dir, "radiative_heating_gpu_environment_latest.json")
+    open(json_path, "w") do io
+        println(io, json_object(result))
+    end
+
+    md_path = joinpath(output_dir, "radiative_heating_gpu_environment_latest.md")
+    open(md_path, "w") do io
+        println(io, "# Radiative Heating GPU Environment")
+        println(io)
+        println(io, "- status: ", result["status"])
+        println(io, "- host: ", result["host"])
+        println(io, "- slurm_job_id: ", result["slurm_job_id"])
+        println(io, "- H100 detected: ", result["h100_detected"])
+        println(io, "- nvidia-smi: ", nvidia_ok)
+        println(io, "- CUDA functional: ", get(cuda, "functional", false))
+        println(io, "- Nsight Systems: ", nsys_ok)
+        println(io, "- Nsight Compute: ", ncu_ok)
+    end
+
+    println(json_path)
+    return ready ? 0 : 1
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    exit(main())
+end

--- a/benchmarking/radiative_heating_h100_acceptance.sh
+++ b/benchmarking/radiative_heating_h100_acceptance.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export PATH="/usr/local/cuda-13.0/bin:${PATH}"
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+env_dir="${RADIATIVE_HEATING_GPU_ENV_DIR:-${repo_root}/benchmarking/results/gpu_environment_h100}"
+result_dir="${RADIATIVE_HEATING_RCEMIP_DIR:-${repo_root}/benchmarking/results/rcemip_h100_32x32x64}"
+nsight_dir="${result_dir}/nsight"
+nsys_report="${nsight_dir}/radiative_heating_rcemip_nsys.nsys-rep"
+ncu_report="${nsight_dir}/radiative_heating_rcemip_ncu.ncu-rep"
+
+if [[ -n "${RADIATIVE_HEATING_SLURM_JOB_ID:-}" && -z "${SLURM_STEP_ID:-}" ]]; then
+  exec srun --jobid="${RADIATIVE_HEATING_SLURM_JOB_ID}" \
+    --export=ALL,RADIATIVE_HEATING_GPU_ENV_DIR="${env_dir}",RADIATIVE_HEATING_RCEMIP_DIR="${result_dir}" \
+    "$0"
+fi
+
+if [[ "${RADIATIVE_HEATING_USE_SRUN:-false}" == "true" && -z "${SLURM_JOB_ID:-}" ]]; then
+  exec srun \
+    --partition="${SLURM_PARTITION:-gpu-prod}" \
+    --gres="${SLURM_GRES:-gpu:h100:1}" \
+    --export=ALL,RADIATIVE_HEATING_GPU_ENV_DIR="${env_dir}",RADIATIVE_HEATING_RCEMIP_DIR="${result_dir}" \
+    "$0"
+fi
+
+cd "${repo_root}"
+julia --project=benchmarking benchmarking/radiative_heating_gpu_environment_check.jl
+
+mkdir -p "${nsight_dir}"
+
+export RADIATIVE_HEATING_BACKEND="${RADIATIVE_HEATING_BACKEND:-H100}"
+export RADIATIVE_HEATING_GAS_MODEL_SOURCE="${RADIATIVE_HEATING_GAS_MODEL_SOURCE:-validated_ecCKD}"
+export RADIATIVE_HEATING_BENCHMARK_STATUS="${RADIATIVE_HEATING_BENCHMARK_STATUS:-final_4x_evidence}"
+export RADIATIVE_HEATING_NX="${RADIATIVE_HEATING_NX:-32}"
+export RADIATIVE_HEATING_NY="${RADIATIVE_HEATING_NY:-32}"
+export RADIATIVE_HEATING_NZ="${RADIATIVE_HEATING_NZ:-64}"
+export RADIATIVE_HEATING_SAMPLES="${RADIATIVE_HEATING_SAMPLES:-5}"
+export RADIATIVE_HEATING_RCEMIP_DIR="${result_dir}"
+export RADIATIVE_HEATING_NSYS_REPORT="${nsys_report}"
+export RADIATIVE_HEATING_NCU_REPORT="${ncu_report}"
+
+julia --project=benchmarking benchmarking/radiative_heating_h100_support_preflight.jl
+
+nsys profile \
+  --force-overwrite=true \
+  --output="${nsight_dir}/radiative_heating_rcemip_nsys" \
+  julia --project=benchmarking benchmarking/radiative_heating_rcemip_benchmark.jl
+
+ncu \
+  --force-overwrite \
+  --export="${ncu_report}" \
+  julia --project=benchmarking benchmarking/radiative_heating_rcemip_benchmark.jl

--- a/benchmarking/radiative_heating_h100_support_preflight.jl
+++ b/benchmarking/radiative_heating_h100_support_preflight.jl
@@ -1,0 +1,68 @@
+using Dates
+using JSON
+
+include(joinpath(@__DIR__, "radiative_heating_rcemip_benchmark.jl"))
+
+function main()
+    output_dir = get(ENV, "RADIATIVE_HEATING_H100_PREFLIGHT_DIR",
+                     joinpath(@__DIR__, "results", "h100_validated_ecckd_preflight"))
+    mkpath(output_dir)
+
+    source = get(ENV, "RADIATIVE_HEATING_GAS_MODEL_SOURCE", "validated_ecCKD")
+    gas_model = withenv("RADIATIVE_HEATING_GAS_MODEL_SOURCE" => source) do
+        benchmark_gas_model(Float64)
+    end
+    support = gas_model_device_support("H100", gas_model.gas_optics)
+    result = Dict(
+        "case" => "radiative_heating_h100_support_preflight",
+        "timestamp_utc" => string(now(UTC)),
+        "status" => support.status == "supported" ? "supported" : "blocked",
+        "backend" => "H100",
+        "gas_model_source" => gas_model.source,
+        "gas_model_kind" => gas_model.kind,
+        "gas_model_accuracy_status" => gas_model.accuracy_status,
+        "gas_model_device_support_status" => support.status,
+        "gas_model_device_support_reason" => support.reason,
+        "gas_model_device_support_source" => support.source,
+        "missing_kernel_requirements" => support.missing_kernel_requirements,
+        "next_required_implementation" => support.status == "supported" ?
+            "none" :
+            "Run and record CPU/GPU parity evidence for the wired official multi-gas EcCKDTabulatedGasOpticsModel H100 path.",
+        "acceptance_unblocked_when" => support.status == "supported" ?
+            "H100 support preflight passes" :
+            "gas_model_device_support(\"H100\", validated_ecCKD.gas_optics) returns supported",
+    )
+
+    json_path = joinpath(output_dir, "radiative_heating_h100_support_preflight_latest.json")
+    open(json_path, "w") do io
+        JSON.print(io, result, 2)
+        println(io)
+    end
+
+    md_path = joinpath(output_dir, "radiative_heating_h100_support_preflight_latest.md")
+    open(md_path, "w") do io
+        println(io, "# Radiative Heating H100 Support Preflight")
+        println(io)
+        println(io, "- status: ", result["status"])
+        println(io, "- backend: ", result["backend"])
+        println(io, "- gas model source: ", result["gas_model_source"])
+        println(io, "- gas model kind: ", result["gas_model_kind"])
+        println(io, "- gas model accuracy status: ", result["gas_model_accuracy_status"])
+        println(io, "- gas model device support: ", result["gas_model_device_support_status"])
+        println(io, "- reason: ", result["gas_model_device_support_reason"])
+        println(io, "- source: ", result["gas_model_device_support_source"])
+        println(io, "- missing kernel requirements:")
+        for requirement in result["missing_kernel_requirements"]
+            println(io, "  - ", requirement)
+        end
+        println(io, "- next required implementation: ", result["next_required_implementation"])
+        println(io, "- acceptance unblocked when: ", result["acceptance_unblocked_when"])
+    end
+
+    println(json_path)
+    return support.status == "supported" ? 0 : 2
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    exit(main())
+end

--- a/benchmarking/radiative_heating_rcemip_benchmark.jl
+++ b/benchmarking/radiative_heating_rcemip_benchmark.jl
@@ -1,0 +1,625 @@
+using Lightflux
+using Breeze
+using CUDA
+using ClimaComms
+using Dates
+using JSON
+using NCDatasets
+using Oceananigans
+using Printf
+using RRTMGP
+using Statistics
+
+using Breeze.AtmosphereModels: update_radiation!
+using Oceananigans.Architectures: CPU, GPU
+
+const DAY = 24 * 60 * 60
+const DEFAULT_ABR_ROOT = normpath(joinpath(@__DIR__, "..", "..", "..", "Lightflux.jl"))
+const OFFICIAL_ECCKD_GASES = (:composite, :h2o, :o3, :co2, :ch4, :n2o, :cfc11, :cfc12)
+const REDUCED_PREFLIGHT_SW_16_INDICES = [1, 4, 9, 10, 12, 13, 14, 16, 21, 22, 25, 27, 28, 30, 31, 32]
+
+envint(name, default) = parse(Int, get(ENV, name, string(default)))
+envfloat(name, default) = parse(Float64, get(ENV, name, string(default)))
+benchmark_status() = get(ENV, "RADIATIVE_HEATING_BENCHMARK_STATUS", "scaffold_not_final_4x_evidence")
+
+function backend_name()
+    requested = get(ENV, "RADIATIVE_HEATING_BACKEND", "CPU")
+    if uppercase(requested) == "H100"
+        CUDA.functional() || error("RADIATIVE_HEATING_BACKEND=H100 was requested but CUDA is not functional")
+        return "H100", GPU()
+    end
+    return "CPU", CPU()
+end
+
+function rcemip_grid(arch, FT, Nx, Ny, Nz)
+    RectilinearGrid(arch, FT;
+                    size = (Nx, Ny, Nz),
+                    x = (0, 96e3),
+                    y = (-12, 12),
+                    z = (0, 30e3),
+                    topology = (Periodic, Periodic, Bounded))
+end
+
+function make_gas_optics(FT; ng_lw = 32, ng_sw = 16)
+    lw = zeros(FT, ng_lw, 2)
+    sw = zeros(FT, ng_sw, 2)
+    for ig in 1:ng_lw
+        lw[ig, 1] = FT(16 + 0.25ig)
+        lw[ig, 2] = FT(18 + 0.1ig)
+    end
+    for ig in 1:ng_sw
+        sw[ig, 1] = FT(220 + 0.8ig)
+        sw[ig, 2] = FT(6 + 0.2ig)
+    end
+    return EcCKDGasOpticsModel(
+        gas_names = (:h2o, :co2),
+        longwave_absorption = lw,
+        shortwave_absorption = sw,
+        longwave_weights = fill(inv(FT(ng_lw)), ng_lw),
+        shortwave_weights = fill(inv(FT(ng_sw)), ng_sw),
+        longwave_source_scale = fill(one(FT), ng_lw),
+    )
+end
+
+function abr_root()
+    return normpath(get(ENV, "RADIATIVE_HEATING_ABR_ROOT", DEFAULT_ABR_ROOT))
+end
+
+function abr_path(parts...)
+    return joinpath(abr_root(), parts...)
+end
+
+function accuracy_gate_status()
+    path = abr_path("validation", "results", "ecrad_accuracy_gate.json")
+    isfile(path) || return "missing_accuracy_gate"
+    result = JSON.parsefile(path)
+    return get(result, "status", "missing_status")
+end
+
+function official_ecckd_gas_optics()
+    lw_path = get(ENV, "RADIATIVE_HEATING_ECCKD_LW_PATH",
+                  abr_path("validation", "external", "ecrad", "data",
+                           "ecckd-1.0_lw_climate_fsck-32b_ckd-definition.nc"))
+    sw_path = get(ENV, "RADIATIVE_HEATING_ECCKD_SW_PATH",
+                  abr_path("validation", "external", "ecrad", "data",
+                           "ecckd-1.4_sw_climate_rgb-32b_ckd-definition.nc"))
+    return read_ecckd_tabulated_gas_optics(lw_path, sw_path;
+                                           gas_names = OFFICIAL_ECCKD_GASES,
+                                           h2o_mole_fraction = envfloat("RADIATIVE_HEATING_ECCKD_H2O_MOLE_FRACTION", 0.005))
+end
+
+function reduced_preflight_json()
+    return abr_path("validation", "results", "reduced_ecckd_optimization_preflight.json")
+end
+
+function reduced_targeted_entry_json()
+    return abr_path("validation", "results", "reduced_ecckd_targeted_entry_refinement.json")
+end
+
+function reduced_global_entry_json()
+    return abr_path("validation", "results", "reduced_ecckd_global_entry_refinement.json")
+end
+
+function reduced_global_block_json()
+    return abr_path("validation", "results", "reduced_ecckd_global_block_refinement.json")
+end
+
+function reduced_global_block_linearized_json()
+    return abr_path("validation", "results", "reduced_ecckd_global_block_linearized_refit.json")
+end
+
+function reduced_exact_weight_refit_json()
+    return abr_path("validation", "results", "reduced_ecckd_exact_weight_refit.json")
+end
+
+function reduced_accuracy_json()
+    return abr_path("validation", "results", "reduced_ecckd_accuracy.json")
+end
+
+function reduced_preflight_parameters(result)
+    for key in ("post_coefficient_weight_refinement",
+                "post_joint_coordinate_refinement",
+                "coefficient_joint_direction_scan",
+                "greedy_coordinate_descent")
+        section = get(result, key, nothing)
+        section isa AbstractDict || continue
+        parameters = get(section, "final_parameters", nothing)
+        parameters isa Vector || continue
+        length(parameters) == 3length(REDUCED_PREFLIGHT_SW_16_INDICES) || continue
+        return Float64.(parameters)
+    end
+    error("could not find reduced preflight final_parameters in $(reduced_preflight_json())")
+end
+
+function reduced_preflight_table_moves(result)
+    refinement = get(result, "pressure_band_table_refinement", Dict{String, Any}())
+    refinement isa AbstractDict || return Any[]
+    moves = get(refinement, "accepted_moves", Any[])
+    return moves isa Vector ? moves : Any[]
+end
+
+function reduced_preflight_active_table_entry_moves(result)
+    refinement = get(result, "active_table_entry_refinement", Dict{String, Any}())
+    refinement isa AbstractDict || return Any[]
+    moves = get(refinement, "accepted_moves", Any[])
+    return moves isa Vector ? moves : Any[]
+end
+
+function reduced_targeted_active_table_entry_moves()
+    path = reduced_targeted_entry_json()
+    isfile(path) || return Any[], Inf
+    result = JSON.parsefile(path)
+    refinement = get(result, "refinement", Dict{String, Any}())
+    refinement isa AbstractDict || return Any[], Inf
+    moves = get(refinement, "accepted_moves", Any[])
+    objective = Float64(get(refinement, "final_objective", Inf))
+    return moves isa Vector ? moves : Any[], objective
+end
+
+function reduced_global_active_table_entry_moves()
+    path = reduced_global_entry_json()
+    isfile(path) || return Any[], Inf
+    result = JSON.parsefile(path)
+    refinement = get(result, "refinement", Dict{String, Any}())
+    refinement isa AbstractDict || return Any[], Inf
+    moves = get(refinement, "all_active_moves", Any[])
+    objective = Float64(get(refinement, "final_objective", Inf))
+    return moves isa Vector ? moves : Any[], objective
+end
+
+function reduced_global_block_active_table_entry_moves()
+    path = reduced_global_block_json()
+    isfile(path) || return Any[], Inf
+    result = JSON.parsefile(path)
+    refinement = get(result, "refinement", Dict{String, Any}())
+    refinement isa AbstractDict || return Any[], Inf
+    moves = get(refinement, "all_active_moves", Any[])
+    objective = Float64(get(refinement, "final_objective", Inf))
+    return moves isa Vector ? moves : Any[], objective
+end
+
+function reduced_global_block_linearized_active_table_entry_moves()
+    path = reduced_global_block_linearized_json()
+    isfile(path) || return Any[], Inf
+    result = JSON.parsefile(path)
+    moves = get(result, "all_active_moves", Any[])
+    objective = Float64(get(result, "final_objective", Inf))
+    return moves isa Vector ? moves : Any[], objective
+end
+
+function reduced_exact_weight_refit_weights()
+    path = reduced_exact_weight_refit_json()
+    isfile(path) || return nothing
+    result = JSON.parsefile(path)
+    weights = get(result, "final_weights", nothing)
+    weights isa Vector || return nothing
+    length(weights) == length(REDUCED_PREFLIGHT_SW_16_INDICES) || return nothing
+    return Float64.(weights)
+end
+
+function reduced_best_active_table_entry_moves(preflight)
+    refinement = get(preflight, "active_table_entry_refinement", Dict{String, Any}())
+    preflight_objective = refinement isa AbstractDict ?
+        Float64(get(refinement, "final_objective", Inf)) : Inf
+    best_moves = reduced_preflight_active_table_entry_moves(preflight)
+    best_objective = preflight_objective
+    targeted_moves, targeted_objective = reduced_targeted_active_table_entry_moves()
+    if !isempty(targeted_moves) && targeted_objective < best_objective
+        best_moves = targeted_moves
+        best_objective = targeted_objective
+    end
+    global_moves, global_objective = reduced_global_active_table_entry_moves()
+    if !isempty(global_moves) && global_objective < best_objective
+        best_moves = global_moves
+        best_objective = global_objective
+    end
+    global_block_moves, global_block_objective =
+        reduced_global_block_active_table_entry_moves()
+    if !isempty(global_block_moves) && global_block_objective < best_objective
+        best_moves = global_block_moves
+        best_objective = global_block_objective
+    end
+    global_block_linearized_moves, global_block_linearized_objective =
+        reduced_global_block_linearized_active_table_entry_moves()
+    if !isempty(global_block_linearized_moves) &&
+       global_block_linearized_objective < best_objective
+        best_moves = global_block_linearized_moves
+    end
+    return best_moves
+end
+
+function softmax(values)
+    shifted = values .- maximum(values)
+    exps = exp.(shifted)
+    return exps ./ sum(exps)
+end
+
+function apply_reduced_preflight_parameters!(model, parameters)
+    ng = length(REDUCED_PREFLIGHT_SW_16_INDICES)
+    model.shortwave_weights .= softmax(parameters[1:ng])
+    absorption_scales = exp.(clamp.(parameters[(ng + 1):(2ng)], -5.0, 5.0))
+    rayleigh_scales = exp.(clamp.(parameters[(2ng + 1):(3ng)], -5.0, 5.0))
+    for ig in 1:ng
+        model.shortwave_absorption[ig, :, :, :] .*= absorption_scales[ig]
+        if length(model.shortwave_h2o_absorption) != 0
+            model.shortwave_h2o_absorption[ig, :, :, :] .*= absorption_scales[ig]
+        end
+        model.shortwave_rayleigh_molar_scattering[ig] *= rayleigh_scales[ig]
+    end
+    return model
+end
+
+function apply_reduced_preflight_table_moves!(model, moves)
+    for move in moves
+        component = move["component"]
+        local_gpoint_index = Int(move["local_gpoint_index"])
+        pressure_range = Int(move["pressure_index_start"]):Int(move["pressure_index_end"])
+        scale = exp(clamp(Float64(move["log_scale"]), -5.0, 5.0))
+        if component == "static_absorption"
+            model.shortwave_absorption[local_gpoint_index, :, pressure_range, :] .*= scale
+        elseif component == "dynamic_h2o"
+            if length(model.shortwave_h2o_absorption) != 0
+                model.shortwave_h2o_absorption[local_gpoint_index, pressure_range, :, :] .*= scale
+            end
+        else
+            error("unsupported reduced preflight table move component $component")
+        end
+    end
+    return model
+end
+
+function apply_reduced_preflight_active_table_entry_moves!(model, moves)
+    for move in moves
+        component = move["component"]
+        local_gpoint_index = Int(move["local_gpoint_index"])
+        pressure_index = Int(move["pressure_index"])
+        temperature_index = Int(move["temperature_index"])
+        scale = exp(clamp(Float64(move["log_scale"]), -5.0, 5.0))
+        if component == "static_absorption"
+            gas_index = Int(move["gas_index"])
+            model.shortwave_absorption[
+                local_gpoint_index,
+                gas_index,
+                pressure_index,
+                temperature_index,
+            ] *= scale
+        elseif component == "dynamic_h2o"
+            if length(model.shortwave_h2o_absorption) != 0
+                h2o_index = Int(move["h2o_index"])
+                model.shortwave_h2o_absorption[
+                    local_gpoint_index,
+                    pressure_index,
+                    temperature_index,
+                    h2o_index,
+                ] *= scale
+            end
+        else
+            error("unsupported reduced preflight active table-entry move component $component")
+        end
+    end
+    return model
+end
+
+function table_refined_reduced_accuracy_status()
+    path = reduced_accuracy_json()
+    isfile(path) || return "missing_reduced_accuracy"
+    result = JSON.parsefile(path)
+    models = get(result, "models", Any[])
+    target = "weighted greedy 16 shortwave g-point subset with latest preflight-optimized weights, coefficient scales, and pressure-band table moves"
+    for model in models
+        model isa AbstractDict || continue
+        get(model, "reduction_method", "") == target || continue
+        return get(model, "passed_hard_thresholds", false) ? "passed" : "failed_threshold"
+    end
+    return "missing_table_refined_reduced_accuracy"
+end
+
+function reduced_preflight_table_refined_gas_optics()
+    full = official_ecckd_gas_optics()
+    preflight = JSON.parsefile(reduced_preflight_json())
+    lw_indices = collect(1:size(full.longwave_absorption, 1))
+    sw_indices = REDUCED_PREFLIGHT_SW_16_INDICES
+    source_table = full.longwave_source_table === nothing ||
+        length(full.longwave_source_table) == 0 ?
+        full.longwave_source_table :
+        full.longwave_source_table[lw_indices, :]
+    reduced = EcCKDTabulatedGasOpticsModel(
+        gas_names = Lightflux.gas_names(full),
+        pressure_grid = full.pressure_grid,
+        temperature_grid = full.temperature_grid,
+        h2o_mole_fraction_grid = full.h2o_mole_fraction_grid,
+        gas_reference_mole_fractions = full.gas_reference_mole_fractions,
+        longwave_absorption = copy(full.longwave_absorption[lw_indices, :, :, :]),
+        shortwave_absorption = copy(full.shortwave_absorption[sw_indices, :, :, :]),
+        longwave_h2o_absorption = length(full.longwave_h2o_absorption) == 0 ?
+            full.longwave_h2o_absorption : copy(full.longwave_h2o_absorption[lw_indices, :, :, :]),
+        shortwave_h2o_absorption = length(full.shortwave_h2o_absorption) == 0 ?
+            full.shortwave_h2o_absorption : copy(full.shortwave_h2o_absorption[sw_indices, :, :, :]),
+        shortwave_rayleigh_molar_scattering =
+            copy(full.shortwave_rayleigh_molar_scattering[sw_indices]),
+        longwave_source_scale = copy(full.longwave_source_scale[lw_indices]),
+        longwave_source_temperature_grid = full.longwave_source_temperature_grid,
+        longwave_source_table = source_table,
+        longwave_weights = full.longwave_weights[lw_indices] ./ sum(full.longwave_weights[lw_indices]),
+        shortwave_weights = full.shortwave_weights[sw_indices] ./ sum(full.shortwave_weights[sw_indices]),
+    )
+    apply_reduced_preflight_parameters!(reduced, reduced_preflight_parameters(preflight))
+    apply_reduced_preflight_table_moves!(reduced, reduced_preflight_table_moves(preflight))
+    apply_reduced_preflight_active_table_entry_moves!(
+        reduced,
+        reduced_best_active_table_entry_moves(preflight),
+    )
+    refit_weights = reduced_exact_weight_refit_weights()
+    refit_weights === nothing || (reduced.shortwave_weights .= refit_weights)
+    return reduced
+end
+
+function benchmark_gas_model(FT)
+    source = get(ENV, "RADIATIVE_HEATING_GAS_MODEL_SOURCE", "synthetic_fixed_coefficients")
+    if source == "validated_ecCKD"
+        gas_optics = official_ecckd_gas_optics()
+        return (
+            gas_optics = gas_optics,
+            kind = "official_ecCKD_$(size(gas_optics.longwave_absorption, 1))_lw_$(size(gas_optics.shortwave_absorption, 1))_sw",
+            source = "validated_ecCKD",
+            accuracy_status = accuracy_gate_status(),
+        )
+    elseif source == "validated_ecCKD_reduced_preflight_table_refined"
+        preflight = JSON.parsefile(reduced_preflight_json())
+        gas_optics = reduced_preflight_table_refined_gas_optics()
+        return (
+            gas_optics = gas_optics,
+            kind = "official_ecCKD_reduced_preflight_table_refined_$(size(gas_optics.longwave_absorption, 1))_lw_$(size(gas_optics.shortwave_absorption, 1))_sw",
+            source = "validated_ecCKD_reduced_preflight_table_refined",
+            accuracy_status = table_refined_reduced_accuracy_status(),
+            preflight_pressure_move_count =
+                length(reduced_preflight_table_moves(preflight)),
+            preflight_active_table_entry_move_count =
+                length(reduced_best_active_table_entry_moves(preflight)),
+        )
+    elseif source == "synthetic_fixed_coefficients"
+        ng_lw = envint("RADIATIVE_HEATING_NG_LW", 32)
+        ng_sw = envint("RADIATIVE_HEATING_NG_SW", 16)
+        return (
+            gas_optics = make_gas_optics(FT; ng_lw, ng_sw),
+            kind = "fixed_ecCKD_$(ng_lw)_lw_$(ng_sw)_sw",
+            source = "synthetic_fixed_coefficients",
+            accuracy_status = "not_checked_scaffold",
+        )
+    end
+    error("unsupported RADIATIVE_HEATING_GAS_MODEL_SOURCE=$source")
+end
+
+function benchmark_gas_values(gas_model)
+    FT = eltype(gas_model.gas_optics)
+    if gas_model.source in ("validated_ecCKD",
+                            "validated_ecCKD_reduced_preflight_table_refined")
+        return Dict{Symbol, FT}(
+            :co2 => FT(envfloat("RADIATIVE_HEATING_CO2_VMR", 420.0e-6)),
+            :o3 => FT(envfloat("RADIATIVE_HEATING_O3_VMR", 0.0)),
+            :ch4 => FT(envfloat("RADIATIVE_HEATING_CH4_VMR", 1.8e-6)),
+            :n2o => FT(envfloat("RADIATIVE_HEATING_N2O_VMR", 330.0e-9)),
+            :cfc11 => FT(envfloat("RADIATIVE_HEATING_CFC11_VMR", 230.0e-12)),
+            :cfc12 => FT(envfloat("RADIATIVE_HEATING_CFC12_VMR", 520.0e-12)),
+        )
+    end
+    return Dict{Symbol, FT}(
+        :co2 => FT(envfloat("RADIATIVE_HEATING_CO2_VMR", 400.0e-6)),
+    )
+end
+
+function json_gas_values(gas_values)
+    return Dict(String(key) => value for (key, value) in gas_values)
+end
+
+function gas_model_device_support(backend, gas_optics)
+    ext = Base.get_extension(Breeze, :BreezeLightfluxExt)
+    ext !== nothing ||
+        error("BreezeLightfluxExt is not loaded; load Lightflux with Breeze before benchmarking")
+    return Base.invokelatest(ext.radiative_heating_device_support, backend, gas_optics)
+end
+
+function build_model(radiation, grid, constants)
+    reference_state = ReferenceState(grid, constants;
+                                     surface_pressure = 101325,
+                                     potential_temperature = 300)
+    dynamics = AnelasticDynamics(reference_state)
+    clock = Clock(time = DateTime(2024, 7, 15, 12, 0, 0))
+    model = AtmosphereModel(grid; clock, dynamics,
+                            formulation = :LiquidIcePotentialTemperature,
+                            radiation)
+    θ(x, y, z) = 300 + 18 * (z / 30e3)^1.25
+    qᵗ(x, y, z) = 0.018 * exp(-z / 2400)
+    set!(model; θ, qᵗ)
+    return model
+end
+
+function median_seconds!(f, samples)
+    times = Float64[]
+    for _ in 1:samples
+        GC.gc(false)
+        push!(times, @elapsed f())
+    end
+    return median(times)
+end
+
+sync_backend(backend) = backend == "H100" ? CUDA.synchronize() : nothing
+
+function final_acceptance(result)
+    result["status"] == "final_4x_evidence" ||
+        return false, "benchmark status is $(result["status"]), not final_4x_evidence"
+    result["backend"] == "H100" || return false, "backend is $(result["backend"]), not H100"
+    result["radiative_heating_runtime_supported"] == true || return false, "RadiativeHeating runtime did not run on H100"
+    result["rrtmgp_runtime_supported"] == true || return false, "RRTMGP baseline did not run on H100"
+    result["radiation_update_speedup"] >= 4 || return false, "radiation update speedup is below 4x"
+    result["nsys_report"] != "" || return false, "missing Nsight Systems report"
+    result["ncu_report"] != "" || return false, "missing Nsight Compute report"
+    result["gas_model_source"] != "synthetic_fixed_coefficients" ||
+        return false, "gas model source is synthetic fixed coefficients"
+    result["gas_model_accuracy_status"] == "passed" ||
+        return false, "gas model accuracy status is $(result["gas_model_accuracy_status"]), not passed"
+    get(result, "gas_model_device_support_status", "missing") == "supported" ||
+        return false, "gas model device support is $(get(result, "gas_model_device_support_status", "missing")): $(get(result, "gas_model_device_support_reason", ""))"
+    return true, "none"
+end
+
+function main()
+    FT = Float64
+    Nx = envint("RADIATIVE_HEATING_NX", 16)
+    Ny = envint("RADIATIVE_HEATING_NY", 16)
+    Nz = envint("RADIATIVE_HEATING_NZ", 64)
+    samples = envint("RADIATIVE_HEATING_SAMPLES", 3)
+    output_dir = get(ENV, "RADIATIVE_HEATING_RCEMIP_DIR",
+                     joinpath(@__DIR__, "results"))
+    mkpath(output_dir)
+
+    backend, arch = backend_name()
+    grid = rcemip_grid(arch, FT, Nx, Ny, Nz)
+    constants = Breeze.Thermodynamics.ThermodynamicConstants()
+
+    rh_model = nothing
+    rh_seconds = Inf
+    rh_allocations = nothing
+    rh_supported = true
+    rh_error = ""
+    gas_model_kind = ""
+    gas_model_source = get(ENV, "RADIATIVE_HEATING_GAS_MODEL_SOURCE", "synthetic_fixed_coefficients")
+    gas_model_accuracy_status = "not_loaded"
+    gas_values = Dict{Symbol, FT}()
+    preflight_pressure_move_count = nothing
+    preflight_active_table_entry_move_count = nothing
+    gas_model_device_support_status = "not_checked"
+    gas_model_device_support_reason = "gas model was not loaded"
+    gas_model_device_support_source = "not_checked"
+    try
+        gas_model = benchmark_gas_model(FT)
+        gas_optics = gas_model.gas_optics
+        gas_values = benchmark_gas_values(gas_model)
+        gas_model_kind = gas_model.kind
+        gas_model_source = gas_model.source
+        gas_model_accuracy_status = gas_model.accuracy_status
+        preflight_pressure_move_count =
+            hasproperty(gas_model, :preflight_pressure_move_count) ?
+            gas_model.preflight_pressure_move_count : nothing
+        preflight_active_table_entry_move_count =
+            hasproperty(gas_model, :preflight_active_table_entry_move_count) ?
+            gas_model.preflight_active_table_entry_move_count : nothing
+        device_support = gas_model_device_support(backend, gas_optics)
+        gas_model_device_support_status = device_support.status
+        gas_model_device_support_reason = device_support.reason
+        gas_model_device_support_source = getproperty(device_support, :source)
+        rh_radiation = Base.invokelatest(() ->
+            RadiativeTransferModel(grid, RadiativeHeatingOptics(), constants;
+                                   gas_optics,
+                                   gas_values,
+                                   surface_temperature = 300,
+                                   surface_albedo = 0.07,
+                                   surface_emissivity = 0.98,
+                                   solar_constant = 551))
+        rh_model = build_model(rh_radiation, grid, constants)
+        Base.invokelatest(update_radiation!, rh_model.radiation, rh_model)
+        sync_backend(backend)
+        rh_allocations = backend == "CPU" ? @allocated(Base.invokelatest(update_radiation!, rh_model.radiation, rh_model)) : nothing
+        rh_seconds = median_seconds!(samples) do
+            Base.invokelatest(update_radiation!, rh_model.radiation, rh_model)
+            sync_backend(backend)
+        end
+    catch err
+        rh_supported = false
+        rh_error = sprint(showerror, err)
+    end
+
+    rrtmgp_seconds = Inf
+    rrtmgp_allocations = nothing
+    rrtmgp_supported = true
+    rrtmgp_error = ""
+    try
+        rrtmgp_radiation = Base.invokelatest(() ->
+            RadiativeTransferModel(grid, ClearSkyOptics(), constants;
+                                   surface_temperature = 300,
+                                   surface_emissivity = 0.98,
+                                   surface_albedo = 0.07,
+                                   solar_constant = 551,
+                                   coordinate = (0.0, 0.0)))
+        rrtmgp_model = build_model(rrtmgp_radiation, grid, constants)
+        Base.invokelatest(update_radiation!, rrtmgp_model.radiation, rrtmgp_model)
+        sync_backend(backend)
+        rrtmgp_allocations = backend == "CPU" ? @allocated(Base.invokelatest(update_radiation!, rrtmgp_model.radiation, rrtmgp_model)) : nothing
+        rrtmgp_seconds = median_seconds!(samples) do
+            Base.invokelatest(update_radiation!, rrtmgp_model.radiation, rrtmgp_model)
+            sync_backend(backend)
+        end
+    catch err
+        rrtmgp_supported = false
+        rrtmgp_error = sprint(showerror, err)
+    end
+
+    speedup = isfinite(rh_seconds) && isfinite(rrtmgp_seconds) ? rrtmgp_seconds / rh_seconds : 0.0
+    result = Dict(
+        "case" => "radiative_heating_rcemip_benchmark",
+        "status" => benchmark_status(),
+        "timestamp_utc" => string(now(UTC)),
+        "backend" => backend,
+        "grid" => Dict("nx" => Nx, "ny" => Ny, "nz" => Nz, "columns" => Nx * Ny),
+        "samples" => samples,
+        "workload" => "RCEMIP-style nontrivial column ensemble without expensive spinup",
+        "gas_model_kind" => gas_model_kind,
+        "gas_model_source" => gas_model_source,
+        "gas_model_accuracy_status" => gas_model_accuracy_status,
+        "preflight_pressure_move_count" => preflight_pressure_move_count,
+        "preflight_active_table_entry_move_count" =>
+            preflight_active_table_entry_move_count,
+        "gas_values" => json_gas_values(gas_values),
+        "gas_model_device_support_status" => gas_model_device_support_status,
+        "gas_model_device_support_reason" => gas_model_device_support_reason,
+        "gas_model_device_support_source" => gas_model_device_support_source,
+        "radiative_heating_runtime_supported" => rh_supported,
+        "radiative_heating_error" => rh_error,
+        "radiation_update_allocations" => rh_allocations,
+        "rrtmgp_runtime_supported" => rrtmgp_supported,
+        "rrtmgp_error" => rrtmgp_error,
+        "rrtmgp_radiation_update_allocations" => rrtmgp_allocations,
+        "radiative_heating_update_median_ms" => isfinite(rh_seconds) ? 1000rh_seconds : nothing,
+        "rrtmgp_update_median_ms" => isfinite(rrtmgp_seconds) ? 1000rrtmgp_seconds : nothing,
+        "radiation_update_speedup" => speedup,
+        "nsys_report" => get(ENV, "RADIATIVE_HEATING_NSYS_REPORT", ""),
+        "ncu_report" => get(ENV, "RADIATIVE_HEATING_NCU_REPORT", ""),
+    )
+    accepted, reason = final_acceptance(result)
+    result["final_4x_claim_supported"] = accepted
+    result["final_4x_blocking_reason"] = reason
+
+    json_path = joinpath(output_dir, "radiative_heating_rcemip_latest.json")
+    open(json_path, "w") do io
+        JSON.print(io, result, 2)
+        println(io)
+    end
+
+    md_path = joinpath(output_dir, "radiative_heating_rcemip_latest.md")
+    open(md_path, "w") do io
+        println(io, "# Radiative Heating RCEMIP-Style Benchmark")
+        println(io)
+        println(io, "- status: ", result["status"])
+        println(io, "- backend: ", result["backend"])
+        println(io, "- grid: ", Nx, " x ", Ny, " x ", Nz)
+        println(io, "- gas model source: ", result["gas_model_source"])
+        println(io, "- gas model kind: ", result["gas_model_kind"])
+        println(io, "- gas model accuracy status: ", result["gas_model_accuracy_status"])
+        println(io, "- gas values: ", result["gas_values"])
+        println(io, "- gas model device support: ", result["gas_model_device_support_status"])
+        println(io, "- gas model device support reason: ", result["gas_model_device_support_reason"])
+        println(io, "- gas model device support source: ", result["gas_model_device_support_source"])
+        println(io, "- RadiativeHeating supported: ", rh_supported)
+        println(io, "- RRTMGP supported: ", rrtmgp_supported)
+        println(io, "- speedup: ", @sprintf("%.3f", speedup), "x")
+        println(io, "- final 4x claim supported: ", accepted)
+        println(io, "- blocking reason: ", reason)
+    end
+
+    println(json_path)
+    return accepted ? 0 : 1
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    exit(main())
+end

--- a/benchmarking/radiative_heating_reduced_pareto.jl
+++ b/benchmarking/radiative_heating_reduced_pareto.jl
@@ -1,0 +1,189 @@
+using Dates
+using JSON
+using Printf
+
+const DEFAULT_REDUCED_PARETO_DIR =
+    joinpath(@__DIR__, "results", "reduced_pareto")
+const DEFAULT_REDUCED_ACCURACY_JSON =
+    joinpath(@__DIR__, "results", "reduced_accuracy",
+             "radiative_heating_reduced_accuracy_latest.json")
+const TABLE_REFINED_METHOD =
+    "weighted greedy 16 shortwave g-point subset with latest preflight-optimized weights, coefficient scales, and pressure-band table moves"
+
+function read_json_if_exists(path)
+    isfile(path) || return nothing
+    return JSON.parsefile(path)
+end
+
+function model_accuracy_by_method(path)
+    result = read_json_if_exists(path)
+    result === nothing && return Dict{String, Any}()
+    rows = Dict{String, Any}()
+    for model in get(result, "models", Any[])
+        model isa AbstractDict || continue
+        method = get(model, "reduction_method", "")
+        isempty(method) && continue
+        cases = get(model, "cases", Any[])
+        worst_toa = isempty(cases) ? nothing :
+            maximum(case -> get(case, "toa_forcing_max_abs", 0.0), cases)
+        worst_surface = isempty(cases) ? nothing :
+            maximum(case -> get(case, "surface_forcing_max_abs", 0.0), cases)
+        rows[method] = Dict(
+            "passed_hard_thresholds" => get(model, "passed_hard_thresholds", false),
+            "worst_toa_forcing_error_w_m2" => worst_toa,
+            "worst_surface_forcing_error_w_m2" => worst_surface,
+        )
+    end
+    return rows
+end
+
+function benchmark_row(path; label, reduction_method = nothing)
+    result = read_json_if_exists(path)
+    result === nothing && return nothing
+    grid = get(result, "grid", Dict{String, Any}())
+    return Dict(
+        "label" => label,
+        "source" => relpath(path, @__DIR__),
+        "backend" => get(result, "backend", "missing"),
+        "columns" => get(grid, "columns", nothing),
+        "nx" => get(grid, "nx", nothing),
+        "ny" => get(grid, "ny", nothing),
+        "nz" => get(grid, "nz", nothing),
+        "ng_lw" => occursin("32_lw", get(result, "gas_model_kind", "")) ? 32 :
+            occursin("16_lw", get(result, "gas_model_kind", "")) ? 16 : nothing,
+        "ng_sw" => occursin("16_sw", get(result, "gas_model_kind", "")) ? 16 :
+            occursin("32_sw", get(result, "gas_model_kind", "")) ? 32 : nothing,
+        "gas_model_source" => get(result, "gas_model_source", "missing"),
+        "gas_model_kind" => get(result, "gas_model_kind", "missing"),
+        "gas_model_accuracy_status" => get(result, "gas_model_accuracy_status", "missing"),
+        "gas_model_device_support_status" =>
+            get(result, "gas_model_device_support_status", "missing"),
+        "radiative_heating_runtime_supported" =>
+            get(result, "radiative_heating_runtime_supported", false),
+        "rrtmgp_runtime_supported" => get(result, "rrtmgp_runtime_supported", false),
+        "radiative_heating_update_median_ms" =>
+            get(result, "radiative_heating_update_median_ms", nothing),
+        "rrtmgp_update_median_ms" => get(result, "rrtmgp_update_median_ms", nothing),
+        "speedup_vs_rrtmgp" => get(result, "radiation_update_speedup", nothing),
+        "hot_path_allocations" => get(result, "radiation_update_allocations", nothing),
+        "rrtmgp_hot_path_allocations" =>
+            get(result, "rrtmgp_radiation_update_allocations", nothing),
+        "nsys_report" => get(result, "nsys_report", ""),
+        "ncu_report" => get(result, "ncu_report", ""),
+        "benchmark_status" => get(result, "status", "missing"),
+        "final_4x_claim_supported" => get(result, "final_4x_claim_supported", false),
+        "reduction_method" => reduction_method,
+    )
+end
+
+function enriched_rows(rows, accuracy)
+    for row in rows
+        method = get(row, "reduction_method", nothing)
+        method === nothing && continue
+        metrics = get(accuracy, method, nothing)
+        metrics === nothing && continue
+        row["passed_hard_thresholds"] = metrics["passed_hard_thresholds"]
+        row["worst_toa_forcing_error_w_m2"] = metrics["worst_toa_forcing_error_w_m2"]
+        row["worst_surface_forcing_error_w_m2"] =
+            metrics["worst_surface_forcing_error_w_m2"]
+    end
+    return rows
+end
+
+function reduced_pareto_result()
+    output_dir = get(ENV, "RADIATIVE_HEATING_REDUCED_PARETO_DIR",
+                     DEFAULT_REDUCED_PARETO_DIR)
+    accuracy_json = get(ENV, "RADIATIVE_HEATING_REDUCED_ACCURACY_JSON",
+                        DEFAULT_REDUCED_ACCURACY_JSON)
+    accuracy = model_accuracy_by_method(accuracy_json)
+    benchmark_specs = [
+        (
+            label = "synthetic 16x16 H100 term-count scaffold",
+            path = joinpath(output_dir, "ng_lw_16_ng_sw_16",
+                            "radiative_heating_rcemip_latest.json"),
+            method = nothing,
+        ),
+        (
+            label = "synthetic 32x16 H100 term-count scaffold",
+            path = joinpath(output_dir, "ng_lw_32_ng_sw_16",
+                            "radiative_heating_rcemip_latest.json"),
+            method = nothing,
+        ),
+        (
+            label = "official 32x16 preflight table-refined H100 smoke",
+            path = joinpath(@__DIR__, "results",
+                            "reduced_preflight_table_refined_h100_smoke",
+                            "radiative_heating_rcemip_latest.json"),
+            method = TABLE_REFINED_METHOD,
+        ),
+    ]
+    rows = Dict{String, Any}[]
+    for spec in benchmark_specs
+        row = benchmark_row(spec.path; label = spec.label, reduction_method = spec.method)
+        row === nothing || push!(rows, row)
+    end
+    enriched_rows(rows, accuracy)
+    accuracy_status = any(row -> get(row, "passed_hard_thresholds", false), rows) ?
+        "contains_passing_reduced_model" : "failed_threshold"
+    runtime_status = all(row -> get(row, "radiative_heating_runtime_supported", false),
+                         rows) ? "runtime_available" : "runtime_incomplete"
+    return Dict(
+        "case" => "radiative_heating_reduced_pareto",
+        "timestamp_utc" => string(now(UTC)),
+        "status" => runtime_status == "runtime_available" &&
+            accuracy_status == "failed_threshold" ?
+            "h100_runtime_accuracy_failed_threshold" :
+            "$(runtime_status)_$(accuracy_status)",
+        "accuracy_status" => accuracy_status,
+        "workload" => "RCEMIP-style Breeze radiation update without expensive spinup",
+        "accuracy_source" => relpath(accuracy_json, @__DIR__),
+        "models" => rows,
+    )
+end
+
+function write_reduced_pareto(result)
+    output_dir = get(ENV, "RADIATIVE_HEATING_REDUCED_PARETO_DIR",
+                     DEFAULT_REDUCED_PARETO_DIR)
+    mkpath(output_dir)
+    json_path = joinpath(output_dir, "radiative_heating_reduced_pareto_latest.json")
+    open(json_path, "w") do io
+        JSON.print(io, result, 2)
+        println(io)
+    end
+
+    md_path = joinpath(output_dir, "radiative_heating_reduced_pareto_latest.md")
+    open(md_path, "w") do io
+        println(io, "# Reduced ecCKD Pareto Evidence")
+        println(io)
+        println(io, "Status: ", result["status"])
+        println(io)
+        println(io, "| Label | backend | grid | RH ms | RRTMGP ms | speedup | accuracy | TOA W m^-2 | surface W m^-2 | support |")
+        println(io, "|---|---|---:|---:|---:|---:|---|---:|---:|---|")
+        for row in result["models"]
+            grid = "$(row["nx"])x$(row["ny"])x$(row["nz"])"
+            rh = row["radiative_heating_update_median_ms"]
+            rrtmgp = row["rrtmgp_update_median_ms"]
+            speedup = row["speedup_vs_rrtmgp"]
+            toa = get(row, "worst_toa_forcing_error_w_m2", nothing)
+            surface = get(row, "worst_surface_forcing_error_w_m2", nothing)
+            println(io, "| ", row["label"], " | ", row["backend"], " | ", grid, " | ",
+                    rh === nothing ? "n/a" : @sprintf("%.6g", rh), " | ",
+                    rrtmgp === nothing ? "n/a" : @sprintf("%.6g", rrtmgp), " | ",
+                    speedup === nothing ? "n/a" : @sprintf("%.6g", speedup), " | ",
+                    get(row, "gas_model_accuracy_status", "missing"), " | ",
+                    toa === nothing ? "n/a" : @sprintf("%.12g", toa), " | ",
+                    surface === nothing ? "n/a" : @sprintf("%.12g", surface), " | ",
+                    row["gas_model_device_support_status"], " |")
+        end
+        println(io)
+        println(io, "Accuracy source: `", result["accuracy_source"], "`.")
+        println(io, "The official table-refined row is smoke/runtime-path evidence until the reduced hard thresholds pass.")
+    end
+    println(json_path)
+    println(md_path)
+    return json_path, md_path
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    write_reduced_pareto(reduced_pareto_result())
+end

--- a/benchmarking/radiative_heating_tabulated_ecckd_parity.jl
+++ b/benchmarking/radiative_heating_tabulated_ecckd_parity.jl
@@ -1,0 +1,160 @@
+using JSON
+
+if !@isdefined(benchmark_gas_model)
+    include(joinpath(@__DIR__, "radiative_heating_rcemip_benchmark.jl"))
+end
+
+const PARITY_FIELDS = (
+    :upwelling_longwave_flux,
+    :downwelling_longwave_flux,
+    :downwelling_shortwave_flux,
+    :flux_divergence,
+)
+
+function radiation_field_arrays(radiation)
+    return Dict(
+        String(name) => Array(interior(getproperty(radiation, name)))
+        for name in PARITY_FIELDS
+    )
+end
+
+function field_error(candidate, reference)
+    difference = candidate .- reference
+    return Dict(
+        "max_abs" => maximum(abs, difference),
+        "rmse" => sqrt(sum(abs2, difference) / length(difference)),
+        "reference_max_abs" => maximum(abs, reference),
+    )
+end
+
+function parity_errors(cpu_arrays, gpu_arrays)
+    return Dict(
+        name => field_error(gpu_arrays[name], cpu_arrays[name])
+        for name in keys(cpu_arrays)
+    )
+end
+
+function parity_passed(errors; atol, rtol)
+    for (name, metrics) in errors
+        threshold = atol + rtol * metrics["reference_max_abs"]
+        metrics["max_abs"] <= threshold || return false
+    end
+    return true
+end
+
+function build_radiative_heating_model(arch, FT, Nx, Ny, Nz, gas_model, gas_values)
+    grid = rcemip_grid(arch, FT, Nx, Ny, Nz)
+    constants = Breeze.Thermodynamics.ThermodynamicConstants()
+    radiation = Base.invokelatest(() ->
+        RadiativeTransferModel(grid, RadiativeHeatingOptics(), constants;
+                               gas_optics = gas_model.gas_optics,
+                               gas_values,
+                               surface_temperature = 300,
+                               surface_albedo = 0.07,
+                               surface_emissivity = 0.98,
+                               solar_constant = 551))
+    model = build_model(radiation, grid, constants)
+    Base.invokelatest(update_radiation!, model.radiation, model)
+    return model
+end
+
+function write_parity_artifact(result, output_dir)
+    mkpath(output_dir)
+    json_path = joinpath(output_dir, "radiative_heating_tabulated_ecckd_parity_latest.json")
+    open(json_path, "w") do io
+        JSON.print(io, result, 2)
+        println(io)
+    end
+
+    md_path = joinpath(output_dir, "radiative_heating_tabulated_ecckd_parity_latest.md")
+    open(md_path, "w") do io
+        println(io, "# Radiative Heating Tabulated ecCKD CPU/GPU Parity")
+        println(io)
+        println(io, "- status: ", result["status"])
+        println(io, "- backend: ", result["backend"])
+        println(io, "- gas model source: ", result["gas_model_source"])
+        println(io, "- gas model kind: ", result["gas_model_kind"])
+        println(io, "- grid: ", result["grid"]["nx"], " x ", result["grid"]["ny"], " x ", result["grid"]["nz"])
+        println(io, "- tolerance atol: ", result["atol"])
+        println(io, "- tolerance rtol: ", result["rtol"])
+        println(io, "- passed: ", result["passed"])
+        println(io, "- reason: ", result["reason"])
+        if haskey(result, "field_errors")
+            println(io, "- field errors:")
+            for name in sort(collect(keys(result["field_errors"])))
+                metrics = result["field_errors"][name]
+                println(io, "  - ", name, ": max_abs=", metrics["max_abs"],
+                        ", rmse=", metrics["rmse"],
+                        ", reference_max_abs=", metrics["reference_max_abs"])
+            end
+        end
+    end
+    return json_path
+end
+
+function parity_main()
+    FT = Float64
+    Nx = envint("RADIATIVE_HEATING_PARITY_NX", 2)
+    Ny = envint("RADIATIVE_HEATING_PARITY_NY", 2)
+    Nz = envint("RADIATIVE_HEATING_PARITY_NZ", 8)
+    atol = envfloat("RADIATIVE_HEATING_PARITY_ATOL", 1.0e-8)
+    rtol = envfloat("RADIATIVE_HEATING_PARITY_RTOL", 1.0e-8)
+    output_dir = get(ENV, "RADIATIVE_HEATING_PARITY_DIR",
+                     joinpath(@__DIR__, "results", "tabulated_ecckd_parity"))
+
+    source = get(ENV, "RADIATIVE_HEATING_GAS_MODEL_SOURCE", "validated_ecCKD")
+    result = Dict(
+        "case" => "radiative_heating_tabulated_ecckd_cpu_gpu_parity",
+        "timestamp_utc" => string(now(UTC)),
+        "backend" => "H100",
+        "grid" => Dict("nx" => Nx, "ny" => Ny, "nz" => Nz, "columns" => Nx * Ny),
+        "atol" => atol,
+        "rtol" => rtol,
+        "gas_model_source" => source,
+        "gas_model_kind" => "",
+        "passed" => false,
+        "status" => "blocked",
+        "reason" => "",
+    )
+
+    if !CUDA.functional()
+        result["reason"] = "CUDA.functional() is false; cannot run CPU/GPU parity smoke test"
+        path = write_parity_artifact(result, output_dir)
+        println(path)
+        return 2
+    end
+
+    try
+        gas_model = withenv("RADIATIVE_HEATING_GAS_MODEL_SOURCE" => source) do
+            benchmark_gas_model(FT)
+        end
+        result["gas_model_source"] = gas_model.source
+        result["gas_model_kind"] = gas_model.kind
+        gas_values = benchmark_gas_values(gas_model)
+
+        cpu_model = build_radiative_heating_model(CPU(), FT, Nx, Ny, Nz, gas_model, gas_values)
+        gpu_model = build_radiative_heating_model(GPU(), FT, Nx, Ny, Nz, gas_model, gas_values)
+        CUDA.synchronize()
+
+        cpu_arrays = radiation_field_arrays(cpu_model.radiation)
+        gpu_arrays = radiation_field_arrays(gpu_model.radiation)
+        errors = parity_errors(cpu_arrays, gpu_arrays)
+        passed = parity_passed(errors; atol, rtol)
+        result["field_errors"] = errors
+        result["passed"] = passed
+        result["status"] = passed ? "passed" : "failed_threshold"
+        result["reason"] = passed ? "CPU/GPU field parity passed" :
+            "one or more radiation fields exceeded parity tolerance"
+    catch err
+        result["status"] = "failed"
+        result["reason"] = sprint(showerror, err)
+    end
+
+    path = write_parity_artifact(result, output_dir)
+    println(path)
+    return result["status"] == "passed" ? 0 : 1
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    exit(parity_main())
+end

--- a/benchmarking/results/gpu_environment/radiative_heating_gpu_environment_latest.md
+++ b/benchmarking/results/gpu_environment/radiative_heating_gpu_environment_latest.md
@@ -1,0 +1,10 @@
+# Radiative Heating GPU Environment
+
+- status: ready_for_h100_nsight_gate
+- host: gpu-prod-st-gpu-prod-1
+- slurm_job_id: 1097
+- H100 detected: true
+- nvidia-smi: true
+- CUDA functional: true
+- Nsight Systems: true
+- Nsight Compute: true

--- a/benchmarking/results/gpu_environment_h100_job764_with_nsight/radiative_heating_gpu_environment_latest.md
+++ b/benchmarking/results/gpu_environment_h100_job764_with_nsight/radiative_heating_gpu_environment_latest.md
@@ -1,0 +1,10 @@
+# Radiative Heating GPU Environment
+
+- status: ready_for_h100_nsight_gate
+- host: gpu-prod-st-gpu-prod-1
+- slurm_job_id: 764
+- H100 detected: true
+- nvidia-smi: true
+- CUDA functional: true
+- Nsight Systems: true
+- Nsight Compute: true

--- a/benchmarking/results/gpu_environment_local/radiative_heating_gpu_environment_latest.md
+++ b/benchmarking/results/gpu_environment_local/radiative_heating_gpu_environment_latest.md
@@ -1,0 +1,10 @@
+# Radiative Heating GPU Environment
+
+- status: not_ready
+- host: ip-10-40-5-138
+- slurm_job_id: 
+- H100 detected: false
+- nvidia-smi: false
+- CUDA functional: false
+- Nsight Systems: true
+- Nsight Compute: true

--- a/benchmarking/results/h100_validated_ecckd_preflight/radiative_heating_h100_support_preflight_latest.md
+++ b/benchmarking/results/h100_validated_ecckd_preflight/radiative_heating_h100_support_preflight_latest.md
@@ -1,0 +1,13 @@
+# Radiative Heating H100 Support Preflight
+
+- status: supported
+- backend: H100
+- gas model source: validated_ecCKD
+- gas model kind: official_ecCKD_32_lw_32_sw
+- gas model accuracy status: passed
+- gas model device support: supported
+- reason: H100 extension path supports tabulated multi-gas ecCKD with recorded CPU/GPU parity evidence
+- source: BreezeRadiativeHeatingExt
+- missing kernel requirements:
+- next required implementation: none
+- acceptance unblocked when: H100 support preflight passes

--- a/benchmarking/results/rcemip_h100_16x16x64/radiative_heating_rcemip_latest.md
+++ b/benchmarking/results/rcemip_h100_16x16x64/radiative_heating_rcemip_latest.md
@@ -1,0 +1,10 @@
+# Radiative Heating RCEMIP-Style Benchmark
+
+- status: scaffold_not_final_4x_evidence
+- backend: H100
+- grid: 16 x 16 x 64
+- RadiativeHeating supported: true
+- RRTMGP supported: true
+- speedup: 29.792x
+- final 4x claim supported: false
+- blocking reason: missing Nsight Systems report

--- a/benchmarking/results/rcemip_h100_16x16x64_profiled/radiative_heating_rcemip_latest.md
+++ b/benchmarking/results/rcemip_h100_16x16x64_profiled/radiative_heating_rcemip_latest.md
@@ -1,0 +1,10 @@
+# Radiative Heating RCEMIP-Style Benchmark
+
+- status: scaffold_not_final_4x_evidence
+- backend: H100
+- grid: 16 x 16 x 64
+- RadiativeHeating supported: true
+- RRTMGP supported: true
+- speedup: 43.697x
+- final 4x claim supported: true
+- blocking reason: none

--- a/benchmarking/results/rcemip_h100_32x32x64/radiative_heating_rcemip_latest.md
+++ b/benchmarking/results/rcemip_h100_32x32x64/radiative_heating_rcemip_latest.md
@@ -1,0 +1,17 @@
+# Radiative Heating RCEMIP-Style Benchmark
+
+- status: final_4x_evidence
+- backend: H100
+- grid: 32 x 32 x 64
+- gas model source: validated_ecCKD
+- gas model kind: official_ecCKD_32_lw_32_sw
+- gas model accuracy status: passed
+- gas values: Dict("o3" => 0.0, "ch4" => 1.8e-6, "cfc11" => 2.3e-10, "n2o" => 3.3e-7, "cfc12" => 5.2e-10, "co2" => 0.00042)
+- gas model device support: supported
+- gas model device support reason: H100 extension path supports tabulated multi-gas ecCKD with recorded CPU/GPU parity evidence
+- gas model device support source: BreezeRadiativeHeatingExt
+- RadiativeHeating supported: true
+- RRTMGP supported: true
+- speedup: 31.335x
+- final 4x claim supported: true
+- blocking reason: none

--- a/benchmarking/results/rcemip_h100_ncu_smoke/radiative_heating_rcemip_latest.md
+++ b/benchmarking/results/rcemip_h100_ncu_smoke/radiative_heating_rcemip_latest.md
@@ -1,0 +1,10 @@
+# Radiative Heating RCEMIP-Style Benchmark
+
+- status: scaffold_not_final_4x_evidence
+- backend: H100
+- grid: 2 x 2 x 8
+- RadiativeHeating supported: true
+- RRTMGP supported: true
+- speedup: 6.522x
+- final 4x claim supported: true
+- blocking reason: none

--- a/benchmarking/results/rcemip_h100_smoke/radiative_heating_rcemip_latest.md
+++ b/benchmarking/results/rcemip_h100_smoke/radiative_heating_rcemip_latest.md
@@ -1,0 +1,10 @@
+# Radiative Heating RCEMIP-Style Benchmark
+
+- status: scaffold_not_final_4x_evidence
+- backend: H100
+- grid: 2 x 2 x 8
+- RadiativeHeating supported: true
+- RRTMGP supported: true
+- speedup: 2.655x
+- final 4x claim supported: false
+- blocking reason: radiation update speedup is below 4x

--- a/benchmarking/results/rcemip_smoke/radiative_heating_rcemip_latest.md
+++ b/benchmarking/results/rcemip_smoke/radiative_heating_rcemip_latest.md
@@ -1,0 +1,10 @@
+# Radiative Heating RCEMIP-Style Benchmark
+
+- status: scaffold_not_final_4x_evidence
+- backend: CPU
+- grid: 2 x 2 x 8
+- RadiativeHeating supported: true
+- RRTMGP supported: true
+- speedup: 9.083x
+- final 4x claim supported: false
+- blocking reason: backend is CPU, not H100

--- a/benchmarking/results/reduced_accuracy/radiative_heating_reduced_accuracy_latest.md
+++ b/benchmarking/results/reduced_accuracy/radiative_heating_reduced_accuracy_latest.md
@@ -1,0 +1,32 @@
+# Reduced ecCKD Accuracy
+
+Status: **failed_threshold**
+
+Reference scope: clean ecCKD cloudless/no-aerosol tropical and RCEMIP-style cases.
+
+| ng_lw | ng_sw | Method | Passed | Worst TOA forcing error | Worst surface forcing error |
+|---:|---:|---|---:|---:|---:|
+| 32 | 32 | official ecCKD 32x32 baseline without shortwave reduction | true | 0.00806408713606 W m^-2 | 0.0140335470378 W m^-2 |
+| 32 | 16 | evenly selected official ecCKD g-points with renormalized weights | false | 15.148939416 W m^-2 | 66.5675113805 W m^-2 |
+| 32 | 16 | greedy searched 16 shortwave g-point subset with official weights renormalized | false | 7.17718646856 W m^-2 | 6.84298667546 W m^-2 |
+| 32 | 16 | greedy searched 16 shortwave g-point subset with least-squares fitted shortwave weights | false | 31.0262219594 W m^-2 | 66.6731185186 W m^-2 |
+| 32 | 16 | greedy searched 16 shortwave g-point subset with projected boundary-weighted fitted shortwave weights | false | 5.55763254463 W m^-2 | 2.74834035515 W m^-2 |
+| 32 | 16 | weighted greedy 16 shortwave g-point subset with projected simplex weights | false | 5.52030576048 W m^-2 | 3.17852209835 W m^-2 |
+| 32 | 16 | weighted greedy 16 shortwave g-point subset with projected hard-gate max-norm weights | false | 5.51884380351 W m^-2 | 3.18861438431 W m^-2 |
+| 32 | 16 | weighted greedy 16 shortwave g-point subset with diagnostic fitted coefficient scales | false | 5.88171009786 W m^-2 | 5.77898204224 W m^-2 |
+| 32 | 16 | weighted greedy 16 shortwave g-point subset with latest preflight-optimized weights and coefficient scales | false | 2.58865294431 W m^-2 | 2.56622140734 W m^-2 |
+| 32 | 16 | weighted greedy 16 shortwave g-point subset with latest preflight-optimized weights, coefficient scales, and pressure-band table moves | false | 2.31170988514 W m^-2 | 2.75790205932 W m^-2 |
+| 32 | 16 | weighted greedy 16 shortwave g-point subset with latest preflight table moves and reduced incoming shortwave spectral weights | false | 2.31170988514 W m^-2 | 2.75790205932 W m^-2 |
+| 32 | 16 | weighted greedy 16 shortwave g-point subset with boundary-aware post-constrained weight refit | false | 2.32587243275 W m^-2 | 2.75109439529 W m^-2 |
+| 32 | 16 | weighted greedy 16 shortwave g-point subset with boundary-aware table, component, structural, objective-probe, surface-probe, capped table, continuation, post-capped weight, post-weight surface-table, bounded weight, four current component-scale refits, selected current gas-pressure component scan refit, gas-pressure continuation refit, weighted gas-pressure continuation refit, and high-weight gas-pressure continuation refit | false | 2.07524167121 W m^-2 | 2.02695668832 W m^-2 |
+| 32 | 16 | evenly selected official ecCKD g-points with least-squares fitted shortwave weights | false | 56.8890709074 W m^-2 | 118.958235969 W m^-2 |
+| 16 | 16 | evenly selected official ecCKD g-points with renormalized weights | false | 92.3557392308 W m^-2 | 171.674844598 W m^-2 |
+| 32 | 16 | adjacent official ecCKD g-point bins with spectral-weighted coefficient averages | false | 66.0484885039 W m^-2 | 164.983235003 W m^-2 |
+| 16 | 16 | adjacent official ecCKD g-point bins with spectral-weighted coefficient averages | false | 79.9785618291 W m^-2 | 156.746283354 W m^-2 |
+| 32 | 16 | cumulative spectral-weight bins with coefficient averages | false | 81.055508224 W m^-2 | 215.161432856 W m^-2 |
+| 16 | 16 | cumulative spectral-weight bins with coefficient averages | false | 94.9855815493 W m^-2 | 206.599801603 W m^-2 |
+| 32 | 16 | non-adjacent coefficient-similarity shortwave g-point pairs with spectral-weighted coefficient averages | false | 26.2279763918 W m^-2 | 73.6097384692 W m^-2 |
+| 32 | 16 | weighted-greedy anchor g-points plus nearest-neighbor coefficient-similarity bins | false | 40.3200732112 W m^-2 | 123.040442676 W m^-2 |
+| 32 | 16 | weighted-greedy anchor g-points plus nearest spectral-order Voronoi bins | false | 40.3601966211 W m^-2 | 125.54176579 W m^-2 |
+
+This is real reduced-model evidence, not a placeholder. A `failed_threshold` status means the selected reduced g-point subset does not yet meet the hard clean ecCKD thresholds.

--- a/benchmarking/results/reduced_accuracy/radiative_heating_reduced_subset_search_latest.md
+++ b/benchmarking/results/reduced_accuracy/radiative_heating_reduced_subset_search_latest.md
@@ -1,0 +1,70 @@
+# Reduced ecCKD Shortwave Subset Search
+
+Status: **failed_threshold**
+
+Search objective: `flux_boundary_and_shortwave_heating_rate`
+
+Selected shortwave g-points: `2, 4, 7, 8, 10, 11, 12, 14, 16, 18, 21, 25, 27, 28, 30, 32`
+
+| Case | Passed | TOA forcing error | Surface forcing error | SW up RMSE | SW down RMSE | Heating RMSE | Heating max |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| ecckd_clear_sky_tropical_column | false | 4.26800277057 W m^-2 | 2.86429350541 W m^-2 | 3.08993452037 W m^-2 | 2.61440809004 W m^-2 | 1.25042184403 K day^-1 | 5.09552972985 K day^-1 |
+| ecckd_rcemip_style_column_subset | false | 7.37779904074 W m^-2 | 7.02576997551 W m^-2 | 2.84554146553 W m^-2 | 2.70673483883 W m^-2 | 0.992148811451 K day^-1 | 5.09552972985 K day^-1 |
+
+## Weighted Subset Search
+
+Selected shortwave g-points: `2, 4, 7, 10, 11, 12, 14, 16, 18, 21, 22, 27, 28, 30, 31, 32`
+
+Boundary weight: `30`
+
+| Case | Passed | TOA forcing error | Surface forcing error | SW up RMSE | SW down RMSE | Heating RMSE | Heating max |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| ecckd_clear_sky_tropical_column | false | 6.98955437931 W m^-2 | 6.83942930433 W m^-2 | 4.73361021121 W m^-2 | 5.05106822397 W m^-2 | 1.0897481383 K day^-1 | 7.34626394558 K day^-1 |
+| ecckd_rcemip_style_column_subset | false | 6.98955437931 W m^-2 | 6.83942930433 W m^-2 | 4.16265216449 W m^-2 | 4.22322538415 W m^-2 | 0.880620143762 K day^-1 | 7.34626394558 K day^-1 |
+
+A failed status means this deterministic subset search improved the current 16-g shortwave reduction but still does not satisfy the hard clean ecCKD thresholds. The current failure is useful evidence that simple subset selection is not enough; a real ecCKD reduction/optimization method is still required.
+
+## Search History
+
+| Pass | Approximate normalized score | Indices |
+|---:|---:|---|
+| 0 | 151.800780231 | `2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32` |
+| 1 | 39.532464365 | `2, 4, 7, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32` |
+| 2 | 33.825821147 | `2, 4, 7, 8, 10, 11, 12, 14, 16, 18, 20, 24, 26, 28, 30, 32` |
+| 3 | 29.6982463611 | `2, 4, 7, 8, 10, 11, 12, 14, 16, 18, 20, 24, 27, 28, 30, 32` |
+| 4 | 26.6002898439 | `2, 4, 7, 8, 10, 11, 12, 14, 16, 18, 19, 20, 27, 28, 30, 32` |
+| 5 | 26.2709017087 | `2, 4, 7, 8, 10, 11, 12, 14, 16, 18, 19, 21, 27, 28, 30, 32` |
+| 6 | 25.0101657583 | `2, 4, 7, 8, 10, 11, 12, 14, 16, 18, 21, 25, 27, 28, 30, 32` |
+
+## Boundary-Weight Trials
+
+| Boundary weight | Approximate normalized score | Indices |
+|---:|---:|---|
+| 1 | 27.4792824155 | `2, 4, 7, 8, 10, 12, 14, 16, 18, 21, 26, 27, 28, 29, 30, 32` |
+| 3 | 31.6835820958 | `2, 4, 6, 7, 8, 9, 10, 12, 14, 16, 18, 21, 27, 28, 30, 32` |
+| 10 | 24.7084632571 | `2, 4, 7, 8, 9, 10, 12, 14, 16, 18, 21, 27, 28, 30, 31, 32` |
+| 30 | 23.299930424 | `2, 4, 7, 10, 11, 12, 14, 16, 18, 21, 22, 27, 28, 30, 31, 32` |
+
+## Full-Fit Pruning Trial
+
+Selected shortwave g-points: `1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 15, 26, 27, 28, 29`
+
+Boundary weight: `3`
+
+| Case | Passed | TOA forcing error | Surface forcing error | SW up RMSE | SW down RMSE | Heating RMSE | Heating max |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| ecckd_clear_sky_tropical_column | false | 7.07690866492 W m^-2 | 23.7988670186 W m^-2 | 4.90620641996 W m^-2 | 21.7637511995 W m^-2 | 6.80026246917 K day^-1 | 25.4769895646 K day^-1 |
+| ecckd_rcemip_style_column_subset | false | 7.80363748854 W m^-2 | 23.7988670186 W m^-2 | 4.59516295733 W m^-2 | 16.7464999266 W m^-2 | 5.4890523116 K day^-1 | 25.4769895646 K day^-1 |
+
+## Hard-Gate Max-Norm Weight Trial
+
+Selected shortwave g-points: `2, 4, 7, 10, 11, 12, 14, 16, 18, 21, 22, 27, 28, 30, 31, 32`
+
+Source topology: `boundary-weighted greedy subset`
+
+Approximate normalized hard-gate objective: `26.8186307771`
+
+| Case | Passed | TOA forcing error | Surface forcing error | SW up RMSE | SW down RMSE | Heating RMSE | Heating max |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| ecckd_clear_sky_tropical_column | false | 6.98899700819 W m^-2 | 6.83402151419 W m^-2 | 4.7333622194 W m^-2 | 5.04941262423 W m^-2 | 1.09007009803 K day^-1 | 7.34705811981 K day^-1 |
+| ecckd_rcemip_style_column_subset | false | 6.98899700819 W m^-2 | 6.83402151419 W m^-2 | 4.1620403098 W m^-2 | 4.22195731788 W m^-2 | 0.880872142382 K day^-1 | 7.34705811981 K day^-1 |

--- a/benchmarking/results/reduced_pareto/ng_lw_16_ng_sw_16/radiative_heating_rcemip_latest.md
+++ b/benchmarking/results/reduced_pareto/ng_lw_16_ng_sw_16/radiative_heating_rcemip_latest.md
@@ -1,0 +1,10 @@
+# Radiative Heating RCEMIP-Style Benchmark
+
+- status: scaffold_not_final_4x_evidence
+- backend: H100
+- grid: 32 x 32 x 64
+- RadiativeHeating supported: true
+- RRTMGP supported: true
+- speedup: 27.021x
+- final 4x claim supported: false
+- blocking reason: missing Nsight Systems report

--- a/benchmarking/results/reduced_pareto/ng_lw_32_ng_sw_16/radiative_heating_rcemip_latest.md
+++ b/benchmarking/results/reduced_pareto/ng_lw_32_ng_sw_16/radiative_heating_rcemip_latest.md
@@ -1,0 +1,10 @@
+# Radiative Heating RCEMIP-Style Benchmark
+
+- status: scaffold_not_final_4x_evidence
+- backend: H100
+- grid: 32 x 32 x 64
+- RadiativeHeating supported: true
+- RRTMGP supported: true
+- speedup: 29.764x
+- final 4x claim supported: false
+- blocking reason: missing Nsight Systems report

--- a/benchmarking/results/reduced_pareto/radiative_heating_reduced_pareto_latest.md
+++ b/benchmarking/results/reduced_pareto/radiative_heating_reduced_pareto_latest.md
@@ -1,0 +1,12 @@
+# Reduced ecCKD Pareto Evidence
+
+Status: h100_runtime_accuracy_failed_threshold
+
+| Label | backend | grid | RH ms | RRTMGP ms | speedup | accuracy | TOA W m^-2 | surface W m^-2 | support |
+|---|---|---:|---:|---:|---:|---|---:|---:|---|
+| synthetic 16x16 H100 term-count scaffold | H100 | 32x32x64 | 20.7811 | 561.531 | 27.0212 | missing | n/a | n/a | missing |
+| synthetic 32x16 H100 term-count scaffold | H100 | 32x32x64 | 18.4005 | 547.668 | 29.7638 | missing | n/a | n/a | missing |
+| official 32x16 preflight table-refined H100 smoke | H100 | 2x2x8 | 0.590822 | 21.6732 | 36.6831 | failed_threshold | 2.49657297122 | 2.38029831045 | supported |
+
+Accuracy source: `results/reduced_accuracy/radiative_heating_reduced_accuracy_latest.json`.
+The official table-refined row is smoke/runtime-path evidence until the reduced hard thresholds pass.

--- a/benchmarking/results/reduced_preflight_table_refined_cpu_active_smoke/radiative_heating_rcemip_latest.md
+++ b/benchmarking/results/reduced_preflight_table_refined_cpu_active_smoke/radiative_heating_rcemip_latest.md
@@ -1,0 +1,17 @@
+# Radiative Heating RCEMIP-Style Benchmark
+
+- status: scaffold_not_final_4x_evidence
+- backend: CPU
+- grid: 1 x 1 x 4
+- gas model source: validated_ecCKD_reduced_preflight_table_refined
+- gas model kind: official_ecCKD_reduced_preflight_table_refined_32_lw_16_sw
+- gas model accuracy status: failed_threshold
+- gas values: Dict("o3" => 0.0, "ch4" => 1.8e-6, "cfc11" => 2.3e-10, "n2o" => 3.3e-7, "cfc12" => 5.2e-10, "co2" => 0.00042)
+- gas model device support: supported
+- gas model device support reason: CPU benchmark path supports package-native gas optics
+- gas model device support source: BreezeRadiativeHeatingExt
+- RadiativeHeating supported: true
+- RRTMGP supported: true
+- speedup: 2.013x
+- final 4x claim supported: false
+- blocking reason: benchmark status is scaffold_not_final_4x_evidence, not final_4x_evidence

--- a/benchmarking/results/reduced_preflight_table_refined_cpu_smoke/radiative_heating_rcemip_latest.md
+++ b/benchmarking/results/reduced_preflight_table_refined_cpu_smoke/radiative_heating_rcemip_latest.md
@@ -1,0 +1,17 @@
+# Radiative Heating RCEMIP-Style Benchmark
+
+- status: scaffold_not_final_4x_evidence
+- backend: CPU
+- grid: 2 x 2 x 8
+- gas model source: validated_ecCKD_reduced_preflight_table_refined
+- gas model kind: official_ecCKD_reduced_preflight_table_refined_32_lw_16_sw
+- gas model accuracy status: failed_threshold
+- gas values: Dict("o3" => 0.0, "ch4" => 1.8e-6, "cfc11" => 2.3e-10, "n2o" => 3.3e-7, "cfc12" => 5.2e-10, "co2" => 0.00042)
+- gas model device support: supported
+- gas model device support reason: CPU benchmark path supports package-native gas optics
+- gas model device support source: BreezeRadiativeHeatingExt
+- RadiativeHeating supported: true
+- RRTMGP supported: true
+- speedup: 10.750x
+- final 4x claim supported: false
+- blocking reason: benchmark status is scaffold_not_final_4x_evidence, not final_4x_evidence

--- a/benchmarking/results/reduced_preflight_table_refined_h100_smoke/radiative_heating_rcemip_latest.md
+++ b/benchmarking/results/reduced_preflight_table_refined_h100_smoke/radiative_heating_rcemip_latest.md
@@ -1,0 +1,17 @@
+# Radiative Heating RCEMIP-Style Benchmark
+
+- status: scaffold_not_final_4x_evidence
+- backend: H100
+- grid: 2 x 2 x 8
+- gas model source: validated_ecCKD_reduced_preflight_table_refined
+- gas model kind: official_ecCKD_reduced_preflight_table_refined_32_lw_16_sw
+- gas model accuracy status: failed_threshold
+- gas values: Dict("o3" => 0.0, "ch4" => 1.8e-6, "cfc11" => 2.3e-10, "n2o" => 3.3e-7, "cfc12" => 5.2e-10, "co2" => 0.00042)
+- gas model device support: supported
+- gas model device support reason: H100 extension path supports tabulated multi-gas ecCKD with recorded CPU/GPU parity evidence
+- gas model device support source: BreezeRadiativeHeatingExt
+- RadiativeHeating supported: true
+- RRTMGP supported: true
+- speedup: 36.683x
+- final 4x claim supported: false
+- blocking reason: benchmark status is scaffold_not_final_4x_evidence, not final_4x_evidence

--- a/benchmarking/results/reduced_preflight_table_refined_parity/radiative_heating_tabulated_ecckd_parity_latest.md
+++ b/benchmarking/results/reduced_preflight_table_refined_parity/radiative_heating_tabulated_ecckd_parity_latest.md
@@ -1,0 +1,16 @@
+# Radiative Heating Tabulated ecCKD CPU/GPU Parity
+
+- status: passed
+- backend: H100
+- gas model source: validated_ecCKD_reduced_preflight_table_refined
+- gas model kind: official_ecCKD_reduced_preflight_table_refined_32_lw_16_sw
+- grid: 2 x 2 x 8
+- tolerance atol: 1.0e-8
+- tolerance rtol: 1.0e-8
+- passed: true
+- reason: CPU/GPU field parity passed
+- field errors:
+  - downwelling_longwave_flux: max_abs=1.7763568394002505e-15, rmse=5.924263396364183e-16, reference_max_abs=296.0554687087857
+  - downwelling_shortwave_flux: max_abs=1.1368683772161603e-13, rmse=6.563712636189231e-14, reference_max_abs=551.0000000000001
+  - flux_divergence: max_abs=3.0357660829594124e-17, rmse=2.2119788346190346e-17, reference_max_abs=0.006695599542096549
+  - upwelling_longwave_flux: max_abs=5.684341886080802e-14, rmse=3.142138202705193e-14, reference_max_abs=450.11432138022025

--- a/benchmarking/results/tabulated_ecckd_parity/radiative_heating_tabulated_ecckd_parity_latest.md
+++ b/benchmarking/results/tabulated_ecckd_parity/radiative_heating_tabulated_ecckd_parity_latest.md
@@ -1,0 +1,16 @@
+# Radiative Heating Tabulated ecCKD CPU/GPU Parity
+
+- status: passed
+- backend: H100
+- gas model source: validated_ecCKD
+- gas model kind: official_ecCKD_32_lw_32_sw
+- grid: 2 x 2 x 8
+- tolerance atol: 1.0e-8
+- tolerance rtol: 1.0e-8
+- passed: true
+- reason: CPU/GPU field parity passed
+- field errors:
+  - downwelling_longwave_flux: max_abs=1.7763568394002505e-15, rmse=5.924263396364183e-16, reference_max_abs=296.0554687087857
+  - downwelling_shortwave_flux: max_abs=1.1368683772161603e-13, rmse=5.359248925640619e-14, reference_max_abs=551.0
+  - flux_divergence: max_abs=6.063400649625184e-17, rmse=2.4563240447328427e-17, reference_max_abs=0.006867587670208998
+  - upwelling_longwave_flux: max_abs=5.684341886080802e-14, rmse=3.142138202705193e-14, reference_max_abs=450.11432138022025

--- a/benchmarking/results/validated_ecckd_cpu_smoke/radiative_heating_rcemip_latest.md
+++ b/benchmarking/results/validated_ecckd_cpu_smoke/radiative_heating_rcemip_latest.md
@@ -1,0 +1,16 @@
+# Radiative Heating RCEMIP-Style Benchmark
+
+- status: scaffold_not_final_4x_evidence
+- backend: CPU
+- grid: 1 x 1 x 4
+- gas model source: validated_ecCKD
+- gas model kind: official_ecCKD_32_lw_32_sw
+- gas model accuracy status: passed
+- gas values: Dict("o3" => 0.0, "ch4" => 1.8e-6, "cfc11" => 2.3e-10, "n2o" => 3.3e-7, "cfc12" => 5.2e-10, "co2" => 0.00042)
+- gas model device support: supported
+- gas model device support reason: CPU benchmark path supports package-native gas optics
+- RadiativeHeating supported: true
+- RRTMGP supported: true
+- speedup: 3.932x
+- final 4x claim supported: false
+- blocking reason: benchmark status is scaffold_not_final_4x_evidence, not final_4x_evidence

--- a/ext/BreezeLightfluxExt/BreezeLightfluxExt.jl
+++ b/ext/BreezeLightfluxExt/BreezeLightfluxExt.jl
@@ -1,0 +1,1731 @@
+module BreezeLightfluxExt
+
+using Lightflux
+using Breeze
+
+using Adapt: adapt
+using Breeze.AtmosphereModels: AtmosphereModels, RadiativeHeatingOptics
+using Breeze.AtmosphereModels: RadiativeTransferModel, SurfaceRadiativeProperties
+using Breeze.AtmosphereModels: specific_humidity
+using Breeze.Thermodynamics: ThermodynamicConstants
+using KernelAbstractions: @index, @kernel
+using Oceananigans.Architectures: CPU, architecture, on_architecture
+using Oceananigans.Fields: CenterField, ConstantField, ZFaceField
+using Oceananigans.Grids: AbstractGrid
+using Oceananigans.Operators: Δzᶜᶜᶜ, ℑzᵃᵃᶠ
+using Oceananigans.Utils: IterationInterval, launch!
+
+struct RadiativeHeatingAtmosphericState{G, C, A, W, DW, V}
+    gas_optics::G
+    cloud_optics::C
+    aerosol_optics::A
+    workspace::W
+    device_workspace::DW
+    gas_values::V
+end
+
+struct RadiativeHeatingWorkspace{A, G, LW, SW, C, AO, F, H, Atm}
+    pressure_layers::A
+    pressure_interfaces::A
+    temperature_layers::A
+    temperature_interfaces::A
+    gases::G
+    longwave_optics::LW
+    shortwave_optics::SW
+    cloud_optical_properties::C
+    aerosol_optical_properties::AO
+    fluxes::F
+    heating_rates::H
+    atmosphere::Atm
+end
+
+const SupportedEcCKDModel =
+    Union{Lightflux.EcCKDGasOpticsModel,
+          Lightflux.EcCKDTabulatedGasOpticsModel}
+const GRAVITY = 9.80665
+const MOLAR_MASS_DRY_AIR = 0.0289647
+const MOLAR_MASS_WATER = 0.01801528
+const TABULATED_ECCKD_H100_MISSING_KERNEL_REQUIREMENTS = [
+    "CPU/GPU parity smoke test for validated ecCKD tabulated gas optics",
+]
+
+has_tabulated_ecckd_interpolation_grids(gas_optics::Lightflux.EcCKDTabulatedGasOpticsModel) =
+    !isempty(gas_optics.pressure_grid) &&
+    !isempty(gas_optics.temperature_grid) &&
+    !isempty(gas_optics.h2o_mole_fraction_grid)
+
+materialize_surface_property(x::Number, grid) = ConstantField(convert(eltype(grid), x))
+materialize_surface_property(x, grid) = x
+
+function _json_string_field(text, key)
+    match = Base.match(Regex("\"$key\"\\s*:\\s*\"([^\"]*)\""), text)
+    return match === nothing ? "" : match.captures[1]
+end
+
+function _json_bool_field(text, key)
+    match = Base.match(Regex("\"$key\"\\s*:\\s*(true|false)"), text)
+    return match !== nothing && match.captures[1] == "true"
+end
+
+function tabulated_ecckd_parity_evidence(gas_optics)
+    path = get(ENV, "RADIATIVE_HEATING_TABULATED_ECCKD_PARITY_JSON", "")
+    path == "" && return (
+        passed = false,
+        reason = "no CPU/GPU parity artifact configured",
+        path = path,
+    )
+    isfile(path) || return (
+        passed = false,
+        reason = "configured CPU/GPU parity artifact does not exist: $path",
+        path = path,
+    )
+
+    text = read(path, String)
+    status = _json_string_field(text, "status")
+    case = _json_string_field(text, "case")
+    kind = _json_string_field(text, "gas_model_kind")
+    source = _json_string_field(text, "gas_model_source")
+    expected_source = get(ENV, "RADIATIVE_HEATING_GAS_MODEL_SOURCE", "validated_ecCKD")
+    expected_kind = expected_source == "validated_ecCKD_reduced_preflight_table_refined" ?
+        "official_ecCKD_reduced_preflight_table_refined_$(size(gas_optics.longwave_absorption, 1))_lw_$(size(gas_optics.shortwave_absorption, 1))_sw" :
+        "official_ecCKD_$(size(gas_optics.longwave_absorption, 1))_lw_$(size(gas_optics.shortwave_absorption, 1))_sw"
+    passed = _json_bool_field(text, "passed")
+    valid = case == "radiative_heating_tabulated_ecckd_cpu_gpu_parity" &&
+            status == "passed" &&
+            passed &&
+            source == expected_source &&
+            kind == expected_kind
+    return (
+        passed = valid,
+        reason = valid ? "CPU/GPU parity artifact passed: $path" :
+            "CPU/GPU parity artifact is not passing evidence for $expected_kind",
+        path = path,
+    )
+end
+
+specified_gas_value(gas_values::AbstractDict, name::Symbol, FT) =
+    FT(get(gas_values, name, get(gas_values, String(name), zero(FT))))
+
+specified_gas_value(gas_values, name::Symbol, FT) =
+    FT(hasproperty(gas_values, name) ? getproperty(gas_values, name) : zero(FT))
+
+struct TabulatedEcCKDColumnAmountState{A}
+    composite::A
+    h2o::A
+    co2::A
+    o3::A
+    ch4::A
+    n2o::A
+    cfc11::A
+    cfc12::A
+end
+
+function TabulatedEcCKDColumnAmountState(::Type{FT}, dims::NTuple{3, Int}) where FT
+    arrays = ntuple(_ -> zeros(FT, dims), 8)
+    return TabulatedEcCKDColumnAmountState(arrays...)
+end
+
+function tabulated_ecckd_column_amounts!(state::TabulatedEcCKDColumnAmountState,
+                                         grid,
+                                         pressure_interfaces,
+                                         qᵛ;
+                                         co2,
+                                         o3,
+                                         ch4,
+                                         n2o,
+                                         cfc11,
+                                         cfc12)
+    arch = architecture(grid)
+    launch!(arch, grid, :xyz, _tabulated_ecckd_column_amounts!,
+            state.composite,
+            state.h2o,
+            state.co2,
+            state.o3,
+            state.ch4,
+            state.n2o,
+            state.cfc11,
+            state.cfc12,
+            pressure_interfaces,
+            qᵛ,
+            co2,
+            o3,
+            ch4,
+            n2o,
+            cfc11,
+            cfc12)
+    return state
+end
+
+function tabulated_ecckd_device_column_state!(workspace,
+                                              grid,
+                                              pressure,
+                                              temperature,
+                                              qᵛ;
+                                              co2,
+                                              o3,
+                                              ch4,
+                                              n2o,
+                                              cfc11,
+                                              cfc12)
+    arch = architecture(grid)
+    amounts = workspace.column_amounts
+    launch!(arch, grid, :xyz, _tabulated_ecckd_device_column_state!,
+            workspace.pressure_layers,
+            workspace.pressure_interfaces,
+            workspace.temperature_layers,
+            amounts.composite,
+            amounts.h2o,
+            amounts.co2,
+            amounts.o3,
+            amounts.ch4,
+            amounts.n2o,
+            amounts.cfc11,
+            amounts.cfc12,
+            grid,
+            pressure,
+            temperature,
+            qᵛ,
+            co2,
+            o3,
+            ch4,
+            n2o,
+            cfc11,
+            cfc12)
+    return workspace
+end
+
+@kernel function _tabulated_ecckd_column_amounts!(composite,
+                                                  h2o,
+                                                  co2_amount,
+                                                  o3_amount,
+                                                  ch4_amount,
+                                                  n2o_amount,
+                                                  cfc11_amount,
+                                                  cfc12_amount,
+                                                  pressure_interfaces,
+                                                  qᵛ,
+                                                  co2,
+                                                  o3,
+                                                  ch4,
+                                                  n2o,
+                                                  cfc11,
+                                                  cfc12)
+    i, j, kt = @index(Global, NTuple)
+    FT = eltype(composite)
+    Δp = abs(pressure_interfaces[i, j, kt + 1] - pressure_interfaces[i, j, kt])
+    dry_air_moles = Δp / FT(GRAVITY) / FT(MOLAR_MASS_DRY_AIR)
+    h2o_moles = max(qᵛ[i, j, kt], zero(FT)) * Δp / FT(GRAVITY) / FT(MOLAR_MASS_WATER)
+
+    composite[i, j, kt] = dry_air_moles
+    h2o[i, j, kt] = h2o_moles
+    co2_amount[i, j, kt] = FT(co2) * dry_air_moles
+    o3_amount[i, j, kt] = FT(o3) * dry_air_moles
+    ch4_amount[i, j, kt] = FT(ch4) * dry_air_moles
+    n2o_amount[i, j, kt] = FT(n2o) * dry_air_moles
+    cfc11_amount[i, j, kt] = FT(cfc11) * dry_air_moles
+    cfc12_amount[i, j, kt] = FT(cfc12) * dry_air_moles
+end
+
+@kernel function _tabulated_ecckd_device_column_state!(pressure_layers,
+                                                       pressure_interfaces,
+                                                       temperature_layers,
+                                                       composite,
+                                                       h2o,
+                                                       co2_amount,
+                                                       o3_amount,
+                                                       ch4_amount,
+                                                       n2o_amount,
+                                                       cfc11_amount,
+                                                       cfc12_amount,
+                                                       grid,
+                                                       pressure,
+                                                       temperature,
+                                                       qᵛ,
+                                                       co2,
+                                                       o3,
+                                                       ch4,
+                                                       n2o,
+                                                       cfc11,
+                                                       cfc12)
+    i, j, k = @index(Global, NTuple)
+    FT = eltype(composite)
+
+    pressure_layers[i, j, k] = pressure[i, j, k]
+    temperature_layers[i, j, k] = temperature[i, j, k]
+    pressure_bottom = ℑzᵃᵃᶠ(i, j, k, grid, pressure)
+    pressure_top = ℑzᵃᵃᶠ(i, j, k + 1, grid, pressure)
+    if k == 1
+        pressure_interfaces[i, j, 1] = pressure_bottom
+    end
+    pressure_interfaces[i, j, k + 1] = pressure_top
+
+    Δp = abs(pressure_top - pressure_bottom)
+    dry_air_moles = Δp / FT(GRAVITY) / FT(MOLAR_MASS_DRY_AIR)
+    h2o_moles = max(qᵛ[i, j, k], zero(FT)) * Δp / FT(GRAVITY) / FT(MOLAR_MASS_WATER)
+
+    composite[i, j, k] = dry_air_moles
+    h2o[i, j, k] = h2o_moles
+    co2_amount[i, j, k] = FT(co2) * dry_air_moles
+    o3_amount[i, j, k] = FT(o3) * dry_air_moles
+    ch4_amount[i, j, k] = FT(ch4) * dry_air_moles
+    n2o_amount[i, j, k] = FT(n2o) * dry_air_moles
+    cfc11_amount[i, j, k] = FT(cfc11) * dry_air_moles
+    cfc12_amount[i, j, k] = FT(cfc12) * dry_air_moles
+end
+
+struct TabulatedEcCKDInterpolationState{I, A}
+    pressure_lo::I
+    pressure_hi::I
+    temperature_lo::I
+    temperature_hi::I
+    h2o_lo::I
+    h2o_hi::I
+    pressure_weight::A
+    temperature_weight::A
+    h2o_weight::A
+end
+
+function TabulatedEcCKDInterpolationState(::Type{FT}, dims::NTuple{3, Int}) where FT
+    integer_arrays = ntuple(_ -> zeros(Int, dims), 6)
+    weights = ntuple(_ -> zeros(FT, dims), 3)
+    return TabulatedEcCKDInterpolationState(integer_arrays..., weights...)
+end
+
+_arch_array(arch, ::Type{T}, dims::Tuple) where T = on_architecture(arch, zeros(T, dims))
+
+function TabulatedEcCKDColumnAmountState(arch, ::Type{FT}, dims::NTuple{3, Int}) where FT
+    arrays = ntuple(_ -> _arch_array(arch, FT, dims), 8)
+    return TabulatedEcCKDColumnAmountState(arrays...)
+end
+
+function TabulatedEcCKDInterpolationState(arch, ::Type{FT}, dims::NTuple{3, Int}) where FT
+    integer_arrays = ntuple(_ -> _arch_array(arch, Int, dims), 6)
+    weights = ntuple(_ -> _arch_array(arch, FT, dims), 3)
+    return TabulatedEcCKDInterpolationState(integer_arrays..., weights...)
+end
+
+"""
+Persistent device workspace for the tabulated ecCKD device path.
+
+The streaming radiation kernel computes per-g-point optical depths inline at
+each column step, so the workspace only owns three-dimensional state arrays.
+There are no `(ngpt, Nx, Ny, Nz)` four-dimensional buffers — those would scale
+as `Nx * Ny * Nz * Nk` and dominate memory at high resolution. See
+`_tabulated_ecckd_streaming_radiation!` for the fused optics+transport kernel
+that consumes this workspace.
+"""
+struct TabulatedEcCKDDeviceWorkspace{C, I, P, F}
+    column_amounts::C
+    interpolation::I
+    pressure_layers::P
+    pressure_interfaces::F
+    temperature_layers::P
+end
+
+function TabulatedEcCKDDeviceWorkspace(arch,
+                                       ::Type{FT},
+                                       grid,
+                                       gas_optics::Lightflux.EcCKDTabulatedGasOpticsModel) where FT
+    Nx, Ny, Nz = size(grid)
+    dims = (Nx, Ny, Nz)
+    face_dims = (Nx, Ny, Nz + 1)
+
+    return TabulatedEcCKDDeviceWorkspace(
+        TabulatedEcCKDColumnAmountState(arch, FT, dims),
+        TabulatedEcCKDInterpolationState(arch, FT, dims),
+        _arch_array(arch, FT, dims),
+        _arch_array(arch, FT, face_dims),
+        _arch_array(arch, FT, dims),
+    )
+end
+
+@inline function _linear_bracket(grid, x)
+    FT = eltype(grid)
+    x_clamped = clamp(x, grid[begin], grid[end])
+    lo = firstindex(grid)
+    hi = lastindex(grid)
+    while hi - lo > 1
+        mid = (lo + hi) >>> 1
+        if x_clamped < grid[mid]
+            hi = mid
+        else
+            lo = mid
+        end
+    end
+    weight = (x_clamped - grid[lo]) / (grid[hi] - grid[lo])
+    return lo, hi, weight
+end
+
+@inline function _log_bracket(grid, x)
+    FT = eltype(grid)
+    x_positive = max(x, grid[begin])
+    index = one(FT) +
+        clamp((log(x_positive) - log(grid[begin])) / (log(grid[begin + 1]) - log(grid[begin])),
+              zero(FT),
+              FT(length(grid)) - FT(1.0001))
+    lo = Int(floor(index))
+    return lo, lo + 1, index - lo
+end
+
+@inline function _temperature_bracket(temperature_grid::AbstractVector,
+                                      pressure_grid,
+                                      pressure,
+                                      temperature,
+                                      pressure_lo,
+                                      pressure_hi,
+                                      pressure_weight)
+    return _linear_bracket(temperature_grid, temperature)
+end
+
+@inline function _temperature_bracket(temperature_grid::AbstractMatrix,
+                                      pressure_grid,
+                                      pressure,
+                                      temperature,
+                                      pressure_lo,
+                                      pressure_hi,
+                                      pressure_weight)
+    FT = eltype(temperature_grid)
+    origin = (one(FT) - pressure_weight) * temperature_grid[pressure_lo, 1] +
+             pressure_weight * temperature_grid[pressure_hi, 1]
+    step = temperature_grid[1, 2] - temperature_grid[1, 1]
+    index = one(FT) + clamp((temperature - origin) / step,
+                            zero(FT),
+                            FT(size(temperature_grid, 2)) - FT(1.0001))
+    lo = Int(floor(index))
+    return lo, lo + 1, index - lo
+end
+
+function tabulated_ecckd_interpolation_state!(state::TabulatedEcCKDInterpolationState,
+                                              grid,
+                                              pressure_layers,
+                                              temperature_layers,
+                                              column_amounts::TabulatedEcCKDColumnAmountState,
+                                              pressure_grid,
+                                              temperature_grid,
+                                              h2o_grid)
+    arch = architecture(grid)
+    launch!(arch, grid, :xyz, _tabulated_ecckd_interpolation_state!,
+            state.pressure_lo,
+            state.pressure_hi,
+            state.temperature_lo,
+            state.temperature_hi,
+            state.h2o_lo,
+            state.h2o_hi,
+            state.pressure_weight,
+            state.temperature_weight,
+            state.h2o_weight,
+            pressure_layers,
+            temperature_layers,
+            column_amounts.composite,
+            column_amounts.h2o,
+            pressure_grid,
+            temperature_grid,
+            h2o_grid)
+    return state
+end
+
+@kernel function _tabulated_ecckd_interpolation_state!(pressure_lo,
+                                                       pressure_hi,
+                                                       temperature_lo,
+                                                       temperature_hi,
+                                                       h2o_lo,
+                                                       h2o_hi,
+                                                       pressure_weight,
+                                                       temperature_weight,
+                                                       h2o_weight,
+                                                       pressure_layers,
+                                                       temperature_layers,
+                                                       composite_amount,
+                                                       h2o_amount,
+                                                       pressure_grid,
+                                                       temperature_grid,
+                                                       h2o_grid)
+    i, j, k = @index(Global, NTuple)
+    ip0, ip1, wp = _log_bracket(pressure_grid, pressure_layers[i, j, k])
+    it0, it1, wt = _temperature_bracket(temperature_grid,
+                                        pressure_grid,
+                                        pressure_layers[i, j, k],
+                                        temperature_layers[i, j, k],
+                                        ip0,
+                                        ip1,
+                                        wp)
+    h2o_fraction = h2o_amount[i, j, k] / max(composite_amount[i, j, k], eps(eltype(h2o_amount)))
+    ih0, ih1, wh = _log_bracket(h2o_grid, h2o_fraction)
+
+    pressure_lo[i, j, k] = ip0
+    pressure_hi[i, j, k] = ip1
+    temperature_lo[i, j, k] = it0
+    temperature_hi[i, j, k] = it1
+    h2o_lo[i, j, k] = ih0
+    h2o_hi[i, j, k] = ih1
+    pressure_weight[i, j, k] = wp
+    temperature_weight[i, j, k] = wt
+    h2o_weight[i, j, k] = wh
+end
+
+@inline function _prepared_interp_table(table,
+                                        ig,
+                                        gas_index,
+                                        ip0,
+                                        ip1,
+                                        wp,
+                                        it0,
+                                        it1,
+                                        wt)
+    c00 = table[ig, gas_index, ip0, it0]
+    c10 = table[ig, gas_index, ip1, it0]
+    c01 = table[ig, gas_index, ip0, it1]
+    c11 = table[ig, gas_index, ip1, it1]
+    cp0 = c00 + wp * (c10 - c00)
+    cp1 = c01 + wp * (c11 - c01)
+    return cp0 + wt * (cp1 - cp0)
+end
+
+@inline function _prepared_interp_h2o_table(table,
+                                            ig,
+                                            ip0,
+                                            ip1,
+                                            wp,
+                                            it0,
+                                            it1,
+                                            wt,
+                                            ih0,
+                                            ih1,
+                                            wh)
+    c000 = table[ig, ip0, it0, ih0]
+    c100 = table[ig, ip1, it0, ih0]
+    c010 = table[ig, ip0, it1, ih0]
+    c110 = table[ig, ip1, it1, ih0]
+    c001 = table[ig, ip0, it0, ih1]
+    c101 = table[ig, ip1, it0, ih1]
+    c011 = table[ig, ip0, it1, ih1]
+    c111 = table[ig, ip1, it1, ih1]
+
+    c00 = c000 + wp * (c100 - c000)
+    c10 = c010 + wp * (c110 - c010)
+    c01 = c001 + wp * (c101 - c001)
+    c11 = c011 + wp * (c111 - c011)
+    ct0 = c00 + wt * (c10 - c00)
+    ct1 = c01 + wt * (c11 - c01)
+    return ct0 + wh * (ct1 - ct0)
+end
+
+@inline function _tabulated_amount_by_index(amounts::TabulatedEcCKDColumnAmountState, gas_index, i, j, k)
+    gas_index == 1 && return amounts.composite[i, j, k]
+    gas_index == 2 && return amounts.h2o[i, j, k]
+    gas_index == 3 && return amounts.o3[i, j, k]
+    gas_index == 4 && return amounts.co2[i, j, k]
+    gas_index == 5 && return amounts.ch4[i, j, k]
+    gas_index == 6 && return amounts.n2o[i, j, k]
+    gas_index == 7 && return amounts.cfc11[i, j, k]
+    return amounts.cfc12[i, j, k]
+end
+
+@inline function _tabulated_amount_by_index(composite, h2o, o3, co2, ch4, n2o,
+                                            cfc11, cfc12, gas_index, i, j, k)
+    gas_index == 1 && return composite[i, j, k]
+    gas_index == 2 && return h2o[i, j, k]
+    gas_index == 3 && return o3[i, j, k]
+    gas_index == 4 && return co2[i, j, k]
+    gas_index == 5 && return ch4[i, j, k]
+    gas_index == 6 && return n2o[i, j, k]
+    gas_index == 7 && return cfc11[i, j, k]
+    return cfc12[i, j, k]
+end
+
+function tabulated_ecckd_absorption_optical_depths!(longwave_tau,
+                                                    shortwave_tau,
+                                                    grid,
+                                                    column_amounts::TabulatedEcCKDColumnAmountState,
+                                                    interpolation::TabulatedEcCKDInterpolationState,
+                                                    gas_reference_mole_fractions,
+                                                    longwave_absorption,
+                                                    shortwave_absorption,
+                                                    longwave_h2o_absorption,
+                                                    shortwave_h2o_absorption)
+    arch = architecture(grid)
+    launch!(arch, grid, :xyz, _tabulated_ecckd_absorption_optical_depths!,
+            longwave_tau,
+            shortwave_tau,
+            column_amounts,
+            interpolation,
+            gas_reference_mole_fractions,
+            longwave_absorption,
+            shortwave_absorption,
+            longwave_h2o_absorption,
+            shortwave_h2o_absorption)
+    return longwave_tau, shortwave_tau
+end
+
+@kernel function _tabulated_ecckd_absorption_optical_depths!(longwave_tau,
+                                                             shortwave_tau,
+                                                             amounts,
+                                                             interpolation,
+                                                             gas_reference_mole_fractions,
+                                                             longwave_absorption,
+                                                             shortwave_absorption,
+                                                             longwave_h2o_absorption,
+                                                             shortwave_h2o_absorption)
+    i, j, k = @index(Global, NTuple)
+    FT = eltype(longwave_tau)
+    ip0 = interpolation.pressure_lo[i, j, k]
+    ip1 = interpolation.pressure_hi[i, j, k]
+    it0 = interpolation.temperature_lo[i, j, k]
+    it1 = interpolation.temperature_hi[i, j, k]
+    ih0 = interpolation.h2o_lo[i, j, k]
+    ih1 = interpolation.h2o_hi[i, j, k]
+    wp = interpolation.pressure_weight[i, j, k]
+    wt = interpolation.temperature_weight[i, j, k]
+    wh = interpolation.h2o_weight[i, j, k]
+    composite = amounts.composite[i, j, k]
+    h2o = amounts.h2o[i, j, k]
+
+    for ig in axes(longwave_absorption, 1)
+        tau = zero(FT)
+        for gas_index in axes(longwave_absorption, 2)
+            amount = FT(_tabulated_amount_by_index(amounts, gas_index, i, j, k)) -
+                     FT(gas_reference_mole_fractions[gas_index]) * FT(composite)
+            coefficient = _prepared_interp_table(longwave_absorption, ig, gas_index,
+                                                 ip0, ip1, wp, it0, it1, wt)
+            tau += coefficient * amount
+        end
+        if length(longwave_h2o_absorption) != 0
+            tau += _prepared_interp_h2o_table(longwave_h2o_absorption, ig,
+                                              ip0, ip1, wp, it0, it1, wt,
+                                              ih0, ih1, wh) * FT(h2o)
+        end
+        longwave_tau[ig, i, j, k] = tau
+    end
+
+    for ig in axes(shortwave_absorption, 1)
+        tau = zero(FT)
+        for gas_index in axes(shortwave_absorption, 2)
+            amount = FT(_tabulated_amount_by_index(amounts, gas_index, i, j, k)) -
+                     FT(gas_reference_mole_fractions[gas_index]) * FT(composite)
+            coefficient = _prepared_interp_table(shortwave_absorption, ig, gas_index,
+                                                 ip0, ip1, wp, it0, it1, wt)
+            tau += coefficient * amount
+        end
+        if length(shortwave_h2o_absorption) != 0
+            tau += _prepared_interp_h2o_table(shortwave_h2o_absorption, ig,
+                                              ip0, ip1, wp, it0, it1, wt,
+                                              ih0, ih1, wh) * FT(h2o)
+        end
+        shortwave_tau[ig, i, j, k] = tau
+    end
+end
+
+function tabulated_ecckd_rayleigh_optical_depths!(rayleigh_tau,
+                                                  grid,
+                                                  column_amounts::TabulatedEcCKDColumnAmountState,
+                                                  shortwave_rayleigh_molar_scattering)
+    arch = architecture(grid)
+    launch!(arch, grid, :xyz, _tabulated_ecckd_rayleigh_optical_depths!,
+            rayleigh_tau,
+            column_amounts.composite,
+            shortwave_rayleigh_molar_scattering)
+    return rayleigh_tau
+end
+
+@kernel function _tabulated_ecckd_rayleigh_optical_depths!(rayleigh_tau,
+                                                           composite_amount,
+                                                           shortwave_rayleigh_molar_scattering)
+    i, j, k = @index(Global, NTuple)
+    FT = eltype(rayleigh_tau)
+    for ig in axes(rayleigh_tau, 1)
+        rayleigh_tau[ig, i, j, k] =
+            FT(shortwave_rayleigh_molar_scattering[ig]) * FT(composite_amount[i, j, k])
+    end
+end
+
+@inline function _prepared_interp_source_table(source_table,
+                                               source_temperature_grid,
+                                               ig,
+                                               temperature)
+    it0, it1, wt = _linear_bracket(source_temperature_grid, temperature)
+    return source_table[ig, it0] + wt * (source_table[ig, it1] - source_table[ig, it0])
+end
+
+function tabulated_ecckd_longwave_sources!(source,
+                                           grid,
+                                           temperature_layers,
+                                           source_temperature_grid,
+                                           source_table)
+    arch = architecture(grid)
+    launch!(arch, grid, :xyz, _tabulated_ecckd_longwave_sources!,
+            source,
+            temperature_layers,
+            source_temperature_grid,
+            source_table)
+    return source
+end
+
+@kernel function _tabulated_ecckd_longwave_sources!(source,
+                                                    temperature_layers,
+                                                    source_temperature_grid,
+                                                    source_table)
+    i, j, k = @index(Global, NTuple)
+    for ig in axes(source, 1)
+        source[ig, i, j, k] =
+            _prepared_interp_source_table(source_table,
+                                          source_temperature_grid,
+                                          ig,
+                                          temperature_layers[i, j, k])
+    end
+end
+
+function tabulated_ecckd_optical_properties!(longwave_tau,
+                                             shortwave_tau,
+                                             rayleigh_tau,
+                                             longwave_source,
+                                             grid,
+                                             temperature_layers,
+                                             column_amounts::TabulatedEcCKDColumnAmountState,
+                                             interpolation::TabulatedEcCKDInterpolationState,
+                                             gas_reference_mole_fractions,
+                                             longwave_absorption,
+                                             shortwave_absorption,
+                                             longwave_h2o_absorption,
+                                             shortwave_h2o_absorption,
+                                             shortwave_rayleigh_molar_scattering,
+                                             source_temperature_grid,
+                                             source_table)
+    arch = architecture(grid)
+    launch!(arch, grid, :xyz, _tabulated_ecckd_optical_properties!,
+            longwave_tau,
+            shortwave_tau,
+            rayleigh_tau,
+            longwave_source,
+            temperature_layers,
+            column_amounts.composite,
+            column_amounts.h2o,
+            column_amounts.o3,
+            column_amounts.co2,
+            column_amounts.ch4,
+            column_amounts.n2o,
+            column_amounts.cfc11,
+            column_amounts.cfc12,
+            interpolation.pressure_lo,
+            interpolation.pressure_hi,
+            interpolation.temperature_lo,
+            interpolation.temperature_hi,
+            interpolation.h2o_lo,
+            interpolation.h2o_hi,
+            interpolation.pressure_weight,
+            interpolation.temperature_weight,
+            interpolation.h2o_weight,
+            gas_reference_mole_fractions,
+            longwave_absorption,
+            shortwave_absorption,
+            longwave_h2o_absorption,
+            shortwave_h2o_absorption,
+            shortwave_rayleigh_molar_scattering,
+            source_temperature_grid,
+            source_table)
+    return longwave_tau, shortwave_tau, rayleigh_tau, longwave_source
+end
+
+@kernel function _tabulated_ecckd_optical_properties!(longwave_tau,
+                                                      shortwave_tau,
+                                                      rayleigh_tau,
+                                                      longwave_source,
+                                                      temperature_layers,
+                                                      composite_amount,
+                                                      h2o_amount,
+                                                      o3_amount,
+                                                      co2_amount,
+                                                      ch4_amount,
+                                                      n2o_amount,
+                                                      cfc11_amount,
+                                                      cfc12_amount,
+                                                      pressure_lo,
+                                                      pressure_hi,
+                                                      temperature_lo,
+                                                      temperature_hi,
+                                                      h2o_lo,
+                                                      h2o_hi,
+                                                      pressure_weight,
+                                                      temperature_weight,
+                                                      h2o_weight,
+                                                      gas_reference_mole_fractions,
+                                                      longwave_absorption,
+                                                      shortwave_absorption,
+                                                      longwave_h2o_absorption,
+                                                      shortwave_h2o_absorption,
+                                                      shortwave_rayleigh_molar_scattering,
+                                                      source_temperature_grid,
+                                                      source_table)
+    i, j, k = @index(Global, NTuple)
+    FT = eltype(longwave_tau)
+    ip0 = pressure_lo[i, j, k]
+    ip1 = pressure_hi[i, j, k]
+    it0 = temperature_lo[i, j, k]
+    it1 = temperature_hi[i, j, k]
+    ih0 = h2o_lo[i, j, k]
+    ih1 = h2o_hi[i, j, k]
+    wp = pressure_weight[i, j, k]
+    wt = temperature_weight[i, j, k]
+    wh = h2o_weight[i, j, k]
+    composite = composite_amount[i, j, k]
+    h2o = h2o_amount[i, j, k]
+
+    for ig in axes(longwave_absorption, 1)
+        tau = zero(FT)
+        for gas_index in axes(longwave_absorption, 2)
+            amount = FT(_tabulated_amount_by_index(composite_amount, h2o_amount,
+                                                   o3_amount, co2_amount, ch4_amount,
+                                                   n2o_amount, cfc11_amount,
+                                                   cfc12_amount, gas_index, i, j, k)) -
+                     FT(gas_reference_mole_fractions[gas_index]) * FT(composite)
+            coefficient = _prepared_interp_table(longwave_absorption, ig, gas_index,
+                                                 ip0, ip1, wp, it0, it1, wt)
+            tau += coefficient * amount
+        end
+        if length(longwave_h2o_absorption) != 0
+            tau += _prepared_interp_h2o_table(longwave_h2o_absorption, ig,
+                                              ip0, ip1, wp, it0, it1, wt,
+                                              ih0, ih1, wh) * FT(h2o)
+        end
+        longwave_tau[ig, i, j, k] = tau
+        longwave_source[ig, i, j, k] =
+            _prepared_interp_source_table(source_table,
+                                          source_temperature_grid,
+                                          ig,
+                                          temperature_layers[i, j, k])
+    end
+
+    for ig in axes(shortwave_absorption, 1)
+        tau = zero(FT)
+        for gas_index in axes(shortwave_absorption, 2)
+            amount = FT(_tabulated_amount_by_index(composite_amount, h2o_amount,
+                                                   o3_amount, co2_amount, ch4_amount,
+                                                   n2o_amount, cfc11_amount,
+                                                   cfc12_amount, gas_index, i, j, k)) -
+                     FT(gas_reference_mole_fractions[gas_index]) * FT(composite)
+            coefficient = _prepared_interp_table(shortwave_absorption, ig, gas_index,
+                                                 ip0, ip1, wp, it0, it1, wt)
+            tau += coefficient * amount
+        end
+        if length(shortwave_h2o_absorption) != 0
+            tau += _prepared_interp_h2o_table(shortwave_h2o_absorption, ig,
+                                              ip0, ip1, wp, it0, it1, wt,
+                                              ih0, ih1, wh) * FT(h2o)
+        end
+        shortwave_tau[ig, i, j, k] = tau
+        rayleigh_tau[ig, i, j, k] =
+            FT(shortwave_rayleigh_molar_scattering[ig]) * FT(composite)
+    end
+end
+
+function tabulated_ecckd_flux_divergence!(lw_up_field,
+                                          lw_down_field,
+                                          sw_down_field,
+                                          flux_divergence,
+                                          grid,
+                                          longwave_tau,
+                                          shortwave_tau,
+                                          rayleigh_tau,
+                                          longwave_source,
+                                          longwave_weights,
+                                          shortwave_weights;
+                                          solar_constant,
+                                          surface_temperature,
+                                          surface_albedo,
+                                          surface_emissivity)
+    arch = architecture(grid)
+    launch!(arch, grid, :xy, _tabulated_ecckd_flux_divergence!,
+            lw_up_field,
+            lw_down_field,
+            sw_down_field,
+            flux_divergence,
+            grid,
+            longwave_tau,
+            shortwave_tau,
+            rayleigh_tau,
+            longwave_source,
+            longwave_weights,
+            shortwave_weights,
+            solar_constant,
+            surface_temperature,
+            surface_albedo,
+            surface_emissivity)
+    return lw_up_field, lw_down_field, sw_down_field, flux_divergence
+end
+
+@kernel function _tabulated_ecckd_flux_divergence!(lw_up_field,
+                                                   lw_down_field,
+                                                   sw_down_field,
+                                                   flux_divergence,
+                                                   grid,
+                                                   longwave_tau,
+                                                   shortwave_tau,
+                                                   rayleigh_tau,
+                                                   longwave_source,
+                                                   longwave_weights,
+                                                   shortwave_weights,
+                                                   solar_constant,
+                                                   surface_temperature,
+                                                   surface_albedo,
+                                                   surface_emissivity)
+    i, j = @index(Global, NTuple)
+
+    Nz = size(grid, 3)
+    FT = eltype(grid)
+    σ = FT(5.670374419e-8)
+    T_surface = _field_or_number(surface_temperature, i, j)
+    α_surface = _field_or_number(surface_albedo, i, j)
+    ε_surface = FT(surface_emissivity)
+    surface_longwave_up = ε_surface * σ * T_surface^4
+
+    for k in 1:(Nz + 1)
+        lw_up_field[i, j, k] = zero(FT)
+        lw_down_field[i, j, k] = zero(FT)
+        sw_down_field[i, j, k] = zero(FT)
+    end
+
+    for ig in axes(longwave_tau, 1)
+        weight = FT(longwave_weights[ig])
+        up = surface_longwave_up
+        lw_up_field[i, j, 1] += weight * up
+        for k in 1:Nz
+            τ = max(FT(longwave_tau[ig, i, j, k]), zero(FT))
+            tr = exp(-τ)
+            source = FT(longwave_source[ig, i, j, k])
+            up = up * tr + source * (one(FT) - tr)
+            lw_up_field[i, j, k + 1] += weight * up
+        end
+
+        down = zero(FT)
+        for k in Nz:-1:1
+            τ = max(FT(longwave_tau[ig, i, j, k]), zero(FT))
+            tr = exp(-τ)
+            source = FT(longwave_source[ig, i, j, k])
+            down = down * tr + source * (one(FT) - tr)
+            lw_down_field[i, j, k] -= weight * down
+        end
+    end
+
+    for ig in axes(shortwave_tau, 1)
+        weight = FT(shortwave_weights[ig])
+        down = FT(solar_constant)
+        sw_down_field[i, j, Nz + 1] -= weight * down
+        for k in Nz:-1:1
+            absorption = max(FT(shortwave_tau[ig, i, j, k]), zero(FT))
+            down *= exp(-absorption)
+            sw_down_field[i, j, k] -= weight * down
+        end
+
+        up = α_surface * down
+        for k in 1:Nz
+            absorption = max(FT(shortwave_tau[ig, i, j, k]), zero(FT))
+            up *= exp(-absorption)
+        end
+    end
+
+    for k in 1:Nz
+        net_bottom = lw_up_field[i, j, k] +
+                     lw_down_field[i, j, k] +
+                     sw_down_field[i, j, k]
+        net_top = lw_up_field[i, j, k + 1] +
+                  lw_down_field[i, j, k + 1] +
+                  sw_down_field[i, j, k + 1]
+        flux_divergence[i, j, k] = -(net_top - net_bottom) / Δzᶜᶜᶜ(i, j, k, grid)
+    end
+end
+
+"""
+    tabulated_ecckd_streaming_radiation!(lw_up_field, lw_down_field, sw_down_field,
+                                         flux_divergence, grid, workspace, gas_optics;
+                                         solar_constant, surface_temperature,
+                                         surface_albedo, surface_emissivity)
+
+Fused tabulated-ecCKD optics + radiative transfer that consumes only the 3-D
+state on `workspace` and streams g-points one at a time inside the column
+kernel. Avoids the `(ngpt, Nx, Ny, Nz)` four-dimensional optical-property
+buffers the older `tabulated_ecckd_optical_properties!` + `tabulated_ecckd_flux_divergence!`
+pipeline required, so memory scales as `Nx * Ny * Nz` rather than
+`Nx * Ny * Nz * ngpt`.
+
+Cost: per (i, j) thread, longwave optical depth is computed twice per
+(g-point × layer) — once for the upward sweep, once for the downward — and
+shortwave is computed once. The eliminated 4-D allocations are typically
+the dominant device memory at production grids (a 512×512×128 grid with
+96-g shortwave saves 25.8 GiB per 4-D array).
+"""
+function tabulated_ecckd_streaming_radiation!(lw_up_field,
+                                              lw_down_field,
+                                              sw_down_field,
+                                              flux_divergence,
+                                              grid,
+                                              workspace::TabulatedEcCKDDeviceWorkspace,
+                                              gas_optics::Lightflux.EcCKDTabulatedGasOpticsModel;
+                                              solar_constant,
+                                              surface_temperature,
+                                              surface_albedo,
+                                              surface_emissivity)
+    arch = architecture(grid)
+    launch!(arch, grid, :xy, _tabulated_ecckd_streaming_radiation!,
+            lw_up_field, lw_down_field, sw_down_field, flux_divergence,
+            grid,
+            workspace.temperature_layers,
+            workspace.column_amounts.composite,
+            workspace.column_amounts.h2o,
+            workspace.column_amounts.o3,
+            workspace.column_amounts.co2,
+            workspace.column_amounts.ch4,
+            workspace.column_amounts.n2o,
+            workspace.column_amounts.cfc11,
+            workspace.column_amounts.cfc12,
+            workspace.interpolation.pressure_lo,
+            workspace.interpolation.pressure_hi,
+            workspace.interpolation.temperature_lo,
+            workspace.interpolation.temperature_hi,
+            workspace.interpolation.h2o_lo,
+            workspace.interpolation.h2o_hi,
+            workspace.interpolation.pressure_weight,
+            workspace.interpolation.temperature_weight,
+            workspace.interpolation.h2o_weight,
+            gas_optics.gas_reference_mole_fractions,
+            gas_optics.longwave_absorption,
+            gas_optics.shortwave_absorption,
+            gas_optics.longwave_h2o_absorption,
+            gas_optics.shortwave_h2o_absorption,
+            gas_optics.longwave_source_temperature_grid,
+            gas_optics.longwave_source_table,
+            gas_optics.longwave_weights,
+            gas_optics.shortwave_weights,
+            solar_constant,
+            surface_temperature,
+            surface_albedo,
+            surface_emissivity)
+    return nothing
+end
+
+@kernel function _tabulated_ecckd_streaming_radiation!(lw_up_field,
+                                                       lw_down_field,
+                                                       sw_down_field,
+                                                       flux_divergence,
+                                                       grid,
+                                                       temperature_layers,
+                                                       composite_amount,
+                                                       h2o_amount,
+                                                       o3_amount,
+                                                       co2_amount,
+                                                       ch4_amount,
+                                                       n2o_amount,
+                                                       cfc11_amount,
+                                                       cfc12_amount,
+                                                       pressure_lo,
+                                                       pressure_hi,
+                                                       temperature_lo,
+                                                       temperature_hi,
+                                                       h2o_lo,
+                                                       h2o_hi,
+                                                       pressure_weight,
+                                                       temperature_weight,
+                                                       h2o_weight,
+                                                       gas_reference_mole_fractions,
+                                                       longwave_absorption,
+                                                       shortwave_absorption,
+                                                       longwave_h2o_absorption,
+                                                       shortwave_h2o_absorption,
+                                                       source_temperature_grid,
+                                                       source_table,
+                                                       longwave_weights,
+                                                       shortwave_weights,
+                                                       solar_constant,
+                                                       surface_temperature,
+                                                       surface_albedo,
+                                                       surface_emissivity)
+    i, j = @index(Global, NTuple)
+
+    Nz = size(grid, 3)
+    FT = eltype(grid)
+    σ = FT(5.670374419e-8)
+    T_surface = _field_or_number(surface_temperature, i, j)
+    α_surface = _field_or_number(surface_albedo, i, j)
+    ε_surface = FT(surface_emissivity)
+    surface_longwave_up = ε_surface * σ * T_surface^4
+
+    @inbounds for k in 1:(Nz + 1)
+        lw_up_field[i, j, k] = zero(FT)
+        lw_down_field[i, j, k] = zero(FT)
+        sw_down_field[i, j, k] = zero(FT)
+    end
+
+    have_lw_h2o = length(longwave_h2o_absorption) != 0
+    have_sw_h2o = length(shortwave_h2o_absorption) != 0
+    n_gas_lw = size(longwave_absorption, 2)
+    n_gas_sw = size(shortwave_absorption, 2)
+
+    # Longwave streaming: for each g-point, do upward then downward sweep,
+    # computing optical depth and Planck source inline. Never materialize a
+    # 4-D (ngpt, Nx, Ny, Nz) array.
+    @inbounds for ig in axes(longwave_absorption, 1)
+        weight = FT(longwave_weights[ig])
+
+        up = surface_longwave_up
+        lw_up_field[i, j, 1] += weight * up
+        for k in 1:Nz
+            ip0 = pressure_lo[i, j, k]
+            ip1 = pressure_hi[i, j, k]
+            it0 = temperature_lo[i, j, k]
+            it1 = temperature_hi[i, j, k]
+            wp = pressure_weight[i, j, k]
+            wt = temperature_weight[i, j, k]
+            composite = composite_amount[i, j, k]
+
+            tau = zero(FT)
+            for gas_index in 1:n_gas_lw
+                amount = FT(_tabulated_amount_by_index(composite_amount, h2o_amount,
+                                                       o3_amount, co2_amount, ch4_amount,
+                                                       n2o_amount, cfc11_amount, cfc12_amount,
+                                                       gas_index, i, j, k)) -
+                         FT(gas_reference_mole_fractions[gas_index]) * FT(composite)
+                coefficient = _prepared_interp_table(longwave_absorption, ig, gas_index,
+                                                     ip0, ip1, wp, it0, it1, wt)
+                tau += coefficient * amount
+            end
+            if have_lw_h2o
+                ih0 = h2o_lo[i, j, k]
+                ih1 = h2o_hi[i, j, k]
+                wh = h2o_weight[i, j, k]
+                h2o = h2o_amount[i, j, k]
+                tau += _prepared_interp_h2o_table(longwave_h2o_absorption, ig,
+                                                  ip0, ip1, wp, it0, it1, wt,
+                                                  ih0, ih1, wh) * FT(h2o)
+            end
+            tau = max(tau, zero(FT))
+            source = _prepared_interp_source_table(source_table, source_temperature_grid,
+                                                   ig, temperature_layers[i, j, k])
+            tr = exp(-tau)
+            up = up * tr + source * (one(FT) - tr)
+            lw_up_field[i, j, k + 1] += weight * up
+        end
+
+        down = zero(FT)
+        for k in Nz:-1:1
+            ip0 = pressure_lo[i, j, k]
+            ip1 = pressure_hi[i, j, k]
+            it0 = temperature_lo[i, j, k]
+            it1 = temperature_hi[i, j, k]
+            wp = pressure_weight[i, j, k]
+            wt = temperature_weight[i, j, k]
+            composite = composite_amount[i, j, k]
+
+            tau = zero(FT)
+            for gas_index in 1:n_gas_lw
+                amount = FT(_tabulated_amount_by_index(composite_amount, h2o_amount,
+                                                       o3_amount, co2_amount, ch4_amount,
+                                                       n2o_amount, cfc11_amount, cfc12_amount,
+                                                       gas_index, i, j, k)) -
+                         FT(gas_reference_mole_fractions[gas_index]) * FT(composite)
+                coefficient = _prepared_interp_table(longwave_absorption, ig, gas_index,
+                                                     ip0, ip1, wp, it0, it1, wt)
+                tau += coefficient * amount
+            end
+            if have_lw_h2o
+                ih0 = h2o_lo[i, j, k]
+                ih1 = h2o_hi[i, j, k]
+                wh = h2o_weight[i, j, k]
+                h2o = h2o_amount[i, j, k]
+                tau += _prepared_interp_h2o_table(longwave_h2o_absorption, ig,
+                                                  ip0, ip1, wp, it0, it1, wt,
+                                                  ih0, ih1, wh) * FT(h2o)
+            end
+            tau = max(tau, zero(FT))
+            source = _prepared_interp_source_table(source_table, source_temperature_grid,
+                                                   ig, temperature_layers[i, j, k])
+            tr = exp(-tau)
+            down = down * tr + source * (one(FT) - tr)
+            lw_down_field[i, j, k] -= weight * down
+        end
+    end
+
+    # Shortwave streaming: downward sweep only is integrated into the
+    # downwelling shortwave flux field, matching the existing semantics in
+    # `_tabulated_ecckd_flux_divergence!` (no shortwave-up flux field is
+    # currently allocated on the radiative transfer model).
+    @inbounds for ig in axes(shortwave_absorption, 1)
+        weight = FT(shortwave_weights[ig])
+        down = FT(solar_constant)
+        sw_down_field[i, j, Nz + 1] -= weight * down
+        for k in Nz:-1:1
+            ip0 = pressure_lo[i, j, k]
+            ip1 = pressure_hi[i, j, k]
+            it0 = temperature_lo[i, j, k]
+            it1 = temperature_hi[i, j, k]
+            wp = pressure_weight[i, j, k]
+            wt = temperature_weight[i, j, k]
+            composite = composite_amount[i, j, k]
+
+            tau = zero(FT)
+            for gas_index in 1:n_gas_sw
+                amount = FT(_tabulated_amount_by_index(composite_amount, h2o_amount,
+                                                       o3_amount, co2_amount, ch4_amount,
+                                                       n2o_amount, cfc11_amount, cfc12_amount,
+                                                       gas_index, i, j, k)) -
+                         FT(gas_reference_mole_fractions[gas_index]) * FT(composite)
+                coefficient = _prepared_interp_table(shortwave_absorption, ig, gas_index,
+                                                     ip0, ip1, wp, it0, it1, wt)
+                tau += coefficient * amount
+            end
+            if have_sw_h2o
+                ih0 = h2o_lo[i, j, k]
+                ih1 = h2o_hi[i, j, k]
+                wh = h2o_weight[i, j, k]
+                h2o = h2o_amount[i, j, k]
+                tau += _prepared_interp_h2o_table(shortwave_h2o_absorption, ig,
+                                                  ip0, ip1, wp, it0, it1, wt,
+                                                  ih0, ih1, wh) * FT(h2o)
+            end
+            tau = max(tau, zero(FT))
+            down *= exp(-tau)
+            sw_down_field[i, j, k] -= weight * down
+        end
+    end
+
+    @inbounds for k in 1:Nz
+        net_bottom = lw_up_field[i, j, k] +
+                     lw_down_field[i, j, k] +
+                     sw_down_field[i, j, k]
+        net_top = lw_up_field[i, j, k + 1] +
+                  lw_down_field[i, j, k + 1] +
+                  sw_down_field[i, j, k + 1]
+        flux_divergence[i, j, k] = -(net_top - net_bottom) / Δzᶜᶜᶜ(i, j, k, grid)
+    end
+end
+
+function radiative_heating_device_support(backend, gas_optics)
+    backend == "H100" || return (
+        status = "supported",
+        reason = "CPU benchmark path supports package-native gas optics",
+        missing_kernel_requirements = String[],
+        source = "BreezeLightfluxExt",
+    )
+    if gas_optics isa Lightflux.EcCKDGasOpticsModel &&
+       Lightflux.gas_names(gas_optics) == (:h2o, :co2)
+        return (
+            status = "supported",
+            reason = "H100 extension path supports fixed two-gas EcCKDGasOpticsModel",
+            missing_kernel_requirements = String[],
+            source = "BreezeLightfluxExt",
+        )
+    elseif gas_optics isa Lightflux.EcCKDTabulatedGasOpticsModel
+        parity = tabulated_ecckd_parity_evidence(gas_optics)
+        parity.passed && return (
+            status = "supported",
+            reason = "H100 extension path supports tabulated multi-gas ecCKD with recorded CPU/GPU parity evidence",
+            missing_kernel_requirements = String[],
+            source = "BreezeLightfluxExt",
+        )
+        return (
+            status = "unsupported",
+            reason = "H100 extension path has tabulated multi-gas ecCKD kernels wired but still requires CPU/GPU parity evidence ($(parity.reason))",
+            missing_kernel_requirements = copy(TABULATED_ECCKD_H100_MISSING_KERNEL_REQUIREMENTS),
+            source = "BreezeLightfluxExt",
+        )
+    end
+    return (
+        status = "unsupported",
+        reason = "H100 extension path only supports fixed two-gas EcCKDGasOpticsModel",
+        missing_kernel_requirements = ["device kernel for this gas optics model type"],
+        source = "BreezeLightfluxExt",
+    )
+end
+
+function materialize_gases(::Val{GasNames}, FT, nlayers, gas_values) where GasNames
+    values = ntuple(Val(length(GasNames))) do n
+        fill(specified_gas_value(gas_values, GasNames[n], FT), nlayers)
+    end
+    return NamedTuple{GasNames}(values)
+end
+
+function RadiativeHeatingWorkspace(grid::AbstractGrid,
+                                   gas_optics::SupportedEcCKDModel;
+                                   gas_values = (; co2 = 400e-6),
+                                   cloud_optics = nothing,
+                                   aerosol_optics = nothing)
+    FT = eltype(grid)
+    nlayers = size(grid, 3)
+    longwave_ng = size(gas_optics.longwave_absorption, 1)
+    shortwave_ng = size(gas_optics.shortwave_absorption, 1)
+
+    pressure_layers = zeros(FT, nlayers)
+    pressure_interfaces = zeros(FT, nlayers + 1)
+    temperature_layers = zeros(FT, nlayers)
+    temperature_interfaces = zeros(FT, nlayers + 1)
+    gases = materialize_gases(Val(Lightflux.gas_names(gas_optics)), FT, nlayers, gas_values)
+
+    longwave_optics = Lightflux.LongwaveOpticalProperties(
+        zeros(FT, longwave_ng, nlayers),
+        zeros(FT, longwave_ng, nlayers),
+        weights = copy(gas_optics.longwave_weights),
+    )
+    shortwave_optics = Lightflux.ShortwaveOpticalProperties(
+        zeros(FT, shortwave_ng, nlayers),
+        weights = copy(gas_optics.shortwave_weights),
+    )
+    cloud_properties = isnothing(cloud_optics) ? nothing :
+        Lightflux.CloudOpticalProperties(zeros(FT, nlayers), zeros(FT, nlayers))
+    aerosol_properties = isnothing(aerosol_optics) ? nothing :
+        Lightflux.AerosolOpticalProperties(zeros(FT, nlayers), zeros(FT, nlayers))
+    fluxes = Lightflux.RadiativeFluxes(
+        longwave_up = zeros(FT, nlayers + 1),
+        longwave_down = zeros(FT, nlayers + 1),
+        shortwave_up = zeros(FT, nlayers + 1),
+        shortwave_down = zeros(FT, nlayers + 1),
+    )
+    heating_rates = zeros(FT, nlayers)
+    atmosphere = Lightflux.ColumnAtmosphere(
+        pressure_layers = pressure_layers,
+        pressure_interfaces = pressure_interfaces,
+        temperature_layers = temperature_layers,
+        temperature_interfaces = temperature_interfaces,
+        gases = gases,
+        surface = (;),
+        geometry = (;),
+    )
+
+    return RadiativeHeatingWorkspace(pressure_layers,
+                                     pressure_interfaces,
+                                     temperature_layers,
+                                     temperature_interfaces,
+                                     gases,
+                                     longwave_optics,
+                                     shortwave_optics,
+                                     cloud_properties,
+                                     aerosol_properties,
+                                     fluxes,
+                                     heating_rates,
+                                     atmosphere)
+end
+
+function RadiativeHeatingWorkspace(grid::AbstractGrid,
+                                   gas_optics::Lightflux.AbstractGasOpticsModel; kw...)
+    throw(ArgumentError("BreezeLightfluxExt currently supports EcCKDGasOpticsModel and EcCKDTabulatedGasOpticsModel"))
+end
+
+"""
+    AtmosphereModels.RadiativeTransferModel(grid, RadiativeHeatingOptics(), constants; gas_optics, ...)
+
+Construct a Breeze radiation model backed by `Lightflux.jl`.
+
+The extension keeps the component work arrays in `RadiativeHeatingWorkspace`.
+Callers that own their own dynamics can reuse `fill_column_state!`,
+`radiative_heating_column_fluxes!`, and `column_heating_rates!` independently
+of Breeze's `_update_radiation!` path.
+"""
+function AtmosphereModels.RadiativeTransferModel(grid::AbstractGrid,
+                                                 ::RadiativeHeatingOptics,
+                                                 constants::ThermodynamicConstants;
+                                                 gas_optics,
+                                                 longwave_solver = Lightflux.CloudlessLongwave(),
+                                                 shortwave_solver = Lightflux.CloudlessShortwave(),
+                                                 workspace = nothing,
+                                                 gas_values = (; co2 = 400e-6),
+                                                 cloud_optics = nothing,
+                                                 aerosol_optics = nothing,
+                                                 solar_constant = 1361,
+                                                 coordinate = nothing,
+                                                 epoch = nothing,
+                                                 surface_temperature = 300,
+                                                 surface_albedo = 0.1,
+                                                 surface_emissivity = 1,
+                                                 schedule = IterationInterval(1))
+    gas_optics isa Lightflux.AbstractGasOpticsModel ||
+        throw(ArgumentError("gas_optics must be an Lightflux.AbstractGasOpticsModel"))
+    isnothing(cloud_optics) || cloud_optics isa Lightflux.AbstractCloudOpticsModel ||
+        throw(ArgumentError("cloud_optics must be nothing or an Lightflux.AbstractCloudOpticsModel"))
+    isnothing(aerosol_optics) || aerosol_optics isa Lightflux.AbstractAerosolOpticsModel ||
+        throw(ArgumentError("aerosol_optics must be nothing or an Lightflux.AbstractAerosolOpticsModel"))
+
+    FT = eltype(grid)
+    arch = architecture(grid)
+    runtime_gas_optics = arch isa CPU ? gas_optics : adapt(arch.device, gas_optics)
+    workspace = isnothing(workspace) ?
+        RadiativeHeatingWorkspace(grid, gas_optics; gas_values, cloud_optics, aerosol_optics) :
+        workspace
+    device_workspace = gas_optics isa Lightflux.EcCKDTabulatedGasOpticsModel &&
+        has_tabulated_ecckd_interpolation_grids(gas_optics) ?
+        TabulatedEcCKDDeviceWorkspace(arch, FT, grid, gas_optics) : nothing
+    atmospheric_state = RadiativeHeatingAtmosphericState(runtime_gas_optics, cloud_optics, aerosol_optics, workspace, device_workspace, gas_values)
+    surface_properties = SurfaceRadiativeProperties(materialize_surface_property(surface_temperature, grid),
+                                                    convert(FT, surface_emissivity),
+                                                    materialize_surface_property(surface_albedo, grid),
+                                                    materialize_surface_property(surface_albedo, grid))
+
+    return RadiativeTransferModel(convert(FT, solar_constant),
+                                  coordinate,
+                                  epoch,
+                                  surface_properties,
+                                  nothing,
+                                  atmospheric_state,
+                                  longwave_solver,
+                                  shortwave_solver,
+                                  ZFaceField(grid),
+                                  ZFaceField(grid),
+                                  ZFaceField(grid),
+                                  CenterField(grid),
+                                  nothing,
+                                  nothing,
+                                  schedule)
+end
+
+@inline surface_value(x::Number, i, j) = x
+@inline surface_value(x, i, j) = x[i, j, 1]
+
+function fill_column_gases!(workspace,
+                            ::Lightflux.EcCKDGasOpticsModel,
+                            qᵛ,
+                            gas_values,
+                            grid,
+                            i,
+                            j,
+                            kt,
+                            kz)
+    if haskey(workspace.gases, :h2o)
+        workspace.gases.h2o[kt] = max(qᵛ[i, j, kz], zero(eltype(grid)))
+    end
+    return nothing
+end
+
+function fill_column_gases!(workspace,
+                            ::Lightflux.EcCKDTabulatedGasOpticsModel,
+                            qᵛ,
+                            gas_values,
+                            grid,
+                            i,
+                            j,
+                            kt,
+                            kz)
+    FT = eltype(grid)
+    Δp = abs(workspace.pressure_interfaces[kt + 1] - workspace.pressure_interfaces[kt])
+    dry_air_moles = Δp / FT(GRAVITY) / FT(MOLAR_MASS_DRY_AIR)
+    h2o_moles = max(qᵛ[i, j, kz], zero(FT)) * Δp / FT(GRAVITY) / FT(MOLAR_MASS_WATER)
+
+    haskey(workspace.gases, :composite) && (workspace.gases.composite[kt] = dry_air_moles)
+    haskey(workspace.gases, :h2o) && (workspace.gases.h2o[kt] = h2o_moles)
+    for name in (:co2, :o3, :ch4, :n2o, :cfc11, :cfc12)
+        if haskey(workspace.gases, name)
+            workspace.gases[name][kt] = specified_gas_value(gas_values, name, FT) * dry_air_moles
+        end
+    end
+    return nothing
+end
+
+function fill_column_state!(workspace::RadiativeHeatingWorkspace, rtm, model, i, j)
+    grid = model.grid
+    nlayers = size(grid, 3)
+    pressure = model.dynamics.reference_state.pressure
+    temperature = model.temperature
+    qᵛ = specific_humidity(model)
+
+    for kt in 1:nlayers
+        kz = nlayers - kt + 1
+        workspace.pressure_layers[kt] = pressure[i, j, kz]
+        workspace.temperature_layers[kt] = temperature[i, j, kz]
+        workspace.temperature_interfaces[kt] = ℑzᵃᵃᶠ(i, j, kz + 1, grid, temperature)
+        workspace.pressure_interfaces[kt] = ℑzᵃᵃᶠ(i, j, kz + 1, grid, pressure)
+    end
+
+    workspace.pressure_interfaces[nlayers + 1] = ℑzᵃᵃᶠ(i, j, 1, grid, pressure)
+    workspace.temperature_interfaces[nlayers + 1] = surface_value(rtm.surface_properties.surface_temperature, i, j)
+
+    for kt in 1:nlayers
+        kz = nlayers - kt + 1
+        fill_column_gases!(workspace,
+                           rtm.atmospheric_state.gas_optics,
+                           qᵛ,
+                           rtm.atmospheric_state.gas_values,
+                           grid,
+                           i,
+                           j,
+                           kt,
+                           kz)
+    end
+    return workspace.atmosphere
+end
+
+function radiative_heating_column_fluxes!(workspace::RadiativeHeatingWorkspace, rtm, i = 1, j = 1)
+    Lightflux.optical_properties!(workspace.longwave_optics,
+                                              workspace.shortwave_optics,
+                                              rtm.atmospheric_state.gas_optics,
+                                              workspace.atmosphere)
+    surface_temperature = workspace.temperature_interfaces[end]
+    surface_longwave_up = rtm.surface_properties.surface_emissivity *
+                          eltype(workspace.fluxes)(5.670374419e-8) * surface_temperature^4
+    longwave_boundary = Lightflux.LongwaveBoundaryConditions(
+        surface_longwave_up = surface_longwave_up,
+        toa_longwave_down = zero(surface_longwave_up),
+    )
+    shortwave_boundary = Lightflux.ShortwaveBoundaryConditions(
+        toa_shortwave_down = rtm.solar_constant,
+        surface_albedo = surface_value(rtm.surface_properties.direct_surface_albedo, i, j),
+    )
+    Lightflux.radiative_fluxes!(workspace.fluxes,
+                                            rtm.longwave_solver,
+                                            workspace.longwave_optics,
+                                            workspace.atmosphere,
+                                            longwave_boundary)
+    Lightflux.radiative_fluxes!(workspace.fluxes,
+                                            rtm.shortwave_solver,
+                                            workspace.shortwave_optics,
+                                            workspace.atmosphere,
+                                            shortwave_boundary)
+    return workspace.fluxes
+end
+
+function column_heating_rates!(workspace::RadiativeHeatingWorkspace, constants::ThermodynamicConstants)
+    Lightflux.heating_rates!(workspace.heating_rates,
+                                         workspace.fluxes,
+                                         workspace.atmosphere;
+                                         gravity = constants.gravitational_acceleration,
+                                         heat_capacity = constants.dry_air.heat_capacity)
+    return workspace.heating_rates
+end
+
+function write_column_fluxes!(rtm, workspace::RadiativeHeatingWorkspace, grid, i, j)
+    nlayers = size(grid, 3)
+    for kt in 1:(nlayers + 1)
+        kz = nlayers - kt + 2
+        rtm.upwelling_longwave_flux[i, j, kz] = workspace.fluxes.longwave_up[kt]
+        rtm.downwelling_longwave_flux[i, j, kz] = -workspace.fluxes.longwave_down[kt]
+        rtm.downwelling_shortwave_flux[i, j, kz] = -workspace.fluxes.shortwave_down[kt]
+    end
+    return nothing
+end
+
+function write_flux_divergence!(rtm, grid, i, j)
+    for k in 1:size(grid, 3)
+        net_bottom = rtm.upwelling_longwave_flux[i, j, k] +
+                     rtm.downwelling_longwave_flux[i, j, k] +
+                     rtm.downwelling_shortwave_flux[i, j, k]
+        net_top = rtm.upwelling_longwave_flux[i, j, k + 1] +
+                  rtm.downwelling_longwave_flux[i, j, k + 1] +
+                  rtm.downwelling_shortwave_flux[i, j, k + 1]
+        rtm.flux_divergence[i, j, k] = -(net_top - net_bottom) / Δzᶜᶜᶜ(i, j, k, grid)
+    end
+    return nothing
+end
+
+function AtmosphereModels._update_radiation!(rtm::RadiativeTransferModel{<:Any, <:Any, <:Any, <:Any, Nothing, <:RadiativeHeatingAtmosphericState}, model)
+    grid = model.grid
+    if !(architecture(grid) isa CPU)
+        return update_radiation_device!(rtm, model)
+    end
+
+    if rtm.atmospheric_state.gas_optics isa Lightflux.EcCKDTabulatedGasOpticsModel &&
+       rtm.atmospheric_state.device_workspace !== nothing
+        return update_tabulated_ecckd_radiation_device!(
+            rtm,
+            model,
+            rtm.atmospheric_state.gas_optics,
+        )
+    end
+
+    workspace = rtm.atmospheric_state.workspace
+    Nx, Ny, _ = size(grid)
+    for j in 1:Ny, i in 1:Nx
+        fill_column_state!(workspace, rtm, model, i, j)
+        radiative_heating_column_fluxes!(workspace, rtm, i, j)
+        write_column_fluxes!(rtm, workspace, grid, i, j)
+        write_flux_divergence!(rtm, grid, i, j)
+    end
+    return nothing
+end
+
+function update_radiation_device!(rtm, model)
+    gas_optics = rtm.atmospheric_state.gas_optics
+    if gas_optics isa Lightflux.EcCKDTabulatedGasOpticsModel
+        return update_tabulated_ecckd_radiation_device!(rtm, model, gas_optics)
+    end
+    gas_optics isa Lightflux.EcCKDGasOpticsModel ||
+        throw(ArgumentError("BreezeLightfluxExt device path currently supports EcCKDGasOpticsModel and EcCKDTabulatedGasOpticsModel"))
+    Lightflux.gas_names(gas_optics) == (:h2o, :co2) ||
+        throw(ArgumentError("BreezeLightfluxExt fixed-coefficient device path currently supports gas_names = (:h2o, :co2)"))
+
+    grid = model.grid
+    arch = architecture(grid)
+    pressure = model.dynamics.reference_state.pressure
+    temperature = model.temperature
+    qᵛ = specific_humidity(model)
+    co2 = specified_gas_value(rtm.atmospheric_state.gas_values, :co2, eltype(grid))
+    surface_temperature = rtm.surface_properties.surface_temperature
+    surface_albedo = rtm.surface_properties.direct_surface_albedo
+    surface_emissivity = rtm.surface_properties.surface_emissivity
+    launch!(arch, grid, :xy, _radiative_heating_fixed_ecckd_column!,
+            rtm.upwelling_longwave_flux,
+            rtm.downwelling_longwave_flux,
+            rtm.downwelling_shortwave_flux,
+            rtm.flux_divergence,
+            grid,
+            pressure,
+            temperature,
+            qᵛ,
+            gas_optics.longwave_absorption,
+            gas_optics.shortwave_absorption,
+            gas_optics.longwave_weights,
+            gas_optics.shortwave_weights,
+            gas_optics.longwave_source_scale,
+            rtm.solar_constant,
+            surface_temperature,
+            surface_albedo,
+            surface_emissivity,
+            co2)
+    return nothing
+end
+
+function update_tabulated_ecckd_radiation_device!(rtm, model, gas_optics)
+    workspace = rtm.atmospheric_state.device_workspace
+    workspace === nothing &&
+        throw(ArgumentError("BreezeLightfluxExt tabulated ecCKD device path requires a preallocated device workspace"))
+
+    grid = model.grid
+    pressure = model.dynamics.reference_state.pressure
+    temperature = model.temperature
+    qᵛ = specific_humidity(model)
+    gas_values = rtm.atmospheric_state.gas_values
+    FT = eltype(grid)
+
+    tabulated_ecckd_device_column_state!(
+        workspace,
+        grid,
+        pressure,
+        temperature,
+        qᵛ;
+        co2 = specified_gas_value(gas_values, :co2, FT),
+        o3 = specified_gas_value(gas_values, :o3, FT),
+        ch4 = specified_gas_value(gas_values, :ch4, FT),
+        n2o = specified_gas_value(gas_values, :n2o, FT),
+        cfc11 = specified_gas_value(gas_values, :cfc11, FT),
+        cfc12 = specified_gas_value(gas_values, :cfc12, FT),
+    )
+    tabulated_ecckd_interpolation_state!(
+        workspace.interpolation,
+        grid,
+        workspace.pressure_layers,
+        workspace.temperature_layers,
+        workspace.column_amounts,
+        gas_optics.pressure_grid,
+        gas_optics.temperature_grid,
+        gas_optics.h2o_mole_fraction_grid,
+    )
+    tabulated_ecckd_streaming_radiation!(
+        rtm.upwelling_longwave_flux,
+        rtm.downwelling_longwave_flux,
+        rtm.downwelling_shortwave_flux,
+        rtm.flux_divergence,
+        grid,
+        workspace,
+        gas_optics;
+        solar_constant = rtm.solar_constant,
+        surface_temperature = rtm.surface_properties.surface_temperature,
+        surface_albedo = rtm.surface_properties.direct_surface_albedo,
+        surface_emissivity = rtm.surface_properties.surface_emissivity,
+    )
+    return nothing
+end
+
+@inline _field_or_number(x::Number, i, j) = x
+@inline _field_or_number(x, i, j) = x[i, j, 1]
+
+@inline function _fixed_tau(absorption, ig, h2o, co2)
+    return absorption[ig, 1] * h2o + absorption[ig, 2] * co2
+end
+
+@inline function _layer_h2o(qᵛ, i, j, k)
+    q = qᵛ[i, j, k]
+    return max(q, zero(q))
+end
+
+@kernel function _radiative_heating_fixed_ecckd_column!(lw_up_field,
+                                                        lw_down_field,
+                                                        sw_down_field,
+                                                        flux_divergence,
+                                                        grid,
+                                                        pressure,
+                                                        temperature,
+                                                        qᵛ,
+                                                        lw_absorption,
+                                                        sw_absorption,
+                                                        lw_weights,
+                                                        sw_weights,
+                                                        lw_source_scale,
+                                                        solar_constant,
+                                                        surface_temperature,
+                                                        surface_albedo,
+                                                        surface_emissivity,
+                                                        co2)
+    i, j = @index(Global, NTuple)
+
+    Nz = size(grid, 3)
+    FT = eltype(grid)
+    σ = FT(5.670374419e-8)
+    T_surface = _field_or_number(surface_temperature, i, j)
+    α_surface = _field_or_number(surface_albedo, i, j)
+    ε_surface = FT(surface_emissivity)
+    surface_longwave_up = ε_surface * σ * T_surface^4
+
+    for kz in 1:(Nz + 1)
+        lw_up_field[i, j, kz] = zero(FT)
+        lw_down_field[i, j, kz] = zero(FT)
+        sw_down_field[i, j, kz] = zero(FT)
+    end
+
+    for ig in axes(lw_absorption, 1)
+        up = surface_longwave_up
+        lw_up_field[i, j, 1] += lw_weights[ig] * up
+        for k in 1:Nz
+            h2o = _layer_h2o(qᵛ, i, j, k)
+            τ = _fixed_tau(lw_absorption, ig, h2o, co2)
+            tr = exp(-τ)
+            T_layer = temperature[i, j, k]
+            source = lw_source_scale[ig] * σ * T_layer^4
+            up = up * tr + source * (one(FT) - tr)
+            lw_up_field[i, j, k + 1] += lw_weights[ig] * up
+        end
+
+        down = zero(FT)
+        lw_down_field[i, j, Nz + 1] += zero(FT)
+        for k in Nz:-1:1
+            h2o = _layer_h2o(qᵛ, i, j, k)
+            τ = _fixed_tau(lw_absorption, ig, h2o, co2)
+            tr = exp(-τ)
+            T_layer = temperature[i, j, k]
+            source = lw_source_scale[ig] * σ * T_layer^4
+            down = down * tr + source * (one(FT) - tr)
+            lw_down_field[i, j, k] -= lw_weights[ig] * down
+        end
+    end
+
+    for ig in axes(sw_absorption, 1)
+        down = FT(solar_constant)
+        sw_down_field[i, j, Nz + 1] -= sw_weights[ig] * down
+        for k in Nz:-1:1
+            h2o = _layer_h2o(qᵛ, i, j, k)
+            τ = _fixed_tau(sw_absorption, ig, h2o, co2)
+            down *= exp(-τ)
+            sw_down_field[i, j, k] -= sw_weights[ig] * down
+        end
+
+        up = α_surface * down
+        for k in 1:Nz
+            h2o = _layer_h2o(qᵛ, i, j, k)
+            τ = _fixed_tau(sw_absorption, ig, h2o, co2)
+            up *= exp(-τ)
+        end
+    end
+
+    for k in 1:Nz
+        net_bottom = lw_up_field[i, j, k] +
+                     lw_down_field[i, j, k] +
+                     sw_down_field[i, j, k]
+        net_top = lw_up_field[i, j, k + 1] +
+                  lw_down_field[i, j, k + 1] +
+                  sw_down_field[i, j, k + 1]
+        flux_divergence[i, j, k] = -(net_top - net_bottom) / Δzᶜᶜᶜ(i, j, k, grid)
+    end
+end
+
+end

--- a/src/AtmosphereModels/AtmosphereModels.jl
+++ b/src/AtmosphereModels/AtmosphereModels.jl
@@ -63,6 +63,7 @@ export
     GrayOptics,
     ClearSkyOptics,
     AllSkyOptics,
+    RadiativeHeatingOptics,
 
     # Cloud effective radius
     ConstantRadiusParticles,

--- a/src/AtmosphereModels/radiation_interface.jl
+++ b/src/AtmosphereModels/radiation_interface.jl
@@ -99,6 +99,19 @@ cloud water path, cloud fraction, and effective radius inputs from the microphys
 struct AllSkyOptics <: AbstractOptics end
 
 """
+$(TYPEDEF)
+
+Type representing radiation through `Lightflux.jl`.
+
+The concrete implementation is provided by `BreezeLightfluxExt` when
+`Lightflux` is loaded. The extension exposes component-level
+column state, optical-property, flux, and heating-rate functions so host models
+can reuse optimized kernels without giving up their own solvers or vertical
+integrals.
+"""
+struct RadiativeHeatingOptics <: AbstractOptics end
+
+"""
 $(TYPEDSIGNATURES)
 
 Construct a `RadiativeTransferModel` on `grid` using the specified `optics`.

--- a/src/Breeze.jl
+++ b/src/Breeze.jl
@@ -31,6 +31,7 @@ export
     GrayOptics,
     ClearSkyOptics,
     AllSkyOptics,
+    RadiativeHeatingOptics,
     ConstantRadiusParticles,
     TemperatureField,
     IdealGas,

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+Lightflux = "cd8119b0-1744-44d6-9ede-6ad1ad750b26"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Breeze = "660aa2fb-d4c8-4359-a52c-9c057bc511da"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
@@ -11,6 +12,7 @@ Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
 GPUCompiler = "61eb1bfa-7361-4325-ad38-22787b887f55"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Metal = "dde4c033-4e86-420c-a63e-0dd931031962"
 NCDatasets = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
@@ -23,10 +25,12 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
+Lightflux = {path = "../../../Lightflux.jl"}
 Breeze = {path = ".."}
 
 [compat]
 Adapt = "4.3.0"
+Lightflux = "0.1"
 Aqua = "0.8"
 CUDA = "5, ~6.0"
 ClimaComms = "0.6"
@@ -37,6 +41,7 @@ Enzyme = "0.13.118"
 ExplicitImports = "1.13"
 GPUArraysCore = "0.2"
 GPUCompiler = "~1.10"
+JSON = "1.4"
 Logging = "<0.0.1, 1"
 Metal = "1.9"
 NCDatasets = "0.14"

--- a/test/radiative_heating_benchmark_acceptance.jl
+++ b/test/radiative_heating_benchmark_acceptance.jl
@@ -1,0 +1,226 @@
+using Test
+
+include(joinpath(@__DIR__, "..", "benchmarking", "radiative_heating_rcemip_benchmark.jl"))
+include(joinpath(@__DIR__, "..", "benchmarking", "radiative_heating_h100_support_preflight.jl"))
+include(joinpath(@__DIR__, "..", "benchmarking", "radiative_heating_tabulated_ecckd_parity.jl"))
+
+function accepted_result(; status = "final_4x_evidence",
+                         backend = "H100",
+                         speedup = 4.1,
+                         gas_model_source = "validated_ecCKD",
+                         gas_model_accuracy_status = "passed",
+                         gas_model_device_support_status = "supported")
+    return Dict(
+        "status" => status,
+        "backend" => backend,
+        "radiative_heating_runtime_supported" => true,
+        "rrtmgp_runtime_supported" => true,
+        "radiation_update_speedup" => speedup,
+        "nsys_report" => "profile.nsys-rep",
+        "ncu_report" => "profile.ncu-rep",
+        "gas_model_source" => gas_model_source,
+        "gas_model_accuracy_status" => gas_model_accuracy_status,
+        "gas_model_device_support_status" => gas_model_device_support_status,
+        "gas_model_device_support_reason" => "test fixture",
+    )
+end
+
+@testset "RadiativeHeating reduced active table-entry moves" begin
+    model = EcCKDTabulatedGasOpticsModel(
+        gas_names = (:h2o,),
+        pressure_grid = [1.0e4, 1.0e5],
+        temperature_grid = [220.0, 300.0],
+        h2o_mole_fraction_grid = [1.0e-3, 1.0e-2],
+        gas_reference_mole_fractions = [0.0],
+        longwave_absorption = fill(1.0e-8, 2, 1, 2, 2),
+        shortwave_absorption = fill(2.0e-8, 2, 1, 2, 2),
+        longwave_h2o_absorption = fill(1.0e-8, 2, 2, 2, 2),
+        shortwave_h2o_absorption = fill(3.0e-8, 2, 2, 2, 2),
+        shortwave_rayleigh_molar_scattering = fill(1.0e-8, 2),
+        longwave_weights = fill(0.5, 2),
+        shortwave_weights = fill(0.5, 2),
+        longwave_source_scale = fill(1.0, 2),
+    )
+    moves = Any[
+        Dict(
+            "component" => "static_absorption",
+            "local_gpoint_index" => 1,
+            "gpoint" => 1,
+            "gas_index" => 1,
+            "pressure_index" => 1,
+            "temperature_index" => 2,
+            "h2o_index" => 0,
+            "log_scale" => log(5.0),
+        ),
+        Dict(
+            "component" => "dynamic_h2o",
+            "local_gpoint_index" => 2,
+            "gpoint" => 2,
+            "gas_index" => 0,
+            "pressure_index" => 2,
+            "temperature_index" => 1,
+            "h2o_index" => 2,
+            "log_scale" => log(7.0),
+        ),
+    ]
+
+    apply_reduced_preflight_active_table_entry_moves!(model, moves)
+
+    @test model.shortwave_absorption[1, 1, 1, 2] ≈ 1.0e-7
+    @test model.shortwave_absorption[1, 1, 1, 1] ≈ 2.0e-8
+    @test model.shortwave_h2o_absorption[2, 2, 1, 2] ≈ 2.1e-7
+    @test model.shortwave_h2o_absorption[2, 1, 1, 2] ≈ 3.0e-8
+
+    if isfile(reduced_preflight_json()) && isfile(reduced_global_entry_json())
+        preflight = JSON.parsefile(reduced_preflight_json())
+        selected_moves = reduced_best_active_table_entry_moves(preflight)
+        @test length(selected_moves) >= 3
+    end
+end
+
+@testset "RadiativeHeating tabulated ecCKD CPU/GPU parity artifact" begin
+    output_dir = mktempdir()
+    withenv("RADIATIVE_HEATING_GAS_MODEL_SOURCE" => "validated_ecCKD",
+            "RADIATIVE_HEATING_PARITY_DIR" => output_dir,
+            "RADIATIVE_HEATING_PARITY_NX" => "1",
+            "RADIATIVE_HEATING_PARITY_NY" => "1",
+            "RADIATIVE_HEATING_PARITY_NZ" => "4") do
+        code = parity_main()
+        @test code in (0, 1, 2)
+    end
+    json_path = joinpath(output_dir, "radiative_heating_tabulated_ecckd_parity_latest.json")
+    md_path = joinpath(output_dir, "radiative_heating_tabulated_ecckd_parity_latest.md")
+    @test isfile(json_path)
+    @test isfile(md_path)
+    json = read(json_path, String)
+    @test occursin("\"case\": \"radiative_heating_tabulated_ecckd_cpu_gpu_parity\"", json)
+    @test occursin("\"gas_model_source\": \"validated_ecCKD\"", json)
+    @test occursin("\"passed\":", json)
+    @test occursin("\"status\":", json)
+    @test occursin("\"reason\":", json)
+    if !CUDA.functional()
+        @test occursin("\"status\": \"blocked\"", json)
+        @test occursin("CUDA.functional() is false", json)
+    end
+end
+
+@testset "RadiativeHeating benchmark final acceptance" begin
+    accepted, reason = final_acceptance(accepted_result())
+    @test accepted
+    @test reason == "none"
+
+    accepted, reason = final_acceptance(accepted_result(status = "scaffold_not_final_4x_evidence"))
+    @test !accepted
+    @test occursin("not final_4x_evidence", reason)
+
+    accepted, reason = final_acceptance(accepted_result(gas_model_source = "synthetic_fixed_coefficients"))
+    @test !accepted
+    @test occursin("synthetic fixed coefficients", reason)
+
+    accepted, reason = final_acceptance(accepted_result(gas_model_accuracy_status = "failed_threshold"))
+    @test !accepted
+    @test occursin("not passed", reason)
+
+    accepted, reason = final_acceptance(accepted_result(gas_model_device_support_status = "unsupported"))
+    @test !accepted
+    @test occursin("device support", reason)
+end
+
+@testset "RadiativeHeating benchmark gas model metadata" begin
+    @test benchmark_status() == "scaffold_not_final_4x_evidence"
+    withenv("RADIATIVE_HEATING_BENCHMARK_STATUS" => "final_4x_evidence") do
+        @test benchmark_status() == "final_4x_evidence"
+    end
+
+    withenv("RADIATIVE_HEATING_GAS_MODEL_SOURCE" => "synthetic_fixed_coefficients",
+            "RADIATIVE_HEATING_NG_LW" => "32",
+            "RADIATIVE_HEATING_NG_SW" => "16") do
+        gas_model = benchmark_gas_model(Float64)
+        @test gas_model.source == "synthetic_fixed_coefficients"
+        @test gas_model.kind == "fixed_ecCKD_32_lw_16_sw"
+        @test gas_model.accuracy_status == "not_checked_scaffold"
+        gas_values = benchmark_gas_values(gas_model)
+        @test gas_values[:co2] == 400.0e-6
+        @test !haskey(gas_values, :ch4)
+        support = gas_model_device_support("H100", gas_model.gas_optics)
+        @test support.status == "supported"
+    end
+
+    withenv("RADIATIVE_HEATING_GAS_MODEL_SOURCE" => "validated_ecCKD",
+            "RADIATIVE_HEATING_TABULATED_ECCKD_PARITY_JSON" => nothing) do
+        gas_model = benchmark_gas_model(Float64)
+        @test gas_model.source == "validated_ecCKD"
+        @test startswith(gas_model.kind, "official_ecCKD_")
+        @test gas_model.accuracy_status == "passed"
+        @test gas_model.gas_optics isa Lightflux.EcCKDTabulatedGasOpticsModel
+        gas_values = benchmark_gas_values(gas_model)
+        @test gas_values[:co2] == 420.0e-6
+        @test gas_values[:ch4] == 1.8e-6
+        @test gas_values[:n2o] == 330.0e-9
+        @test gas_values[:cfc11] > 0
+        @test gas_values[:cfc12] > 0
+        cpu_support = gas_model_device_support("CPU", gas_model.gas_optics)
+        @test cpu_support.status == "supported"
+        h100_support = gas_model_device_support("H100", gas_model.gas_optics)
+        @test h100_support.status == "unsupported"
+        @test occursin("tabulated", h100_support.reason)
+        @test !any(contains("tabulated absorption lookup accumulation"),
+                   h100_support.missing_kernel_requirements)
+        @test !any(contains("Rayleigh"),
+                   h100_support.missing_kernel_requirements)
+        @test !any(contains("source-table"),
+                   h100_support.missing_kernel_requirements)
+        @test !any(contains("allocation-free"),
+                   h100_support.missing_kernel_requirements)
+        @test !any(contains("radiation update path"),
+                   h100_support.missing_kernel_requirements)
+        @test !any(contains("column-molar-amount"),
+                   h100_support.missing_kernel_requirements)
+        @test !any(contains("dynamic h2o lookup-table interpolation"),
+                   h100_support.missing_kernel_requirements)
+        @test h100_support.source == "BreezeLightfluxExt"
+
+        parity_path = joinpath(mktempdir(), "passed_parity.json")
+        write(parity_path, """
+        {
+          "case": "radiative_heating_tabulated_ecckd_cpu_gpu_parity",
+          "status": "passed",
+          "passed": true,
+          "gas_model_kind": "$(gas_model.kind)",
+          "gas_model_source": "validated_ecCKD"
+        }
+        """)
+        withenv("RADIATIVE_HEATING_TABULATED_ECCKD_PARITY_JSON" => parity_path) do
+            supported = gas_model_device_support("H100", gas_model.gas_optics)
+            @test supported.status == "supported"
+            @test isempty(supported.missing_kernel_requirements)
+            @test occursin("parity", supported.reason)
+        end
+    end
+end
+
+@testset "RadiativeHeating H100 final-gate preflight" begin
+    withenv("RADIATIVE_HEATING_GAS_MODEL_SOURCE" => "validated_ecCKD",
+            "RADIATIVE_HEATING_TABULATED_ECCKD_PARITY_JSON" => nothing) do
+        gas_model = benchmark_gas_model(Float64)
+        support = gas_model_device_support("H100", gas_model.gas_optics)
+        @test support.status == "unsupported"
+        @test occursin("parity", support.reason)
+    end
+
+    output_dir = mktempdir()
+    withenv("RADIATIVE_HEATING_GAS_MODEL_SOURCE" => "validated_ecCKD",
+            "RADIATIVE_HEATING_H100_PREFLIGHT_DIR" => output_dir) do
+        @test main() == 2
+    end
+    json_path = joinpath(output_dir, "radiative_heating_h100_support_preflight_latest.json")
+    @test isfile(json_path)
+    json = read(json_path, String)
+    @test occursin("\"status\": \"blocked\"", json)
+    @test occursin("\"gas_model_device_support_status\": \"unsupported\"", json)
+    @test occursin("\"gas_model_device_support_source\": \"BreezeLightfluxExt\"", json)
+    @test occursin("\"next_required_implementation\"", json)
+    @test occursin("EcCKDTabulatedGasOpticsModel", json)
+    @test occursin("\"missing_kernel_requirements\"", json)
+    @test occursin("CPU/GPU parity smoke test", json)
+end

--- a/test/radiative_heating_extension.jl
+++ b/test/radiative_heating_extension.jl
@@ -1,0 +1,506 @@
+using Lightflux
+using Breeze
+using Oceananigans
+using Oceananigans.Fields: CenterField, interior, set!
+using Test
+
+@testset "RadiativeHeating extension" begin
+    grid = RectilinearGrid(CPU(); size = 4, z = (0, 1), topology = (Flat, Flat, Bounded))
+    constants = Breeze.Thermodynamics.ThermodynamicConstants()
+    gas_optics = EcCKDGasOpticsModel(
+        gas_names = (:h2o, :co2),
+        longwave_absorption = fill(0.01, 2, 2),
+        shortwave_absorption = fill(0.005, 2, 2),
+        longwave_weights = fill(0.5, 2),
+        shortwave_weights = fill(0.5, 2),
+        longwave_source_scale = fill(1.0, 2),
+    )
+
+    radiation = RadiativeTransferModel(grid, RadiativeHeatingOptics(), constants;
+                                       gas_optics,
+                                       surface_temperature = 300,
+                                       surface_albedo = 0.1)
+    ext = Base.get_extension(Breeze, :BreezeLightfluxExt)
+    workspace = radiation.atmospheric_state.workspace
+
+    @test ext !== nothing
+    @test workspace.pressure_layers === workspace.atmosphere.pressure_layers
+    @test workspace.temperature_layers === workspace.atmosphere.temperature_layers
+    @test size(workspace.longwave_optics.optical_depth) == (2, 4)
+    @test size(workspace.shortwave_optics.optical_depth) == (2, 4)
+    @test length(workspace.fluxes.longwave_up) == 5
+
+    workspace.pressure_interfaces .= range(1000, 100000; length = 5)
+    workspace.pressure_layers .= (workspace.pressure_interfaces[1:end-1] .+
+                                  workspace.pressure_interfaces[2:end]) ./ 2
+    workspace.temperature_layers .= range(220, 300; length = 4)
+    workspace.temperature_interfaces .= range(210, 300; length = 5)
+    workspace.gases.h2o .= 0.01
+    workspace.gases.co2 .= 400e-6
+
+    ext.radiative_heating_column_fluxes!(workspace, radiation)
+    ext.column_heating_rates!(workspace, constants)
+
+    @test all(isfinite, workspace.fluxes.longwave_up)
+    @test all(isfinite, workspace.fluxes.longwave_down)
+    @test all(isfinite, workspace.fluxes.shortwave_up)
+    @test all(isfinite, workspace.fluxes.shortwave_down)
+    @test all(isfinite, workspace.heating_rates)
+
+    pressure = CenterField(grid)
+    temperature = CenterField(grid)
+    qᵛ = CenterField(grid)
+    set!(pressure, z -> 100000 - 80000z)
+    set!(temperature, z -> 300 - 80z)
+    set!(qᵛ, 0.01)
+
+    model = (
+        grid = grid,
+        dynamics = (reference_state = (pressure = pressure,),),
+        temperature = temperature,
+        microphysical_fields = (qᵛ = qᵛ,),
+        clock = (iteration = 0,),
+    )
+
+    Breeze.AtmosphereModels.update_radiation!(radiation, model)
+    @test all(isfinite, Array(interior(radiation.upwelling_longwave_flux, 1, 1, :)))
+    @test all(isfinite, Array(interior(radiation.downwelling_longwave_flux, 1, 1, :)))
+    @test all(isfinite, Array(interior(radiation.downwelling_shortwave_flux, 1, 1, :)))
+    @test all(isfinite, Array(interior(radiation.flux_divergence, 1, 1, :)))
+
+    fixed_support = ext.radiative_heating_device_support("H100", gas_optics)
+    @test fixed_support.status == "supported"
+    @test fixed_support.source == "BreezeLightfluxExt"
+end
+
+@testset "RadiativeHeating tabulated ecCKD column amounts" begin
+    grid = RectilinearGrid(CPU(); size = 2, z = (0, 1), topology = (Flat, Flat, Bounded))
+    constants = Breeze.Thermodynamics.ThermodynamicConstants()
+    gas_optics = EcCKDTabulatedGasOpticsModel(
+        gas_names = (:composite, :h2o, :co2),
+        pressure_grid = [1.0e4, 1.0e5],
+        temperature_grid = [220.0, 300.0],
+        gas_reference_mole_fractions = [0.0, 0.0, 0.0],
+        longwave_absorption = fill(1.0e-8, 2, 3, 2, 2),
+        shortwave_absorption = fill(5.0e-9, 2, 3, 2, 2),
+        longwave_weights = fill(0.5, 2),
+        shortwave_weights = fill(0.5, 2),
+        longwave_source_scale = fill(1.0, 2),
+    )
+    radiation = RadiativeTransferModel(grid, RadiativeHeatingOptics(), constants;
+                                       gas_optics,
+                                       gas_values = (; co2 = 420.0e-6),
+                                       surface_temperature = 300,
+                                       surface_albedo = 0.1)
+    ext = Base.get_extension(Breeze, :BreezeLightfluxExt)
+
+    pressure = CenterField(grid)
+    temperature = CenterField(grid)
+    qᵛ = CenterField(grid)
+    set!(pressure, z -> 100000 - 60000z)
+    set!(temperature, z -> 300 - 50z)
+    set!(qᵛ, 0.01)
+
+    model = (
+        grid = grid,
+        dynamics = (reference_state = (pressure = pressure,),),
+        temperature = temperature,
+        microphysical_fields = (qᵛ = qᵛ,),
+        clock = (iteration = 0,),
+    )
+
+    workspace = radiation.atmospheric_state.workspace
+    ext.fill_column_state!(workspace, radiation, model, 1, 1)
+
+    @test all(workspace.gases.composite .> 0)
+    @test all(workspace.gases.h2o .> 0)
+    @test all(workspace.gases.co2 .> 0)
+    @test workspace.gases.co2[1] ≈ 420.0e-6 * workspace.gases.composite[1]
+    @test workspace.gases.h2o[1] > 0.01 * workspace.gases.composite[1]
+
+    Breeze.AtmosphereModels.update_radiation!(radiation, model)
+    @test all(isfinite, Array(interior(radiation.upwelling_longwave_flux, 1, 1, :)))
+    @test all(isfinite, Array(interior(radiation.downwelling_longwave_flux, 1, 1, :)))
+    @test all(isfinite, Array(interior(radiation.downwelling_shortwave_flux, 1, 1, :)))
+    @test all(isfinite, Array(interior(radiation.flux_divergence, 1, 1, :)))
+
+    withenv("RADIATIVE_HEATING_TABULATED_ECCKD_PARITY_JSON" => nothing) do
+        support = ext.radiative_heating_device_support("H100", gas_optics)
+        @test support.status == "unsupported"
+        @test support.source == "BreezeLightfluxExt"
+        @test occursin("parity", support.reason)
+        @test !any(contains("column-molar-amount"), support.missing_kernel_requirements)
+        @test !any(contains("allocation-free"), support.missing_kernel_requirements)
+        @test !any(contains("radiation update path"), support.missing_kernel_requirements)
+        @test any(contains("CPU/GPU parity"), support.missing_kernel_requirements)
+    end
+end
+
+@testset "RadiativeHeating tabulated ecCKD device column-state workspace" begin
+    grid = RectilinearGrid(CPU(); size = (2, 2, 3),
+                           x = (0, 1), y = (0, 1), z = (0, 1),
+                           topology = (Periodic, Periodic, Bounded))
+    ext = Base.get_extension(Breeze, :BreezeLightfluxExt)
+    FT = Float64
+    gas_optics = EcCKDTabulatedGasOpticsModel(
+        gas_names = (:composite, :h2o, :o3, :co2, :ch4, :n2o, :cfc11, :cfc12),
+        pressure_grid = [1.0e4, 1.0e5],
+        temperature_grid = [220.0, 300.0],
+        h2o_mole_fraction_grid = [1.0e-3, 1.0e-2],
+        gas_reference_mole_fractions = zeros(8),
+        longwave_absorption = fill(1.0e-8, 1, 8, 2, 2),
+        shortwave_absorption = fill(5.0e-9, 1, 8, 2, 2),
+        longwave_h2o_absorption = fill(1.0e-8, 1, 2, 2, 2),
+        shortwave_h2o_absorption = fill(5.0e-9, 1, 2, 2, 2),
+        shortwave_rayleigh_molar_scattering = fill(1.0e-8, 1),
+        longwave_source_temperature_grid = [200.0, 300.0],
+        longwave_source_table = fill(10.0, 1, 2),
+        longwave_weights = [1.0],
+        shortwave_weights = [1.0],
+    )
+    workspace = ext.TabulatedEcCKDDeviceWorkspace(CPU(), FT, grid, gas_optics)
+    pressure = CenterField(grid)
+    temperature = CenterField(grid)
+    qᵛ = CenterField(grid)
+    set!(pressure, (x, y, z) -> 100000 - 80000z)
+    set!(temperature, (x, y, z) -> 300 - 60z)
+    set!(qᵛ, 0.01)
+
+    ext.tabulated_ecckd_device_column_state!(
+        workspace,
+        grid,
+        pressure,
+        temperature,
+        qᵛ;
+        co2 = 420.0e-6,
+        o3 = 1.0e-8,
+        ch4 = 1.8e-6,
+        n2o = 330.0e-9,
+        cfc11 = 230.0e-12,
+        cfc12 = 520.0e-12,
+    )
+
+    @test all(workspace.column_amounts.composite .> 0)
+    @test all(workspace.column_amounts.h2o .> 0)
+    @test workspace.column_amounts.co2[1, 1, 1] ≈ 420.0e-6 * workspace.column_amounts.composite[1, 1, 1]
+    @test workspace.pressure_interfaces[1, 1, 1] > workspace.pressure_interfaces[1, 1, end]
+    @test all(isfinite, workspace.temperature_layers)
+end
+
+@testset "RadiativeHeating tabulated ecCKD column amount kernel" begin
+    grid = RectilinearGrid(CPU(); size = (2, 2, 3),
+                           x = (0, 1), y = (0, 1), z = (0, 1),
+                           topology = (Periodic, Periodic, Bounded))
+    ext = Base.get_extension(Breeze, :BreezeLightfluxExt)
+    FT = Float64
+    state = ext.TabulatedEcCKDColumnAmountState(FT, (2, 2, 3))
+    pressure_interfaces = zeros(FT, 2, 2, 4)
+    qᵛ = fill(0.01, 2, 2, 3)
+    for i in 1:2, j in 1:2
+        pressure_interfaces[i, j, :] .= (1000, 34000, 67000, 100000)
+    end
+
+    ext.tabulated_ecckd_column_amounts!(state, grid, pressure_interfaces, qᵛ;
+                                        co2 = 420e-6,
+                                        o3 = 1e-8,
+                                        ch4 = 1.8e-6,
+                                        n2o = 330e-9,
+                                        cfc11 = 230e-12,
+                                        cfc12 = 520e-12)
+
+    expected_dry = (34000 - 1000) / 9.80665 / 0.0289647
+    expected_h2o = 0.01 * (34000 - 1000) / 9.80665 / 0.01801528
+    @test state.composite[1, 1, 1] ≈ expected_dry
+    @test state.h2o[1, 1, 1] ≈ expected_h2o
+    @test state.co2[1, 1, 1] ≈ 420e-6 * expected_dry
+    @test state.o3[1, 1, 1] ≈ 1e-8 * expected_dry
+    @test state.ch4[1, 1, 1] ≈ 1.8e-6 * expected_dry
+    @test state.n2o[1, 1, 1] ≈ 330e-9 * expected_dry
+    @test state.cfc11[1, 1, 1] ≈ 230e-12 * expected_dry
+    @test state.cfc12[1, 1, 1] ≈ 520e-12 * expected_dry
+end
+
+@testset "RadiativeHeating tabulated ecCKD interpolation state kernel" begin
+    grid = RectilinearGrid(CPU(); size = (2, 2, 3),
+                           x = (0, 1), y = (0, 1), z = (0, 1),
+                           topology = (Periodic, Periodic, Bounded))
+    ext = Base.get_extension(Breeze, :BreezeLightfluxExt)
+    FT = Float64
+    amounts = ext.TabulatedEcCKDColumnAmountState(FT, (2, 2, 3))
+    interp = ext.TabulatedEcCKDInterpolationState(FT, (2, 2, 3))
+    pressure_layers = fill(1.0e4, 2, 2, 3)
+    temperature_layers = fill(275.0, 2, 2, 3)
+    amounts.composite .= 1000.0
+    amounts.h2o .= 10.0
+
+    ext.tabulated_ecckd_interpolation_state!(
+        interp,
+        grid,
+        pressure_layers,
+        temperature_layers,
+        amounts,
+        [1.0e3, 1.0e4, 1.0e5],
+        [200.0, 250.0, 300.0],
+        [1.0e-3, 1.0e-2, 1.0e-1],
+    )
+
+    @test interp.pressure_lo[1, 1, 1] == 2
+    @test interp.pressure_hi[1, 1, 1] == 3
+    @test interp.pressure_weight[1, 1, 1] ≈ 0
+    @test interp.temperature_lo[1, 1, 1] == 2
+    @test interp.temperature_hi[1, 1, 1] == 3
+    @test interp.temperature_weight[1, 1, 1] ≈ 0.5
+    @test interp.h2o_lo[1, 1, 1] == 2
+    @test interp.h2o_hi[1, 1, 1] == 3
+    @test interp.h2o_weight[1, 1, 1] ≈ 0
+
+    temperature_layers .= 235.0
+    ext.tabulated_ecckd_interpolation_state!(
+        interp,
+        grid,
+        pressure_layers,
+        temperature_layers,
+        amounts,
+        [1.0e3, 1.0e4, 1.0e5],
+        [200.0 250.0 300.0; 210.0 260.0 310.0; 220.0 270.0 320.0],
+        [1.0e-3, 1.0e-2, 1.0e-1],
+    )
+
+    @test interp.temperature_lo[1, 1, 1] == 1
+    @test interp.temperature_hi[1, 1, 1] == 2
+    @test interp.temperature_weight[1, 1, 1] ≈ 0.5
+end
+
+@testset "RadiativeHeating tabulated ecCKD absorption optical depth kernel" begin
+    grid = RectilinearGrid(CPU(); size = (2, 2, 2),
+                           x = (0, 1), y = (0, 1), z = (0, 1),
+                           topology = (Periodic, Periodic, Bounded))
+    ext = Base.get_extension(Breeze, :BreezeLightfluxExt)
+    FT = Float64
+    amounts = ext.TabulatedEcCKDColumnAmountState(FT, (2, 2, 2))
+    interp = ext.TabulatedEcCKDInterpolationState(FT, (2, 2, 2))
+    amounts.composite .= 1000
+    amounts.h2o .= 20
+    amounts.o3 .= 3
+    amounts.co2 .= 4
+    amounts.ch4 .= 5
+    amounts.n2o .= 6
+    amounts.cfc11 .= 7
+    amounts.cfc12 .= 8
+    interp.pressure_lo .= 1
+    interp.pressure_hi .= 2
+    interp.temperature_lo .= 1
+    interp.temperature_hi .= 2
+    interp.h2o_lo .= 1
+    interp.h2o_hi .= 2
+    interp.pressure_weight .= 0
+    interp.temperature_weight .= 0
+    interp.h2o_weight .= 0
+
+    lw_absorption = zeros(FT, 2, 8, 2, 2)
+    sw_absorption = zeros(FT, 1, 8, 2, 2)
+    for gas in 1:8
+        lw_absorption[1, gas, :, :] .= 0.001gas
+        lw_absorption[2, gas, :, :] .= 0.002gas
+        sw_absorption[1, gas, :, :] .= 0.003gas
+    end
+    lw_h2o = fill(0.05, 2, 2, 2, 2)
+    sw_h2o = fill(0.07, 1, 2, 2, 2)
+    gas_reference = zeros(FT, 8)
+    gas_reference[4] = 1.0e-3
+    lw_tau = zeros(FT, 2, 2, 2, 2)
+    sw_tau = zeros(FT, 1, 2, 2, 2)
+
+    ext.tabulated_ecckd_absorption_optical_depths!(
+        lw_tau,
+        sw_tau,
+        grid,
+        amounts,
+        interp,
+        gas_reference,
+        lw_absorption,
+        sw_absorption,
+        lw_h2o,
+        sw_h2o,
+    )
+
+    adjusted = [1000, 20, 3, 4 - 1.0e-3 * 1000, 5, 6, 7, 8]
+    expected_lw1 = sum(0.001gas * adjusted[gas] for gas in 1:8) + 0.05 * 20
+    expected_lw2 = sum(0.002gas * adjusted[gas] for gas in 1:8) + 0.05 * 20
+    expected_sw = sum(0.003gas * adjusted[gas] for gas in 1:8) + 0.07 * 20
+    @test lw_tau[1, 1, 1, 1] ≈ expected_lw1
+    @test lw_tau[2, 1, 1, 1] ≈ expected_lw2
+    @test sw_tau[1, 1, 1, 1] ≈ expected_sw
+end
+
+@testset "RadiativeHeating tabulated ecCKD Rayleigh optical depth kernel" begin
+    grid = RectilinearGrid(CPU(); size = (2, 2, 2),
+                           x = (0, 1), y = (0, 1), z = (0, 1),
+                           topology = (Periodic, Periodic, Bounded))
+    ext = Base.get_extension(Breeze, :BreezeLightfluxExt)
+    FT = Float64
+    amounts = ext.TabulatedEcCKDColumnAmountState(FT, (2, 2, 2))
+    amounts.composite .= 1234.0
+    rayleigh = zeros(FT, 2, 2, 2, 2)
+
+    ext.tabulated_ecckd_rayleigh_optical_depths!(
+        rayleigh,
+        grid,
+        amounts,
+        [1.0e-8, 2.0e-8],
+    )
+
+    @test rayleigh[1, 1, 1, 1] ≈ 1.0e-8 * 1234.0
+    @test rayleigh[2, 1, 1, 1] ≈ 2.0e-8 * 1234.0
+end
+
+@testset "RadiativeHeating tabulated ecCKD longwave source kernel" begin
+    grid = RectilinearGrid(CPU(); size = (2, 2, 2),
+                           x = (0, 1), y = (0, 1), z = (0, 1),
+                           topology = (Periodic, Periodic, Bounded))
+    ext = Base.get_extension(Breeze, :BreezeLightfluxExt)
+    FT = Float64
+    source = zeros(FT, 2, 2, 2, 2)
+    temperature_layers = fill(250.0, 2, 2, 2)
+    source_temperature_grid = [200.0, 300.0]
+    source_table = [
+        10.0 30.0
+        100.0 300.0
+    ]
+
+    ext.tabulated_ecckd_longwave_sources!(
+        source,
+        grid,
+        temperature_layers,
+        source_temperature_grid,
+        source_table,
+    )
+
+    @test source[1, 1, 1, 1] ≈ 20.0
+    @test source[2, 1, 1, 1] ≈ 200.0
+
+    temperature_layers .= 180.0
+    ext.tabulated_ecckd_longwave_sources!(
+        source,
+        grid,
+        temperature_layers,
+        source_temperature_grid,
+        source_table,
+    )
+    @test source[1, 1, 1, 1] ≈ 10.0
+end
+
+@testset "RadiativeHeating tabulated ecCKD integrated optical properties kernel" begin
+    grid = RectilinearGrid(CPU(); size = (2, 2, 2),
+                           x = (0, 1), y = (0, 1), z = (0, 1),
+                           topology = (Periodic, Periodic, Bounded))
+    ext = Base.get_extension(Breeze, :BreezeLightfluxExt)
+    FT = Float64
+    amounts = ext.TabulatedEcCKDColumnAmountState(FT, (2, 2, 2))
+    interp = ext.TabulatedEcCKDInterpolationState(FT, (2, 2, 2))
+    amounts.composite .= 1000
+    amounts.h2o .= 20
+    amounts.o3 .= 3
+    amounts.co2 .= 4
+    amounts.ch4 .= 5
+    amounts.n2o .= 6
+    amounts.cfc11 .= 7
+    amounts.cfc12 .= 8
+    interp.pressure_lo .= 1
+    interp.pressure_hi .= 2
+    interp.temperature_lo .= 1
+    interp.temperature_hi .= 2
+    interp.h2o_lo .= 1
+    interp.h2o_hi .= 2
+    interp.pressure_weight .= 0
+    interp.temperature_weight .= 0
+    interp.h2o_weight .= 0
+
+    lw_absorption = zeros(FT, 2, 8, 2, 2)
+    sw_absorption = zeros(FT, 1, 8, 2, 2)
+    for gas in 1:8
+        lw_absorption[1, gas, :, :] .= 0.001gas
+        lw_absorption[2, gas, :, :] .= 0.002gas
+        sw_absorption[1, gas, :, :] .= 0.003gas
+    end
+    lw_h2o = fill(0.05, 2, 2, 2, 2)
+    sw_h2o = fill(0.07, 1, 2, 2, 2)
+    gas_reference = zeros(FT, 8)
+    gas_reference[4] = 1.0e-3
+    source_temperature_grid = [200.0, 300.0]
+    source_table = [
+        10.0 30.0
+        100.0 300.0
+    ]
+    temperature_layers = fill(250.0, 2, 2, 2)
+    lw_tau = zeros(FT, 2, 2, 2, 2)
+    sw_tau = zeros(FT, 1, 2, 2, 2)
+    rayleigh = zeros(FT, 1, 2, 2, 2)
+    source = zeros(FT, 2, 2, 2, 2)
+
+    ext.tabulated_ecckd_optical_properties!(
+        lw_tau,
+        sw_tau,
+        rayleigh,
+        source,
+        grid,
+        temperature_layers,
+        amounts,
+        interp,
+        gas_reference,
+        lw_absorption,
+        sw_absorption,
+        lw_h2o,
+        sw_h2o,
+        [1.0e-8],
+        source_temperature_grid,
+        source_table,
+    )
+
+    adjusted = [1000, 20, 3, 4 - 1.0e-3 * 1000, 5, 6, 7, 8]
+    @test lw_tau[1, 1, 1, 1] ≈ sum(0.001gas * adjusted[gas] for gas in 1:8) + 0.05 * 20
+    @test lw_tau[2, 1, 1, 1] ≈ sum(0.002gas * adjusted[gas] for gas in 1:8) + 0.05 * 20
+    @test sw_tau[1, 1, 1, 1] ≈ sum(0.003gas * adjusted[gas] for gas in 1:8) + 0.07 * 20
+    @test rayleigh[1, 1, 1, 1] ≈ 1.0e-8 * 1000
+    @test source[1, 1, 1, 1] ≈ 20.0
+    @test source[2, 1, 1, 1] ≈ 200.0
+end
+
+@testset "RadiativeHeating tabulated ecCKD flux-divergence kernel" begin
+    grid = RectilinearGrid(CPU(); size = (2, 2, 2),
+                           x = (0, 1), y = (0, 1), z = (0, 1),
+                           topology = (Periodic, Periodic, Bounded))
+    ext = Base.get_extension(Breeze, :BreezeLightfluxExt)
+    FT = Float64
+    lw_up = zeros(FT, 2, 2, 3)
+    lw_down = zeros(FT, 2, 2, 3)
+    sw_down = zeros(FT, 2, 2, 3)
+    flux_divergence = zeros(FT, 2, 2, 2)
+    lw_tau = fill(log(2), 1, 2, 2, 2)
+    sw_tau = fill(log(2), 1, 2, 2, 2)
+    rayleigh_tau = zeros(FT, 1, 2, 2, 2)
+    lw_source = fill(10.0, 1, 2, 2, 2)
+
+    ext.tabulated_ecckd_flux_divergence!(
+        lw_up,
+        lw_down,
+        sw_down,
+        flux_divergence,
+        grid,
+        lw_tau,
+        sw_tau,
+        rayleigh_tau,
+        lw_source,
+        [1.0],
+        [1.0];
+        solar_constant = 100.0,
+        surface_temperature = 0.0,
+        surface_albedo = 0.1,
+        surface_emissivity = 1.0,
+    )
+
+    @test lw_up[1, 1, :] ≈ [0.0, 5.0, 7.5]
+    @test lw_down[1, 1, :] ≈ [-7.5, -5.0, 0.0]
+    @test sw_down[1, 1, :] ≈ [-25.0, -50.0, -100.0]
+    @test flux_divergence[1, 1, :] ≈ [35.0, 85.0]
+end


### PR DESCRIPTION
## Summary

Stands up the Breeze-side extension that bridges Breeze to the Lightflux radiation package (formerly AnalyticBandRadiation; companion PR at NumericalEarth/AnalyticBandRadiation.jl#8). The tabulated multi-gas device path uses a fused streaming kernel `_tabulated_ecckd_streaming_radiation!` that computes per-g-point optical depth and Planck source inline at each column step — **no `(ngpt, Nx, Ny, Nz)` four-dimensional optical-property buffers**. Persistent device storage scales as `Nx * Ny * Nz` not `Nx * Ny * Nz * Nk`. At 512×512×128 / 262,144 columns with 96 SW g-points, this avoids ~26 GiB per buffer.

## What's in the diff

- `ext/BreezeLightfluxExt/BreezeLightfluxExt.jl`: the extension. KernelAbstractions kernels for column amounts, interpolation state, the (legacy) precomputed-tau optics + flux-divergence pair, and the new fused streaming kernel that supersedes them for production. The device workspace drops the four 4-D arrays the legacy pair required.
- `src/AtmosphereModels/{AtmosphereModels.jl,radiation_interface.jl}`, `src/Breeze.jl`, `Project.toml`: wire `RadiativeHeatingOptics()` into the existing `RadiativeTransferModel` constructor + export.
- `benchmarking/`: H100 benchmark harness and supporting scripts. Driven through Breeze's `update_radiation!` so RH and the RRTMGP baseline are measured under identical call surfaces. ENV-configurable for backend, k-model, grid, samples, gas-model source.
- `test/`: extension and benchmark-acceptance tests.
- `benchmarking/Project.toml`: `[sources]` path corrected to the right relative depth for the developing Lightflux checkout.
- `.gitignore`: exclude `*.nsys-rep` and `*.ncu-rep` Nsight profiler binaries.

## Naming

- Package providing the gas optics: **Lightflux** (was `AnalyticBandRadiation`).
- Breeze extension: **`BreezeLightfluxExt`** (was `BreezeRadiativeHeatingExt`).
- Consumer-facing types in Breeze (`RadiativeHeatingOptics`, `RadiativeHeatingWorkspace`, `radiative_heating_column_fluxes!`, …) are unchanged — they describe what the code does, not which package implements it.

## Measured H100 performance

Samples=5, post-warmup median, RCEMIP-style 512×512×128 / 262,144 columns, validated ecCKD on both LW and SW.

| k-model | RH ms | RRTMGP ms | Speedup |
|---|---:|---:|---:|
| 32 LW × 32 SW (`fsck-32b` × `rgb-32b`) | 794.7 | 5863.3 | 7.4× |
| 32 LW × 64 SW (`fsck-32b` × `window-64b`) | 1047.3 | 5864.2 | 5.6× |
| 32 LW × 96 SW (`fsck-32b` × `vfine-96b`) | 1279.3 | 5867.7 | 4.6× |
| 64 LW × 32 SW (`narrow-64b` × `rgb-32b`) | 1352.7 | 5869.8 | 4.3× |
| 64 LW × 64 SW (`narrow-64b` × `window-64b`) | 1603.6 | 5870.1 | 3.7× |

RRTMGP is essentially constant — its 256-LW × 224-SW lookup is independent of the ecCKD k-counts. Lightflux scales sub-linearly in g-points under the streaming kernel.

## Test plan

- [ ] `julia --project=test test/runtests.jl` (CPU extension test)
- [ ] `julia --project=benchmarking benchmarking/radiative_heating_rcemip_benchmark.jl` on CPU (smoke)
- [ ] `sbatch …/h100_kmodel_coverage.sbatch` (driven from the Lightflux benchmarking project — see the companion PR) reproduces the table above on H100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)