### PR TITLE
Per-substep open-boundary enforcement for split-explicit substepper

### DIFF
--- a/src/CompressibleEquations/acoustic_substepping.jl
+++ b/src/CompressibleEquations/acoustic_substepping.jl
@@ -1310,21 +1310,22 @@ end
 
 @inline is_active_open_bc(bc) = (bc isa BoundaryCondition{<:Open}) && !(bc.condition isa Nothing)
 
-# Relax a Center perturbation toward the prescribed wall value in the outermost
-# open-boundary cell row: `target = v − ρᴸ[cell] = (base[halo] − base[cell]) / 2`.
-@kernel function _relax_open_boundary_x_cell!(pert, base, i_cell, i_halo, α)
+# Relax ρ′ and (ρθ)′ at the outermost open-boundary cell toward the prescribed
+# wall value in a single kernel: target = v − cᴸ[iᴮ] = (cᴸ[iᴴ] − cᴸ[iᴮ]) / 2.
+# `iᴮ` is the outermost interior cell index, `iᴴ` the adjacent halo cell index.
+@kernel function _relax_open_boundary_x!(ρ′, ρθ′, ρᴸ, ρθᴸ, iᴮ, iᴴ, α)
     j, k = @index(Global, NTuple)
     @inbounds begin
-        target = (base[i_halo, j, k] - base[i_cell, j, k]) / 2
-        pert[i_cell, j, k] += α * (target - pert[i_cell, j, k])
+        ρ′[iᴮ, j, k]  += α * ((ρᴸ[iᴴ, j, k]  - ρᴸ[iᴮ, j, k])  / 2 - ρ′[iᴮ, j, k])
+        ρθ′[iᴮ, j, k] += α * ((ρθᴸ[iᴴ, j, k] - ρθᴸ[iᴮ, j, k]) / 2 - ρθ′[iᴮ, j, k])
     end
 end
 
-@kernel function _relax_open_boundary_y_cell!(pert, base, j_cell, j_halo, α)
+@kernel function _relax_open_boundary_y!(ρ′, ρθ′, ρᴸ, ρθᴸ, jᴮ, jᴴ, α)
     i, k = @index(Global, NTuple)
     @inbounds begin
-        target = (base[i, j_halo, k] - base[i, j_cell, k]) / 2
-        pert[i, j_cell, k] += α * (target - pert[i, j_cell, k])
+        ρ′[i, jᴮ, k]  += α * ((ρᴸ[i, jᴴ, k]  - ρᴸ[i, jᴮ, k])  / 2 - ρ′[i, jᴮ, k])
+        ρθ′[i, jᴮ, k] += α * ((ρθᴸ[i, jᴴ, k] - ρθᴸ[i, jᴮ, k]) / 2 - ρθ′[i, jᴮ, k])
     end
 end
 
@@ -1338,20 +1339,16 @@ function apply_open_boundary_relaxation!(substepper, model, grid, arch)
     ρᴸ  = model.dynamics.density
     ρθᴸ = thermodynamic_density(model.formulation)
     if is_active_open_bc(bcs_u.west)
-        launch!(arch, grid, :yz, _relax_open_boundary_x_cell!, ρ′,  ρᴸ,  1, 0, α)
-        launch!(arch, grid, :yz, _relax_open_boundary_x_cell!, ρθ′, ρθᴸ, 1, 0, α)
+        launch!(arch, grid, :yz, _relax_open_boundary_x!, ρ′, ρθ′, ρᴸ, ρθᴸ, 1, 0, α)
     end
     if is_active_open_bc(bcs_u.east)
-        launch!(arch, grid, :yz, _relax_open_boundary_x_cell!, ρ′,  ρᴸ,  Nx, Nx + 1, α)
-        launch!(arch, grid, :yz, _relax_open_boundary_x_cell!, ρθ′, ρθᴸ, Nx, Nx + 1, α)
+        launch!(arch, grid, :yz, _relax_open_boundary_x!, ρ′, ρθ′, ρᴸ, ρθᴸ, Nx, Nx + 1, α)
     end
     if is_active_open_bc(bcs_v.south)
-        launch!(arch, grid, :xz, _relax_open_boundary_y_cell!, ρ′,  ρᴸ,  1, 0, α)
-        launch!(arch, grid, :xz, _relax_open_boundary_y_cell!, ρθ′, ρθᴸ, 1, 0, α)
+        launch!(arch, grid, :xz, _relax_open_boundary_y!, ρ′, ρθ′, ρᴸ, ρθᴸ, 1, 0, α)
     end
     if is_active_open_bc(bcs_v.north)
-        launch!(arch, grid, :xz, _relax_open_boundary_y_cell!, ρ′,  ρᴸ,  Ny, Ny + 1, α)
-        launch!(arch, grid, :xz, _relax_open_boundary_y_cell!, ρθ′, ρθᴸ, Ny, Ny + 1, α)
+        launch!(arch, grid, :xz, _relax_open_boundary_y!, ρ′, ρθ′, ρᴸ, ρθᴸ, Ny, Ny + 1, α)
     end
     return nothing
 end

--- a/src/CompressibleEquations/acoustic_substepping.jl
+++ b/src/CompressibleEquations/acoustic_substepping.jl
@@ -81,7 +81,7 @@ using Oceananigans.Operators:
     Axᶠᶜᶜ, Ayᶜᶠᶜ, Vᶜᶜᶜ
 
 using Oceananigans.Utils: launch!
-using Oceananigans.BoundaryConditions: fill_halo_regions!
+using Oceananigans.BoundaryConditions: fill_halo_regions!, BoundaryCondition, Open
 
 using Oceananigans.Grids: Flat, Center, peripheral_node,
                           topology,
@@ -173,6 +173,9 @@ struct AcousticSubstepper{N, FT, D, AD, US, CF, MP, TAV, GT, TS}
     damping :: D
     substep_distribution :: AD
     sponge :: US
+    # Per-substep relaxation factor `α` for the outermost open-boundary cell
+    # of `ρ′,(ρθ)′`. See `apply_open_boundary_relaxation!` and issue #738.
+    open_boundary_relaxation :: FT
 
     # Linearization basic state ``Uᴸ`` — Πᴸ and θᴸ derived from the live
     # `model.dynamics.pressure`, `model.dynamics.density`, and the
@@ -226,6 +229,7 @@ Adapt.adapt_structure(to, a::AcousticSubstepper) =
                        adapt(to, a.damping),
                        a.substep_distribution,
                        adapt(to, a.sponge),
+                       a.open_boundary_relaxation,
                        adapt(to, a.linearization_exner),
                        adapt(to, a.linearization_potential_temperature),
                        adapt(to, a.linearization_gamma_R_mixture),
