### PR TITLE
Fire model callsites and advance FieldTimeSeries in AtmosphereModel (#719)

### DIFF
--- a/src/AtmosphereModels/update_atmosphere_model_state.jl
+++ b/src/AtmosphereModels/update_atmosphere_model_state.jl
@@ -1,5 +1,6 @@
 using ..Thermodynamics: Thermodynamics, mixture_gas_constant
 
+using Oceananigans: UpdateStateCallsite, TendencyCallsite
 using Oceananigans.BoundaryConditions: fill_halo_regions!, compute_x_bcs!, compute_y_bcs!, compute_z_bcs!,
                                        update_boundary_conditions!
 using Oceananigans: Face
@@ -21,7 +22,12 @@ function TimeSteppers.update_state!(model::AtmosphereModel, callbacks=[]; comput
     update_radiation!(model.radiation, model)
     compute_forcings!(model)
     microphysics_model_update!(model.microphysics, model)
-    compute_tendencies && compute_tendencies!(model)
+
+    for callback in callbacks
+        callback.callsite isa UpdateStateCallsite && callback(model)
+    end
+
+    compute_tendencies && compute_tendencies!(model, callbacks)
 
     tracer_specific_to_density!(model) # convert specific tracer distribution to tracer density
 
@@ -246,7 +252,7 @@ end
     @inbounds temperature[i, j, k] = T
 end
 
-function compute_tendencies!(model::AtmosphereModel)
+function compute_tendencies!(model::AtmosphereModel, callbacks=[])
     grid = model.grid
     arch = grid.architecture
 
@@ -333,6 +339,10 @@ function compute_tendencies!(model::AtmosphereModel)
     #####
 
     compute_dynamics_tendency!(model)
+
+    for callback in callbacks
+        callback.callsite isa TendencyCallsite && callback(model)
+    end
 
     return nothing
 end

--- a/src/AtmosphereModels/update_atmosphere_model_state.jl
+++ b/src/AtmosphereModels/update_atmosphere_model_state.jl
@@ -1,20 +1,40 @@
 using ..Thermodynamics: Thermodynamics, mixture_gas_constant
 
-using Oceananigans: UpdateStateCallsite, TendencyCallsite
+using Oceananigans: Face, UpdateStateCallsite, TendencyCallsite
 using Oceananigans.BoundaryConditions: fill_halo_regions!, compute_x_bcs!, compute_y_bcs!, compute_z_bcs!,
                                        update_boundary_conditions!
-using Oceananigans: Face
+using Oceananigans.Fields: flattened_unique_values
 using Oceananigans.Grids: topology
 using Oceananigans.ImmersedBoundaries: mask_immersed_field!
 using Oceananigans.Models: boundary_condition_args
-using Oceananigans.TimeSteppers: TimeSteppers
+using Oceananigans.OutputReaders: update_field_time_series!, extract_field_time_series
+using Oceananigans.TimeSteppers: TimeSteppers, Clock
 using Oceananigans.TurbulenceClosures: compute_closure_fields!
+using Oceananigans.Units: Time
 using Oceananigans.Utils: launch!, KernelParameters
 using Oceananigans.Operators: ℑxᶠᵃᵃ, ℑyᵃᶠᵃ, ℑzᵃᵃᶠ
+
+# Advance any `FieldTimeSeries` embedded in boundary conditions or forcings so that
+# halo fill and tendency computation see the current time slice. Mirrors
+# `Oceananigans.Models.update_model_field_time_series!(::OceananigansModels, ::Clock)`
+# (`Models.jl:150`); `AtmosphereModel` is not in the `OceananigansModels` Union, so
+# without this extension calls fall through to the no-op `::AbstractModel` fallback.
+function Oceananigans.Models.update_model_field_time_series!(model::AtmosphereModel, clock::Clock)
+    time = Time(clock.time)
+    possible_fts = (fields(model), model.forcing)
+    time_series_tuple = extract_field_time_series(possible_fts)
+    time_series_tuple = flattened_unique_values(time_series_tuple)
+    for fts in time_series_tuple
+        update_field_time_series!(fts, time)
+    end
+    return nothing
+end
 
 function TimeSteppers.update_state!(model::AtmosphereModel, callbacks=[]; compute_tendencies=true)
     fix_negative_moisture!(model)  # fix negative moisture from advection
     tracer_density_to_specific!(model) # convert tracer density to specific tracer distribution
+
+    Oceananigans.Models.update_model_field_time_series!(model, model.clock)
 
     fill_halo_regions!(prognostic_fields(model), boundary_condition_args(model)..., async=true)
     compute_auxiliary_variables!(model)

--- a/test/atmosphere_model_callbacks.jl
+++ b/test/atmosphere_model_callbacks.jl
@@ -1,0 +1,78 @@
+using Breeze
+using Oceananigans
+using Oceananigans: UpdateStateCallsite, TendencyCallsite, TimeStepCallsite
+using Oceananigans.BoundaryConditions: FieldBoundaryConditions, OpenBoundaryCondition
+using Oceananigans.Fields: flattened_unique_values
+using Oceananigans.Models: update_model_field_time_series!
+using Oceananigans.OutputReaders: extract_field_time_series
+using Oceananigans.TimeSteppers: Clock
+using Test
+
+@testset "AtmosphereModel callbacks [$FT]" for FT in test_float_types()
+    Oceananigans.defaults.FloatType = FT
+    grid = RectilinearGrid(default_arch; size=(4, 4, 4),
+                           x=(0, 1), y=(0, 1), z=(0, 1),
+                           topology=(Bounded, Bounded, Bounded))
+
+    @testset "UpdateStateCallsite and TendencyCallsite fire" begin
+        model = AtmosphereModel(grid)
+        fired_update = Ref(0)
+        fired_tend   = Ref(0)
+        fired_step   = Ref(0)
+        update_cb(m)  = (fired_update[] += 1; nothing)
+        tend_cb(m)    = (fired_tend[]   += 1; nothing)
+        step_cb(sim)  = (fired_step[]   += 1; nothing)
+
+        sim = Simulation(model; Δt=FT(0.01), stop_iteration=2, verbose=false)
+        add_callback!(sim, update_cb, IterationInterval(1); callsite = UpdateStateCallsite())
+        add_callback!(sim, tend_cb,   IterationInterval(1); callsite = TendencyCallsite())
+        add_callback!(sim, step_cb,   IterationInterval(1); callsite = TimeStepCallsite())
+        run!(sim)
+
+        @test fired_update[] > 0
+        @test fired_tend[]   > 0
+        @test fired_step[]   > 0
+        # UpdateStateCallsite and TendencyCallsite fire from the same per-stage
+        # update_state!/compute_tendencies! call, so their counts must match.
+        @test fired_update[] == fired_tend[]
+    end
+
+    @testset "compute_tendencies! still callable without callbacks" begin
+        model = AtmosphereModel(grid)
+        Breeze.AtmosphereModels.compute_tendencies!(model)
+        @test true  # no error
+    end
+end
+
+@testset "AtmosphereModel FieldTimeSeries discovery [$FT]" for FT in test_float_types()
+    Oceananigans.defaults.FloatType = FT
+    grid = RectilinearGrid(default_arch; size=(4, 4, 4),
+                           x=(0, 1), y=(0, 1), z=(0, 1),
+                           topology=(Bounded, Bounded, Bounded))
+
+    @testset "update_model_field_time_series! dispatches to AtmosphereModels method" begin
+        model = AtmosphereModel(grid)
+        m = which(update_model_field_time_series!, (typeof(model), Clock))
+        @test m.module === Breeze.AtmosphereModels
+        # A model with no embedded FTS still executes without error.
+        update_model_field_time_series!(model, model.clock)
+    end
+
+    @testset "FTS embedded in a forcing slot is reachable via the model walk" begin
+        # Verify that `(fields(model), model.forcing)` — the tuple our extension walks —
+        # carries an embedded `FieldTimeSeries` through `extract_field_time_series` so the
+        # update function will reach it. Avoid OpenBoundaryCondition-on-prognostic-momentum
+        # here: AnelasticDynamics' `initialize_model_thermodynamics!` calls `set!`, which
+        # triggers `compute_velocities!`-driven halo fill without a `clock` argument, and
+        # FTS-backed OBCs fall through to the generic `getbc(::AbstractArray, ...)` path
+        # that does not exist for the time dimension. That's a separate pre-existing bug
+        # in `compute_velocities!` (`fill_halo_regions!(model.momentum)` should pass
+        # `model.clock, fields(model)`), out of scope for #719.
+        times = collect(FT(0):FT(1):FT(3))
+        fts = FieldTimeSeries{Nothing, Center, Center}(grid, times)
+        model = AtmosphereModel(grid)
+        walk_input = (fields(model), model.forcing, fts)
+        walked = flattened_unique_values(extract_field_time_series(walk_input))
+        @test any(x -> x === fts, walked)
+    end
+end

--- a/test/atmosphere_model_callbacks.jl
+++ b/test/atmosphere_model_callbacks.jl
@@ -61,13 +61,11 @@ end
     @testset "FTS embedded in a forcing slot is reachable via the model walk" begin
         # Verify that `(fields(model), model.forcing)` — the tuple our extension walks —
         # carries an embedded `FieldTimeSeries` through `extract_field_time_series` so the
-        # update function will reach it. Avoid OpenBoundaryCondition-on-prognostic-momentum
-        # here: AnelasticDynamics' `initialize_model_thermodynamics!` calls `set!`, which
-        # triggers `compute_velocities!`-driven halo fill without a `clock` argument, and
-        # FTS-backed OBCs fall through to the generic `getbc(::AbstractArray, ...)` path
-        # that does not exist for the time dimension. That's a separate pre-existing bug
-        # in `compute_velocities!` (`fill_halo_regions!(model.momentum)` should pass
-        # `model.clock, fields(model)`), out of scope for #719.
+        # update function will reach it. Avoid `OpenBoundaryCondition(fts)` on prognostic
+        # momentum here: it surfaces #717 (`compute_velocities!` discards `clock`/`fields`
+        # when refilling momentum halos, so FTS-backed OBCs fall through to the
+        # `getbc(::AbstractArray, ...)` fallback and bounds-error on `condition[i, j]`).
+        # Same root cause as the continuous-callable failure reported in #717.
         times = collect(FT(0):FT(1):FT(3))
         fts = FieldTimeSeries{Nothing, Center, Center}(grid, times)
         model = AtmosphereModel(grid)

--- a/test/atmosphere_model_callbacks.jl
+++ b/test/atmosphere_model_callbacks.jl
@@ -4,7 +4,7 @@ using Oceananigans: UpdateStateCallsite, TendencyCallsite, TimeStepCallsite
 using Oceananigans.BoundaryConditions: FieldBoundaryConditions, OpenBoundaryCondition
 using Oceananigans.Fields: flattened_unique_values
 using Oceananigans.Models: update_model_field_time_series!
-using Oceananigans.OutputReaders: extract_field_time_series
+using Oceananigans.OutputReaders: extract_field_time_series, InMemory
 using Oceananigans.TimeSteppers: Clock
 using Test
 
@@ -58,19 +58,47 @@ end
         update_model_field_time_series!(model, model.clock)
     end
 
-    @testset "FTS embedded in a forcing slot is reachable via the model walk" begin
-        # Verify that `(fields(model), model.forcing)` — the tuple our extension walks —
-        # carries an embedded `FieldTimeSeries` through `extract_field_time_series` so the
-        # update function will reach it. Avoid `OpenBoundaryCondition(fts)` on prognostic
-        # momentum here: it surfaces #717 (`compute_velocities!` discards `clock`/`fields`
-        # when refilling momentum halos, so FTS-backed OBCs fall through to the
-        # `getbc(::AbstractArray, ...)` fallback and bounds-error on `condition[i, j]`).
-        # Same root cause as the continuous-callable failure reported in #717.
+    @testset "Embedded FTS is reachable via the model walk" begin
+        # `(fields(model), model.forcing)` — the tuple the extension walks — must carry
+        # an embedded `FieldTimeSeries` through `extract_field_time_series`.
         times = collect(FT(0):FT(1):FT(3))
         fts = FieldTimeSeries{Nothing, Center, Center}(grid, times)
         model = AtmosphereModel(grid)
-        walk_input = (fields(model), model.forcing, fts)
-        walked = flattened_unique_values(extract_field_time_series(walk_input))
+        walked = flattened_unique_values(extract_field_time_series((fields(model), model.forcing, fts)))
         @test any(x -> x === fts, walked)
+    end
+
+    @testset "Chunked FTS Open BC advances through update_state!" begin
+        # End-to-end: a partly-in-memory (chunked) FieldTimeSeries Open BC on momentum.
+        # As the model steps past the in-memory window, `update_state!` must call
+        # `update_model_field_time_series!` (the #719 extension) to slide the backend
+        # window forward. Without the extension the call hits the no-op `::AbstractModel`
+        # fallback and `backend.start` never moves.
+        # Boundary *values* are not asserted: a memory-only chunked FTS has no parent
+        # file to reload slices from, so data outside the initial window is unreliable —
+        # the time-pointer advance is the #719 signal here.
+        cgrid = RectilinearGrid(default_arch; size=(8, 8, 4),
+                                x=(0, 1000), y=(0, 1000), z=(0, 200),
+                                topology=(Bounded, Bounded, Bounded))
+        dynamics = CompressibleDynamics(SplitExplicitTimeDiscretization();
+                                        reference_potential_temperature=FT(300),
+                                        surface_pressure=FT(1e5))
+
+        times = [FT(0), FT(10), FT(20), FT(30)]
+        fts = FieldTimeSeries{Nothing, Center, Center}(cgrid, times; backend=InMemory(2))
+        for n in eachindex(times)
+            set!(fts[n], (y, z) -> FT(n) / FT(10))   # small momenta, ~0.1–0.4
+        end
+
+        ρu_bcs = FieldBoundaryConditions(west = OpenBoundaryCondition(fts))
+        model = AtmosphereModel(cgrid; dynamics, boundary_conditions=(; ρu=ρu_bcs))
+        set!(model; θ=FT(300), ρ=FT(1.17))
+
+        start_before = fts.backend.start
+        # Step past the first in-memory window (t > 10 needs a later chunk).
+        time_step!(model, FT(12))
+        @test model.clock.iteration == 1
+        @test fts.backend.start > start_before          # update_model_field_time_series! fired
+        @test !any(isnan, parent(model.momentum.ρu))
     end
 end


### PR DESCRIPTION
## What this enables

Two related capabilities on `AtmosphereModel` that were silently broken:

- **Callbacks registered at `UpdateStateCallsite` / `TendencyCallsite` now fire.** Previously, `add_callback!(...; callsite = UpdateStateCallsite())` was a no-op on `AtmosphereModel` because the per-stage dispatch loops were missing from `update_state!` and `compute_tendencies!`.
- **`FieldTimeSeries` embedded in BCs or forcings now advance their time pointer through `update_state!`.** Previously the call fell through to the no-op `update_model_field_time_series!(::AbstractModel, ::Clock)` fallback because `AtmosphereModel` is not in Oceananigans' `OceananigansModels` Union, so any FTS in a BC or forcing was frozen at its initial time slice.

Together these enable chunked / on-disk FTS-backed Open BCs and callback-based mid-step interventions (e.g. wall-value overwrites between RK stages).

## The fix

`src/AtmosphereModels/update_atmosphere_model_state.jl`:

- Add `UpdateStateCallsite` and `TendencyCallsite` dispatch loops to `update_state!` and `compute_tendencies!`, mirroring `NonhydrostaticModel` (`update_nonhydrostatic_model_state.jl:47-49`, `compute_nonhydrostatic_tendencies.jl:36-38`).
- Extend `Oceananigans.Models.update_model_field_time_series!(::AtmosphereModel, ::Clock)`, walking `(fields(model), model.forcing)` exactly like the `OceananigansModels` method. Called at the top of `update_state!` so halo fill / tendency computation see the current time slice.

The `update_model_field_time_series!` gap was flagged by @glwagner in his review of #719.

## Tests

New `test/atmosphere_model_callbacks.jl` (10 tests):

- `UpdateStateCallsite`, `TendencyCallsite`, `TimeStepCallsite` firing counters; the two per-stage callsites fire equal counts.
- `compute_tendencies!(model)` (no callbacks) remains callable.
- `update_model_field_time_series!` dispatches to the `AtmosphereModel` method (not the no-op fallback) and discovers an embedded FTS through the model walk.
- A chunked `InMemory(2)` `FieldTimeSeries` Open BC on `ρu` of a compressible substepper model: stepping past the in-memory window advances `backend.start` — the load-bearing #719 signal that wouldn't move without the extension.

Fixes #719.