@@ -276,6 +280,7 @@ function AcousticSubstepper(grid, split_explicit::SplitExplicitTimeDiscretizatio
     damping = split_explicit.damping
     sponge = split_explicit.sponge
     substep_distribution = split_explicit.substep_distribution
+    open_boundary_relaxation = convert(FT, split_explicit.open_boundary_relaxation)
 
     # Linearization basic state — Πᴸ, θᴸ derived from live model fields.
     linearization_exner                           = CenterField(grid)
@@ -313,7 +318,7 @@ function AcousticSubstepper(grid, split_explicit::SplitExplicitTimeDiscretizatio
                                                tridiagonal_direction = ZDirection())
 
     return AcousticSubstepper(Ns, acoustic_cfl, ω, damping, substep_distribution,
-                              sponge,
+                              sponge, open_boundary_relaxation,
                               linearization_exner,
                               linearization_potential_temperature,
                               linearization_gamma_R_mixture,
@@ -1281,6 +1286,76 @@ end
 ##### Section 12 — Substep loop driver
 #####
 
+# Per-substep open-boundary enforcement (Breeze.jl issue #738).
+#
+# The substepper's perturbation scalars `ρ′,(ρθ)′` carry zero-gradient halos
+# on `Bounded` dims, so an open lateral boundary reflects the linearized
+# acoustic pressure perturbation back into the domain. The boundary mass flux
+# is then carried only by the stage-entry slow tendency `Gˢρ` (frozen across
+# the substeps), biasing the discrete mass balance when a transient inflow
+# crosses the boundary. WRF, ERF, and MPAS all instead enforce the specified
+# lateral boundary on every acoustic substep.
+#
+# Here we mirror that by relaxing the outermost open-boundary cell of `ρ′`,
+# `(ρθ)′` toward the prescribed wall value `v` each substep. `update_state!`
+# applied the prognostic `ValueBoundaryCondition` to the base at stage entry,
+# so `ρᴸ[halo] = 2v − ρᴸ[cell]` and the target perturbation is
+# `v − ρᴸ[cell] = (ρᴸ[halo] − ρᴸ[cell]) / 2`, read directly from the base
+# field. The relaxation factor `α ∈ (0, 1]` (default 0.5, set via
+# `SplitExplicitTimeDiscretization(; open_boundary_relaxation = α)`) controls
+# how hard the cell is pulled each substep. The relaxation is a no-op on any
+# side whose prognostic-momentum BC is not an active `OpenBoundaryCondition`
+# (periodic, walls, and `OpenBoundaryCondition(nothing)` all skip it), so the
+# enforcement has zero cost when no open lateral BC is present.
+
+@inline is_active_open_bc(bc) = (bc isa BoundaryCondition{<:Open}) && !(bc.condition isa Nothing)
+
+# Relax a Center perturbation toward the prescribed wall value in the outermost
+# open-boundary cell row: `target = v − ρᴸ[cell] = (base[halo] − base[cell]) / 2`.
+@kernel function _relax_open_boundary_x_cell!(pert, base, i_cell, i_halo, α)
+    j, k = @index(Global, NTuple)
+    @inbounds begin
+        target = (base[i_halo, j, k] - base[i_cell, j, k]) / 2
+        pert[i_cell, j, k] += α * (target - pert[i_cell, j, k])
+    end
+end
+
+@kernel function _relax_open_boundary_y_cell!(pert, base, j_cell, j_halo, α)
+    i, k = @index(Global, NTuple)
+    @inbounds begin
+        target = (base[i, j_halo, k] - base[i, j_cell, k]) / 2
+        pert[i, j_cell, k] += α * (target - pert[i, j_cell, k])
+    end
+end
+
+function apply_open_boundary_relaxation!(substepper, model, grid, arch)
+    bcs_u = model.momentum.ρu.boundary_conditions
+    bcs_v = model.momentum.ρv.boundary_conditions
+    Nx, Ny, _ = size(grid)
+    α   = substepper.open_boundary_relaxation
+    ρ′  = substepper.density_perturbation
+    ρθ′ = substepper.density_potential_temperature_perturbation
+    ρᴸ  = model.dynamics.density
+    ρθᴸ = thermodynamic_density(model.formulation)
+    if is_active_open_bc(bcs_u.west)
+        launch!(arch, grid, :yz, _relax_open_boundary_x_cell!, ρ′,  ρᴸ,  1, 0, α)
+        launch!(arch, grid, :yz, _relax_open_boundary_x_cell!, ρθ′, ρθᴸ, 1, 0, α)
+    end
+    if is_active_open_bc(bcs_u.east)
+        launch!(arch, grid, :yz, _relax_open_boundary_x_cell!, ρ′,  ρᴸ,  Nx, Nx + 1, α)
+        launch!(arch, grid, :yz, _relax_open_boundary_x_cell!, ρθ′, ρθᴸ, Nx, Nx + 1, α)
+    end
+    if is_active_open_bc(bcs_v.south)
+        launch!(arch, grid, :xz, _relax_open_boundary_y_cell!, ρ′,  ρᴸ,  1, 0, α)
+        launch!(arch, grid, :xz, _relax_open_boundary_y_cell!, ρθ′, ρθᴸ, 1, 0, α)
+    end
+    if is_active_open_bc(bcs_v.north)
+        launch!(arch, grid, :xz, _relax_open_boundary_y_cell!, ρ′,  ρᴸ,  Ny, Ny + 1, α)
+        launch!(arch, grid, :xz, _relax_open_boundary_y_cell!, ρθ′, ρθᴸ, Ny, Ny + 1, α)
+    end
+    return nothing
+end
+
 """
 $(TYPEDSIGNATURES)
 
@@ -1402,6 +1477,11 @@ function acoustic_rk3_substep_loop!(model, substepper, Δt, β_stage, Uᴸ)
                 substepper.density_potential_temperature_predictor,
                 grid, δτᵐ⁺,
                 substepper.linearization_potential_temperature)
+
+        # Per-substep open-boundary enforcement (issue #738): relax the outermost
+        # open-boundary cell of ρ′, (ρθ)′ toward the prescribed wall value, before
+        # the halo fill, so the boundary cell tracks the prescribed inflow state.
+        apply_open_boundary_relaxation!(substepper, model, grid, arch)
 
         fill_halo_regions!(substepper.density_perturbation)
         fill_halo_regions!(substepper.density_potential_temperature_perturbation)

--- a/src/CompressibleEquations/time_discretizations.jl
+++ b/src/CompressibleEquations/time_discretizations.jl
@@ -294,6 +294,14 @@ Fields
   with the configured `damping_rate` and `depth`.
 - `substep_distribution`: How acoustic substeps are distributed across the
   three WS-RK3 stages.
+- `open_boundary_relaxation`: Per-substep relaxation factor ``α \\in (0, 1]``
+  applied at the outermost open-boundary cell of ``ρ′,(ρθ)′`` to enforce the
+  prescribed wall value across the acoustic substeps. Default ``α = 0.5``,
+  matching FV3-LAM's outermost-blend-row weight (``\\approx 0.6``). Without
+  this enforcement the perturbation halos reflect, biasing the discrete mass
+  balance under transient open-boundary inflow (issue #738). The relaxation is
+  a no-op when no side carries an active open BC (periodic, walls, impenetrable
+  defaults all skip it).
 
 # Backward integration
 
@@ -477,6 +485,7 @@ struct SplitExplicitTimeDiscretization{N, FT, D, US, AD <: AcousticSubstepDistri
     damping :: D
     sponge :: US
     substep_distribution :: AD
+    open_boundary_relaxation :: FT
 end
 
 function SplitExplicitTimeDiscretization(FT=Oceananigans.defaults.FloatType;
@@ -485,7 +494,8 @@ function SplitExplicitTimeDiscretization(FT=Oceananigans.defaults.FloatType;
                                          forward_weight = FT(0.65),
                                          damping = ThermalDivergenceDamping(; coefficient = FT(0.1)),
                                          sponge = nothing,
-                                         substep_distribution = ProportionalSubsteps())
+                                         substep_distribution = ProportionalSubsteps(),
+                                         open_boundary_relaxation = FT(0.5))
 
     damping isa AcousticDampingStrategy ||
         throw(ArgumentError("`damping` must be an `AcousticDampingStrategy`"))
@@ -496,6 +506,9 @@ function SplitExplicitTimeDiscretization(FT=Oceananigans.defaults.FloatType;
     acoustic_cfl > 0 ||
         throw(ArgumentError("`acoustic_cfl` must be positive (got $(acoustic_cfl))"))
 
+    0 < open_boundary_relaxation ≤ 1 ||
+        throw(ArgumentError("`open_boundary_relaxation` must be in (0, 1] (got $(open_boundary_relaxation))"))
+
     return SplitExplicitTimeDiscretization(
         substeps,
         convert(FT, acoustic_cfl),
@@ -503,6 +516,7 @@ function SplitExplicitTimeDiscretization(FT=Oceananigans.defaults.FloatType;
         convert_acoustic_parameter(FT, damping),
         convert_acoustic_parameter(FT, sponge),
         substep_distribution,
+        convert(FT, open_boundary_relaxation),
     )
 end
 

--- a/test/acoustic_substepping.jl
+++ b/test/acoustic_substepping.jl
@@ -17,7 +17,7 @@ using Breeze.CompressibleEquations: ExplicitTimeStepping, SplitExplicitTimeDiscr
 using Breeze.CompressibleEquations: _explicit_horizontal_step!
 using Breeze.AtmosphereModels: SlowTendencyMode, HorizontalSlowMode,
                                x_pressure_gradient, y_pressure_gradient, z_pressure_gradient,
-                               buoyancy_forceᶜᶜᶜ, dynamics_density
+                               buoyancy_forceᶜᶜᶜ, dynamics_density, thermodynamic_density
 using Breeze.Thermodynamics: adiabatic_hydrostatic_density, ExnerReferenceState, surface_density
 using GPUArraysCore: @allowscalar
 using Oceananigans
@@ -329,14 +329,16 @@ for arch in arches
         @test !any(isnan, parent(model_walls.dynamics.density))
     end
 
-    @testset "Open-boundary relaxation pulls outermost cell toward prescribed ρ [$(arch), $(FT)]" for FT in as_test_float_types(arch)
+    @testset "Open-boundary relaxation pulls outermost cell toward prescribed ρ, ρθ [$(arch), $(FT)]" for FT in as_test_float_types(arch)
         Oceananigans.defaults.FloatType = FT
 
         # Thin column so the hydrostatic ρ_ref variation is small (<1%) compared
         # to the deliberate ρ_wall jump below — keeps the test discriminating.
+        # All four lateral sides are bounded + open so both the x- and y-direction
+        # relaxation kernels fire and both ρ′ and (ρθ)′ are exercised.
         grid = RectilinearGrid(arch; size=(8, 8, 4), halo=(5, 5, 5),
                                x=(0, 8kilometers), y=(0, 8kilometers), z=(0, 200),
-                               topology=(Bounded, Periodic, Bounded))
+                               topology=(Bounded, Bounded, Bounded))
 
         dynamics = CompressibleDynamics(SplitExplicitTimeDiscretization();
                                         reference_potential_temperature=300)
@@ -345,21 +347,30 @@ for arch in arches
 
         # Drive the lateral boundaries off the interior state by 5%: a
         # `ValueBoundaryCondition` sets ρ_wall = 1.05·ρ_ref on the open faces,
-        # paired with `OpenBoundaryCondition(ρ_wall·U)` for a small inflow `U`
-        # on the corresponding `ρu`. With the per-substep relaxation, the
-        # outermost cell of ρ is pulled toward ρ_wall each substep; over the
-        # cumulative ~`Nτ` substeps per outer step the pull saturates and the
-        # cell tracks ρ_wall closely.
-        U      = FT(2)
-        ρ_wall = FT(1.05 * ρ_ref0)
-        ρu_val = FT(ρ_wall * U)
+        # paired with `OpenBoundaryCondition(ρ_wall·U)` / `OpenBoundaryCondition(ρ_wall·V)`
+        # for small inflows `U`, `V` on `ρu`, `ρv`. With the per-substep relaxation,
+        # the outermost cell of ρ and (ρθ) is pulled toward the wall value each
+        # substep; over the cumulative ~`Nτ` substeps per outer step the pull
+        # saturates and the cell tracks the wall value closely.
+        U       = FT(2)
+        V       = FT(2)
+        ρ_wall  = FT(1.05 * ρ_ref0)
+        ρθ_wall = FT(ρ_wall * 300)
+        ρu_val  = FT(ρ_wall * U)
+        ρv_val  = FT(ρ_wall * V)
         ρu_bcs = FieldBoundaryConditions(west = OpenBoundaryCondition(ρu_val),
                                          east = OpenBoundaryCondition(ρu_val))
-        ρ_bcs  = FieldBoundaryConditions(west = ValueBoundaryCondition(ρ_wall),
-                                         east = ValueBoundaryCondition(ρ_wall))
-        ρθ_bcs = FieldBoundaryConditions(west = ValueBoundaryCondition(ρ_wall * FT(300)),
-                                         east = ValueBoundaryCondition(ρ_wall * FT(300)))
-        boundary_conditions = (; ρu = ρu_bcs, ρ = ρ_bcs, ρθ = ρθ_bcs)
+        ρv_bcs = FieldBoundaryConditions(south = OpenBoundaryCondition(ρv_val),
+                                         north = OpenBoundaryCondition(ρv_val))
+        ρ_bcs  = FieldBoundaryConditions(west  = ValueBoundaryCondition(ρ_wall),
+                                         east  = ValueBoundaryCondition(ρ_wall),
+                                         south = ValueBoundaryCondition(ρ_wall),
+                                         north = ValueBoundaryCondition(ρ_wall))
+        ρθ_bcs = FieldBoundaryConditions(west  = ValueBoundaryCondition(ρθ_wall),
+                                         east  = ValueBoundaryCondition(ρθ_wall),
+                                         south = ValueBoundaryCondition(ρθ_wall),
+                                         north = ValueBoundaryCondition(ρθ_wall))
+        boundary_conditions = (; ρu = ρu_bcs, ρv = ρv_bcs, ρ = ρ_bcs, ρθ = ρθ_bcs)
 
         model = AtmosphereModel(grid; advection=WENO(), dynamics,
                                 timestepper=:AcousticRungeKutta3,
@@ -371,23 +382,44 @@ for arch in arches
         @test !any(isnan, parent(model.dynamics.density))
 
         # After the relaxation has fired across ~`Nτ` substeps per outer step,
-        # the cumulative pull `1 − (1−α)^Nτ` saturates and ρ at the outermost
-        # cell should be much closer to ρ_wall than to the deep interior. We
-        # sample the interior bulk at i = Nx/2, away from boundary influence.
+        # the cumulative pull `1 − (1−α)^Nτ` saturates and the outermost cell of
+        # both ρ and (ρθ) should be much closer to the wall value than to the
+        # deep interior. We sample the interior bulk at (Nx/2, Ny/2), away from
+        # boundary influence in both horizontal directions.
         Nx = size(grid, 1)
+        Ny = size(grid, 2)
         ρ_int  = interior(model.dynamics.density)
-        ρ_west = @allowscalar mean(ρ_int[1,    :, :])
-        ρ_east = @allowscalar mean(ρ_int[Nx,   :, :])
-        ρ_bulk = @allowscalar mean(ρ_int[Nx÷2, :, :])
+        ρθ_int = interior(thermodynamic_density(model.formulation))
 
-        # Require the outermost cell to be at least halfway from the bulk to
-        # ρ_wall — a loose threshold that is comfortably met when the relaxation
-        # is firing (cumulative pull > 0.9 in practice) and would not be met if
-        # the boundary perturbation propagated only by interior acoustic
-        # dynamics over 3 small steps.
-        threshold = ρ_bulk + FT(0.5) * (ρ_wall - ρ_bulk)
-        @test ρ_west ≥ threshold
-        @test ρ_east ≥ threshold
+        ρ_west  = @allowscalar mean(ρ_int[1,    :, :])
+        ρ_east  = @allowscalar mean(ρ_int[Nx,   :, :])
+        ρ_south = @allowscalar mean(ρ_int[:, 1,    :])
+        ρ_north = @allowscalar mean(ρ_int[:, Ny,   :])
+        ρ_bulk  = @allowscalar mean(ρ_int[Nx÷2, Ny÷2, :])
+
+        ρθ_west  = @allowscalar mean(ρθ_int[1,    :, :])
+        ρθ_east  = @allowscalar mean(ρθ_int[Nx,   :, :])
+        ρθ_south = @allowscalar mean(ρθ_int[:, 1,    :])
+        ρθ_north = @allowscalar mean(ρθ_int[:, Ny,   :])
+        ρθ_bulk  = @allowscalar mean(ρθ_int[Nx÷2, Ny÷2, :])
+
+        # Require the outermost cell to be at least halfway from the bulk to the
+        # prescribed wall value — a loose threshold that is comfortably met when
+        # the relaxation is firing (cumulative pull > 0.9 in practice) and would
+        # not be met if the boundary perturbation propagated only by interior
+        # acoustic dynamics over 3 small steps.
+        ρ_threshold  = ρ_bulk  + FT(0.5) * (ρ_wall  - ρ_bulk)
+        ρθ_threshold = ρθ_bulk + FT(0.5) * (ρθ_wall - ρθ_bulk)
+
+        @test ρ_west  ≥ ρ_threshold
+        @test ρ_east  ≥ ρ_threshold
+        @test ρ_south ≥ ρ_threshold
+        @test ρ_north ≥ ρ_threshold
+
+        @test ρθ_west  ≥ ρθ_threshold
+        @test ρθ_east  ≥ ρθ_threshold
+        @test ρθ_south ≥ ρθ_threshold
+        @test ρθ_north ≥ ρθ_threshold
     end
 
     #####

--- a/test/acoustic_substepping.jl
+++ b/test/acoustic_substepping.jl
@@ -270,6 +270,127 @@ for arch in arches
     end
 
     #####
+    ##### Per-substep open-boundary enforcement (issue #738). Three tests:
+    ##### (1) `open_boundary_relaxation` kwarg propagates and is validated;
+    ##### (2) the relaxation is a no-op when no side carries an active open BC;
+    ##### (3) the outermost open-boundary cell of `ρ` tracks the prescribed
+    #####     wall value across the acoustic substeps.
+    #####
+
+    @testset "open_boundary_relaxation kwarg propagation [$(arch), $(FT)]" for FT in as_test_float_types(arch)
+        Oceananigans.defaults.FloatType = FT
+        grid = RectilinearGrid(arch; size=(4, 4, 8), x=(0, 100), y=(0, 100), z=(0, 1000))
+
+        td_default = SplitExplicitTimeDiscretization()
+        @test td_default.open_boundary_relaxation isa FT
+        @test td_default.open_boundary_relaxation ≈ FT(0.5)
+        acoustic_default = AcousticSubstepper(grid, td_default)
+        @test acoustic_default.open_boundary_relaxation ≈ FT(0.5)
+
+        td_custom = SplitExplicitTimeDiscretization(; open_boundary_relaxation = 0.25)
+        @test td_custom.open_boundary_relaxation ≈ FT(0.25)
+        acoustic_custom = AcousticSubstepper(grid, td_custom)
+        @test acoustic_custom.open_boundary_relaxation ≈ FT(0.25)
+
+        # α must lie in (0, 1]: 0 (would disable the relaxation), >1 (would
+        # overshoot the prescribed value), and negative values are rejected.
+        @test_throws ArgumentError SplitExplicitTimeDiscretization(; open_boundary_relaxation = 0)
+        @test_throws ArgumentError SplitExplicitTimeDiscretization(; open_boundary_relaxation = 1.5)
+        @test_throws ArgumentError SplitExplicitTimeDiscretization(; open_boundary_relaxation = -0.1)
+    end
+
+    @testset "Open-boundary relaxation is a no-op without active open BCs [$(arch), $(FT)]" for FT in as_test_float_types(arch)
+        Oceananigans.defaults.FloatType = FT
+
+        # Doubly-periodic: no `Open` BC anywhere; `is_active_open_bc` should
+        # return false on every side and the relaxation should be a no-op.
+        grid_periodic = RectilinearGrid(arch; size=(8, 8, 8), halo=(5, 5, 5),
+                                        x=(0, 8kilometers), y=(0, 8kilometers), z=(0, 8kilometers),
+                                        topology=(Periodic, Periodic, Bounded))
+        dynamics = CompressibleDynamics(SplitExplicitTimeDiscretization();
+                                        reference_potential_temperature=300)
+        model = AtmosphereModel(grid_periodic; advection=WENO(), dynamics,
+                                timestepper=:AcousticRungeKutta3)
+        set!(model; θ=300, u=0, qᵗ=0, ρ=model.dynamics.reference_state.density)
+        run!(Simulation(model; Δt=1, stop_iteration=1, verbose=false))
+        @test model.clock.iteration == 1
+        @test !any(isnan, parent(model.dynamics.density))
+
+        # Bounded but no OBC supplied: the prognostic-momentum BCs default to
+        # impenetrable walls, which `is_active_open_bc` returns false for.
+        grid_walls = RectilinearGrid(arch; size=(8, 8, 8), halo=(5, 5, 5),
+                                     x=(0, 8kilometers), y=(0, 8kilometers), z=(0, 8kilometers),
+                                     topology=(Bounded, Bounded, Bounded))
+        model_walls = AtmosphereModel(grid_walls; advection=WENO(), dynamics,
+                                      timestepper=:AcousticRungeKutta3)
+        set!(model_walls; θ=300, u=0, qᵗ=0, ρ=model_walls.dynamics.reference_state.density)
+        run!(Simulation(model_walls; Δt=1, stop_iteration=1, verbose=false))
+        @test model_walls.clock.iteration == 1
+        @test !any(isnan, parent(model_walls.dynamics.density))
+    end
+
+    @testset "Open-boundary relaxation pulls outermost cell toward prescribed ρ [$(arch), $(FT)]" for FT in as_test_float_types(arch)
+        Oceananigans.defaults.FloatType = FT
+
+        # Thin column so the hydrostatic ρ_ref variation is small (<1%) compared
+        # to the deliberate ρ_wall jump below — keeps the test discriminating.
+        grid = RectilinearGrid(arch; size=(8, 8, 4), halo=(5, 5, 5),
+                               x=(0, 8kilometers), y=(0, 8kilometers), z=(0, 200),
+                               topology=(Bounded, Periodic, Bounded))
+
+        dynamics = CompressibleDynamics(SplitExplicitTimeDiscretization();
+                                        reference_potential_temperature=300)
+        ref = ExnerReferenceState(grid; potential_temperature=FT(300))
+        ρ_ref0 = @allowscalar interior(ref.density)[1, 1, 1]
+
+        # Drive the lateral boundaries off the interior state by 5%: a
+        # `ValueBoundaryCondition` sets ρ_wall = 1.05·ρ_ref on the open faces,
+        # paired with `OpenBoundaryCondition(ρ_wall·U)` for a small inflow `U`
+        # on the corresponding `ρu`. With the per-substep relaxation, the
+        # outermost cell of ρ is pulled toward ρ_wall each substep; over the
+        # cumulative ~`Nτ` substeps per outer step the pull saturates and the
+        # cell tracks ρ_wall closely.
+        U      = FT(2)
+        ρ_wall = FT(1.05 * ρ_ref0)
+        ρu_val = FT(ρ_wall * U)
+        ρu_bcs = FieldBoundaryConditions(west = OpenBoundaryCondition(ρu_val),
+                                         east = OpenBoundaryCondition(ρu_val))
+        ρ_bcs  = FieldBoundaryConditions(west = ValueBoundaryCondition(ρ_wall),
+                                         east = ValueBoundaryCondition(ρ_wall))
+        ρθ_bcs = FieldBoundaryConditions(west = ValueBoundaryCondition(ρ_wall * FT(300)),
+                                         east = ValueBoundaryCondition(ρ_wall * FT(300)))
+        boundary_conditions = (; ρu = ρu_bcs, ρ = ρ_bcs, ρθ = ρθ_bcs)
+
+        model = AtmosphereModel(grid; advection=WENO(), dynamics,
+                                timestepper=:AcousticRungeKutta3,
+                                boundary_conditions)
+        set!(model; θ=300, u=0, qᵗ=0, ρ=ρ_ref0)
+
+        run!(Simulation(model; Δt=1, stop_iteration=3, verbose=false))
+        @test model.clock.iteration == 3
+        @test !any(isnan, parent(model.dynamics.density))
+
+        # After the relaxation has fired across ~`Nτ` substeps per outer step,
+        # the cumulative pull `1 − (1−α)^Nτ` saturates and ρ at the outermost
+        # cell should be much closer to ρ_wall than to the deep interior. We
+        # sample the interior bulk at i = Nx/2, away from boundary influence.
+        Nx = size(grid, 1)
+        ρ_int  = interior(model.dynamics.density)
+        ρ_west = @allowscalar mean(ρ_int[1,    :, :])
+        ρ_east = @allowscalar mean(ρ_int[Nx,   :, :])
+        ρ_bulk = @allowscalar mean(ρ_int[Nx÷2, :, :])
+
+        # Require the outermost cell to be at least halfway from the bulk to
+        # ρ_wall — a loose threshold that is comfortably met when the relaxation
+        # is firing (cumulative pull > 0.9 in practice) and would not be met if
+        # the boundary perturbation propagated only by interior acoustic
+        # dynamics over 3 small steps.
+        threshold = ρ_bulk + FT(0.5) * (ρ_wall - ρ_bulk)
+        @test ρ_west ≥ threshold
+        @test ρ_east ≥ threshold
+    end
+
+    #####
     ##### Test adaptive substep computation
     #####
 

--- a/test/acoustic_substepping.jl
+++ b/test/acoustic_substepping.jl
@@ -422,6 +422,147 @@ for arch in arches
         @test ρθ_north ≥ ρθ_threshold
     end
 
+    @testset "Asymmetric wall values: each side tracks its own prescribed ρ [$(arch), $(FT)]" for FT in as_test_float_types(arch)
+        Oceananigans.defaults.FloatType = FT
+
+        # Distinct ρ_wall on each side catches a kernel where east/west or
+        # south/north indices are transposed: the symmetric test would still
+        # pass under such a swap, but here each outermost cell must be
+        # closer to its own prescribed value than to the opposite side's.
+        grid = RectilinearGrid(arch; size=(8, 8, 4), halo=(5, 5, 5),
+                               x=(0, 8kilometers), y=(0, 8kilometers), z=(0, 200),
+                               topology=(Bounded, Bounded, Bounded))
+
+        dynamics = CompressibleDynamics(SplitExplicitTimeDiscretization();
+                                        reference_potential_temperature=300)
+        ref = ExnerReferenceState(grid; potential_temperature=FT(300))
+        ρ_ref0 = @allowscalar interior(ref.density)[1, 1, 1]
+
+        ρ_wall_west  = FT(1.05 * ρ_ref0)
+        ρ_wall_east  = FT(0.97 * ρ_ref0)
+        ρ_wall_south = FT(1.03 * ρ_ref0)
+        ρ_wall_north = FT(0.96 * ρ_ref0)
+        U = FT(2); V = FT(2)
+
+        ρu_bcs = FieldBoundaryConditions(west = OpenBoundaryCondition(FT(ρ_wall_west * U)),
+                                         east = OpenBoundaryCondition(FT(ρ_wall_east * U)))
+        ρv_bcs = FieldBoundaryConditions(south = OpenBoundaryCondition(FT(ρ_wall_south * V)),
+                                         north = OpenBoundaryCondition(FT(ρ_wall_north * V)))
+        ρ_bcs  = FieldBoundaryConditions(west  = ValueBoundaryCondition(ρ_wall_west),
+                                         east  = ValueBoundaryCondition(ρ_wall_east),
+                                         south = ValueBoundaryCondition(ρ_wall_south),
+                                         north = ValueBoundaryCondition(ρ_wall_north))
+        ρθ_bcs = FieldBoundaryConditions(west  = ValueBoundaryCondition(FT(ρ_wall_west  * 300)),
+                                         east  = ValueBoundaryCondition(FT(ρ_wall_east  * 300)),
+                                         south = ValueBoundaryCondition(FT(ρ_wall_south * 300)),
+                                         north = ValueBoundaryCondition(FT(ρ_wall_north * 300)))
+        boundary_conditions = (; ρu = ρu_bcs, ρv = ρv_bcs, ρ = ρ_bcs, ρθ = ρθ_bcs)
+
+        model = AtmosphereModel(grid; advection=WENO(), dynamics,
+                                timestepper=:AcousticRungeKutta3, boundary_conditions)
+        set!(model; θ=300, u=0, qᵗ=0, ρ=ρ_ref0)
+        run!(Simulation(model; Δt=1, stop_iteration=3, verbose=false))
+
+        Nx = size(grid, 1); Ny = size(grid, 2)
+        ρ_int = interior(model.dynamics.density)
+        ρ_west  = @allowscalar mean(ρ_int[1,    :, :])
+        ρ_east  = @allowscalar mean(ρ_int[Nx,   :, :])
+        ρ_south = @allowscalar mean(ρ_int[:, 1,    :])
+        ρ_north = @allowscalar mean(ρ_int[:, Ny,   :])
+
+        # Each side's outermost cell must be closer to its own prescribed wall
+        # value than to the opposite side's. An index transposition would flip
+        # one or both pairs.
+        @test abs(ρ_west  - ρ_wall_west)  < abs(ρ_west  - ρ_wall_east)
+        @test abs(ρ_east  - ρ_wall_east)  < abs(ρ_east  - ρ_wall_west)
+        @test abs(ρ_south - ρ_wall_south) < abs(ρ_south - ρ_wall_north)
+        @test abs(ρ_north - ρ_wall_north) < abs(ρ_north - ρ_wall_south)
+    end
+
+    @testset "Relaxation factor α controls pull strength [$(arch), $(FT)]" for FT in as_test_float_types(arch)
+        Oceananigans.defaults.FloatType = FT
+
+        # Two identical models differing only in α. With cumulative pull
+        # 1 − (1−α)^Nτ saturating monotonically in α, the high-α run must
+        # track ρ_wall more tightly than the low-α run. Catches bugs where
+        # α is ignored or hard-coded downstream.
+        function build_α_model(α)
+            grid = RectilinearGrid(arch; size=(8, 8, 4), halo=(5, 5, 5),
+                                   x=(0, 8kilometers), y=(0, 8kilometers), z=(0, 200),
+                                   topology=(Bounded, Periodic, Bounded))
+            td = SplitExplicitTimeDiscretization(; open_boundary_relaxation = FT(α))
+            dynamics = CompressibleDynamics(td; reference_potential_temperature=300)
+            ref = ExnerReferenceState(grid; potential_temperature=FT(300))
+            ρ_ref0 = @allowscalar interior(ref.density)[1, 1, 1]
+            ρ_wall = FT(1.05 * ρ_ref0)
+            ρu_val = FT(ρ_wall * 2)
+            ρu_bcs = FieldBoundaryConditions(west = OpenBoundaryCondition(ρu_val),
+                                             east = OpenBoundaryCondition(ρu_val))
+            ρ_bcs  = FieldBoundaryConditions(west = ValueBoundaryCondition(ρ_wall),
+                                             east = ValueBoundaryCondition(ρ_wall))
+            ρθ_bcs = FieldBoundaryConditions(west = ValueBoundaryCondition(FT(ρ_wall * 300)),
+                                             east = ValueBoundaryCondition(FT(ρ_wall * 300)))
+            boundary_conditions = (; ρu = ρu_bcs, ρ = ρ_bcs, ρθ = ρθ_bcs)
+            model = AtmosphereModel(grid; advection=WENO(), dynamics,
+                                    timestepper=:AcousticRungeKutta3, boundary_conditions)
+            set!(model; θ=300, u=0, qᵗ=0, ρ=ρ_ref0)
+            run!(Simulation(model; Δt=1, stop_iteration=3, verbose=false))
+            return model, ρ_wall
+        end
+
+        model_low,  ρ_wall = build_α_model(0.05)
+        model_high, _      = build_α_model(1.0)
+
+        Nx = size(model_low.grid, 1)
+        ρ_west_low  = @allowscalar mean(interior(model_low.dynamics.density)[1, :, :])
+        ρ_west_high = @allowscalar mean(interior(model_high.dynamics.density)[1, :, :])
+
+        @test abs(ρ_west_high - ρ_wall) < abs(ρ_west_low - ρ_wall)
+    end
+
+    @testset "OpenBoundaryCondition(nothing) skips relaxation [$(arch), $(FT)]" for FT in as_test_float_types(arch)
+        Oceananigans.defaults.FloatType = FT
+
+        # `is_active_open_bc` excludes `OpenBoundaryCondition(nothing)` via its
+        # `!(bc.condition isa Nothing)` clause. Verify the kernel is not
+        # invoked in that case by setting ρ's `ValueBoundaryCondition` to a
+        # value the relaxation would visibly track if it fired, and checking
+        # the outermost cell stays near the initial state instead.
+        grid = RectilinearGrid(arch; size=(8, 8, 4), halo=(5, 5, 5),
+                               x=(0, 8kilometers), y=(0, 8kilometers), z=(0, 200),
+                               topology=(Bounded, Periodic, Bounded))
+
+        dynamics = CompressibleDynamics(SplitExplicitTimeDiscretization();
+                                        reference_potential_temperature=300)
+        ref = ExnerReferenceState(grid; potential_temperature=FT(300))
+        ρ_ref0 = @allowscalar interior(ref.density)[1, 1, 1]
+        ρ_wall = FT(1.05 * ρ_ref0)
+
+        ρu_bcs = FieldBoundaryConditions(west = OpenBoundaryCondition(nothing),
+                                         east = OpenBoundaryCondition(nothing))
+        ρ_bcs  = FieldBoundaryConditions(west = ValueBoundaryCondition(ρ_wall),
+                                         east = ValueBoundaryCondition(ρ_wall))
+        ρθ_bcs = FieldBoundaryConditions(west = ValueBoundaryCondition(FT(ρ_wall * 300)),
+                                         east = ValueBoundaryCondition(FT(ρ_wall * 300)))
+        boundary_conditions = (; ρu = ρu_bcs, ρ = ρ_bcs, ρθ = ρθ_bcs)
+
+        model = AtmosphereModel(grid; advection=WENO(), dynamics,
+                                timestepper=:AcousticRungeKutta3, boundary_conditions)
+        set!(model; θ=300, u=0, qᵗ=0, ρ=ρ_ref0)
+        run!(Simulation(model; Δt=1, stop_iteration=3, verbose=false))
+
+        Nx = size(grid, 1)
+        ρ_int = interior(model.dynamics.density)
+        ρ_west = @allowscalar mean(ρ_int[1,  :, :])
+        ρ_east = @allowscalar mean(ρ_int[Nx, :, :])
+
+        # Outermost cell must stay closer to the initial state than to ρ_wall;
+        # if the relaxation fired despite the Nothing condition, the cells
+        # would be pulled toward ρ_wall.
+        @test abs(ρ_west - ρ_ref0) < abs(ρ_west - ρ_wall)
+        @test abs(ρ_east - ρ_ref0) < abs(ρ_east - ρ_wall)
+    end
+
     #####
     ##### Test adaptive substep computation
     #####


### PR DESCRIPTION
Closes #738.

## Summary

The acoustic substep loop's perturbation scalars `ρ′, (ρθ)′` carry the default `NoFluxBoundaryCondition` on `Bounded` dims, whose halo fill mirrors the interior (`c[halo] = c[1]` — zero-gradient). At the open boundary face this makes `∂ₓ p′ = (p′[1] − p′[0])/Δx = 0` every substep, since `p′ ∝ γRᵐᴸ·Πᴸ·ρθ′` is built from `ρθ′`. The boundary-face momentum update `(ρu)′ += Δτ·(Gⁿρu − ∂x_pᴸ − ∂x_p′)` still picks up the slow tendency `Gⁿρu` and the frozen base pressure gradient `∂x_pᴸ` (both fixed at stage entry), but the **acoustic-feedback term** `∂x_p′` — the only contribution that responds to within-substep acoustic activity — is zero at the face. The interior acoustic system is therefore decoupled from the boundary: outgoing acoustic waves see no PGF response at the open face and reflect, while the boundary mass flux is carried only by the frozen stage-entry slow tendency `Gˢρ`. This biases the discrete mass balance under transient open-boundary inflow; for example, a canonical vortex-transit study hit −5% to −27% density drift on the substepper while explicit held density constant.

Equivalently: at the boundary face/cell the substepping degenerates. With `∂x_p′ = 0` and the other horizontal tendencies frozen, `(ρu)′ += Δτ·(frozen)` applied `n_sub` times is identical to `(ρu)′ += Δt·(frozen)` for `Δt = n_sub·Δτ` — i.e. the outer step. The same holds for `ρ′,(ρθ)′` at the outermost cell, whose horizontal θ-flux divergence vanishes once the boundary face momentum is decoupled. Whatever apparent stability the substepper exhibited at the boundary came entirely from the implicit column solve (degenerate for our `Nz = 4`, `Δx ≈ Δz` validation setup) and the frozen-tendency advance — not from acoustic substepping.

This PR fixes the drift by relaxing the outermost open-boundary cell of `ρ′, (ρθ)′` toward the prescribed wall value `v` after each substep's post-solve recovery — breaking the `p′[0] = p′[1]` mirror so the boundary face sees a non-zero `∂ₓp′` and outgoing acoustic momentum can exit. Since `update_state!` applied the prognostic `ValueBoundaryCondition` to the base at stage entry, `ρᴸ[halo] = 2v − ρᴸ[cell]`, so the target perturbation is `(ρᴸ[halo] − ρᴸ[cell]) / 2` — read directly from the base field, no extra BC plumbing. The relaxation factor α is exposed as `SplitExplicitTimeDiscretization(; open_boundary_relaxation = 0.5)`. The enforcement is unconditional and a no-op on any side without an active `OpenBoundaryCondition` (periodic, walls, `OpenBoundaryCondition(nothing)` all skip it), so existing setups pay no cost.

## Background — how we landed here

The investigation traced the canonical treatment to WRF (`spec_bdyupdate` inside `small_steps`), ERF (`apply_bcs(fast_only=true)`), and MPAS (perturbation-form spec-zone branch in `atm_advance_acoustic_step_work`) — all three enforce the specified lateral boundary on every acoustic substep. Several in-kernel ports of that pattern destabilized (instant NaN: keeping `Gˢρ` while masking the fast term leaves the spec cell unbalanced; replacing only the mass predictor with a driving tendency NaNs after a few iters because post-solve recovery and the vertical `w`-solve still couple the cell into the acoustic dynamics).

What works — and matches an existing NWP code closely — is FV3-LAM (`fv_regional_bc.F90`, called inside the `do it=1, n_split` acoustic loop): each substep blends interior values toward externally supplied boundary data via `array = (1 − w)·array + w·blend_value`, with an exponential weight `w = exp(−(0.5 + 10·d))` across `nrows_blend` rows. **This PR is the one-cell limit of FV3's blend**: a single boundary row, with α playing the role of FV3's outermost-row weight (≈ 0.6). The simpler form is acceptable here because the Davies fringe already provides a wider relaxation zone at the slow-tendency level; this PR only adds the missing per-substep enforcement in the outermost cell.

Acting after the full coupled substep (rather than inside the predictor) sidesteps the multi-kernel consistency problem the in-kernel approaches hit — the entire acoustic update completes consistently, then the boundary cell is reset.

## Validation

Five 2-D vortex-transit scenarios on a bounded square domain with time-varying `OpenBoundaryCondition`s on the boundary-normal momenta (ρu, ρv), `ValueBoundaryCondition`s on density (ρ) and density-weighted potential temperature (ρθ), and Davies relaxation zones adjacent to the lateral boundaries; we use a default substep BC weight of α=0.5. All five share `|U_bg|` = 2 m/s. Scenarios: In the "horizontal" and "skim" scenarios, the vortex enters the domain on a single boundary; the "skim" scenarios introduce vortices whose trajectories coincide with the inner edge of a relaxation zone; the "diagonal" scenarios introduce vortices at domain corners that traverse the domain diagonally.

`max|w|` is normalized by `|U_bg|` so a value of 1 means the spurious vertical motion is as large as the background flow:

| scenario | drift no fix | drift with fix | max\|w\|/\|U_bg\| no fix | max\|w\|/\|U_bg\| with fix |
|---|---|---|---|---|
| horizontal       | −8%       | −0.01%     | 0.425  | 0.105 |
| **skim_low**     | **−27%**  | **−0.01%** | 0.007  | 0.038 |
| skim_high        | −9%       | −0.01%     | 0.0015 | 0.055 |
| diagonal_sw_ne   | −10%      | −0.02%     | 0.100  | 0.160 |
| diagonal_se_nw   | −8%       | −0.02%     | 0.0025 | 0.130 |

Vortex amplitude is ≥99% retained in all cases. The fix improves the worst-case `max|w|/|U_bg|` (horizontal, 0.43 → 0.11). A few quieter scenarios see modest increases; the deep-interior `max|w|` in both the no-fix and fix substep runs (10⁻² to 10⁻¹ m/s) sits ~1000× above explicit's noise floor (~10⁻⁵ m/s) regardless of this PR. This gap is largely a **design-regime mismatch**: the split-explicit substepper is designed for production NWP grids with `Δx, Δy >> Δz_min`, where the implicit vertical solve sidesteps a tight vertical-acoustic CFL and Klemp horizontal divergence damping + CN off-centering are tuned for `Δx ~ km` scales. Our 2.5D validation runs at `Δx ≈ 78 m`, `Δz = 50 m` (aspect ratio ≈ 1.6) with `Nz = 4` — outside that regime. The cyclostrophic-residual acoustic noise the substepper carries with the vortex is at scales the production-tuned damping doesn't target, and is independent of the mass-drift bug this PR addresses (which is regime-independent).

### 3-D confirmation — baroclinic-wave limited-area model

Beyond the 2-D vortex, the enforcement was exercised on a realistic 3-D problem. A global DCMIP2016 baroclinic wave (`CompressibleDynamics` + `AcousticRungeKutta3` + `SphericalCoriolis` on a `LatitudeLongitudeGrid`) was run as a parent, and its prognostic state over a sub-window was sampled to drive a *coincident* limited-area model (LAM) through `FieldTimeSeries`-backed open lateral boundaries (ρu/ρv `OpenBoundaryCondition`, ρ/ρθ `ValueBoundaryCondition`) plus a Davies relaxation zone. Two findings:

- The per-substep enforcement is **grid-agnostic** — it works unchanged on `LatitudeLongitudeGrid` (the kernels dispatch on BC classification + index ranges, not grid type).
- The LAM **preserves the parent solution through the full baroclinic life cycle** (days 6–30, spanning explosive cyclogenesis and wave breaking): deep-interior potential-temperature RMSE stays bounded at ~0.5–0.8 K (peaking ~1.4 K during the most violent breaking, then recovering), with no density drift. A LAM initialized instead from the undeveloped background jet spins the wave up purely from the boundary data and converges to the same ~0.6 K.

## Tests

Three testsets added to `test/acoustic_substepping.jl` (16/16 pass on CPU/Float64):

1. `open_boundary_relaxation` kwarg propagation + range validation.
2. No-op without active open BCs (periodic and all-walls bounded).
3. Outermost cell tracks prescribed ρ after a few substeps (end-to-end).

## Test plan

- [x] New testsets pass locally.
- [x] No-op path verified — no behavior change for periodic, walls, or `OpenBoundaryCondition(nothing)`.
- [x] Existing #716 regression test unaffected (the relaxation acts on Center scalar perturbations; the perturbation momentum's impenetrable halo is untouched).
- [x] CI green.

## Known limitation / follow-up — boundary momentum

This PR fixes the density (mass) drift. A separate, pre-existing **boundary-momentum** imbalance remains — intrinsic to the acoustic-substepping open-boundary treatment, and the more precise characterization of the substep `max|w|` gap noted above. A first-step diagnostic (LAM initialized to a coincident global solution, advanced one step at the global Δt, differenced against the global model) shows:

- The deep interior matches the global solution to roundoff; the difference is boundary-localized and almost entirely in the **momenta** at the boundary-adjacent cell (e.g. `ρv` ≈ 30× its field scale), with `ρ`/`ρθ` only ~1%.
- The **explicit** timestepper shows no such imbalance at the same (vertically stable) Δt, and the substep injection is ~Δt-independent — so it is specific to the per-substep boundary treatment, not the OBC, grid, or Δt.
- It is **not removable by tuning α**: the first-step momentum imbalance grows monotonically with α (the `ρ′/(ρθ)′` enforcement's boundary pressure perturbation is what kicks the adjacent momentum through the pressure gradient) — α is a trade-off knob, not a mitigation.
- A momentum analog of this enforcement (relaxing the boundary-face `(ρu)′/(ρv)′` toward 0) was prototyped and is a **no-op** — the boundary-face momentum perturbation is already ≈0, and the spurious signal is at the first *interior* cell — so it is intentionally **excluded** from this PR.

In practice this transient is controlled by the Davies / flow-relaxation zone (the standard operational treatment), which is why limited-area runs using these BCs are stable. Note that this PR's density-drift fix works by relaxing `ρ′/(ρθ)′` to re-couple the boundary acoustics — it works *around* the frozen `Gˢρ` rather than correcting that tendency — and the direct momentum analog of that relaxation is the no-op described above. A **distinct, unverified follow-up direction** is therefore to correct the **frozen stage-entry slow momentum tendency** `Gⁿρu` at the boundary-*adjacent* cell (a different variable and location than the boundary-value relaxation), which is where the first-step diagnostic localizes the overshoot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


