### PR TITLE
Density-based θˡⁱ state: fix compressible saturation & temperature inversion (closes #765, supersedes #752)

### DIFF
--- a/examples/acoustic_wave.jl
+++ b/examples/acoustic_wave.jl
@@ -50,7 +50,12 @@ Lx, Lz = 1000, 200  # (m)
 grid = RectilinearGrid(size = (Nx, Nz), x = (-Lx/2, Lx/2), z = (0, Lz),
                        topology = (Periodic, Flat, Bounded))
 
-model = AtmosphereModel(grid; dynamics = CompressibleDynamics(ExplicitTimeStepping()))
+# `temperature_tolerance = 0` selects the fixed-trip (unrolled) θˡⁱ→T inversion. The differentiable
+# pass at the end of this example takes a reverse-mode gradient through the compressible time step
+# with Reactant/Enzyme, and the default tolerance-based `while` inversion compiles to an XLA `while`
+# op that does not differentiate cheaply (NumericalEarth/Breeze.jl#767). The forward and adjoint
+# models use identical dynamics, so we make that choice here too.
+model = AtmosphereModel(grid; dynamics = CompressibleDynamics(ExplicitTimeStepping(); temperature_tolerance = 0))
 
 # ## Background state
 #
@@ -256,7 +261,7 @@ grid_ad = RectilinearGrid(ReactantState(); size = (Nx, Nz),
                           x = (-Lx/2, Lx/2), z = (0, Lz),
                           topology = (Periodic, Flat, Bounded))
 
-model_ad = AtmosphereModel(grid_ad; dynamics = CompressibleDynamics(ExplicitTimeStepping()))
+model_ad = AtmosphereModel(grid_ad; dynamics = CompressibleDynamics(ExplicitTimeStepping(); temperature_tolerance = 0)) # fixed-trip EOS inversion so Enzyme can differentiate it (see forward model above)
 
 # ### Fixed and varying fields
 #

--- a/examples/acoustic_wave.jl
+++ b/examples/acoustic_wave.jl
@@ -50,12 +50,14 @@ Lx, Lz = 1000, 200  # (m)
 grid = RectilinearGrid(size = (Nx, Nz), x = (-Lx/2, Lx/2), z = (0, Lz),
                        topology = (Periodic, Flat, Bounded))
 
-# `temperature_tolerance = 0` selects the fixed-trip (unrolled) θˡⁱ→T inversion. The differentiable
-# pass at the end of this example takes a reverse-mode gradient through the compressible time step
-# with Reactant/Enzyme, and the default tolerance-based `while` inversion compiles to an XLA `while`
-# op that does not differentiate cheaply (NumericalEarth/Breeze.jl#767). The forward and adjoint
-# models use identical dynamics, so we make that choice here too.
-model = AtmosphereModel(grid; dynamics = CompressibleDynamics(ExplicitTimeStepping(); temperature_tolerance = 0))
+# This example is dry, so the θˡⁱ→T inversion has an exact closed form and needs no Newton steps.
+# `temperature_tolerance = 0` selects the fixed-trip (unrolled) inversion and `temperature_maxiter = 2`
+# keeps the trip count tiny: the differentiable pass at the end of this example takes a reverse-mode
+# gradient through the compressible time step with Reactant/Enzyme, and the default tolerance-based
+# `while` inversion compiles to an XLA `while` op that does not differentiate cheaply, while a high
+# iteration count needlessly inflates the traced graph (NumericalEarth/Breeze.jl#767). The forward
+# and adjoint models use identical dynamics.
+model = AtmosphereModel(grid; dynamics = CompressibleDynamics(ExplicitTimeStepping(); temperature_tolerance = 0, temperature_maxiter = 2))
 
 # ## Background state
 #
@@ -261,7 +263,7 @@ grid_ad = RectilinearGrid(ReactantState(); size = (Nx, Nz),
                           x = (-Lx/2, Lx/2), z = (0, Lz),
                           topology = (Periodic, Flat, Bounded))
 
-model_ad = AtmosphereModel(grid_ad; dynamics = CompressibleDynamics(ExplicitTimeStepping(); temperature_tolerance = 0)) # fixed-trip EOS inversion so Enzyme can differentiate it (see forward model above)
+model_ad = AtmosphereModel(grid_ad; dynamics = CompressibleDynamics(ExplicitTimeStepping(); temperature_tolerance = 0, temperature_maxiter = 2)) # fixed-trip, low-iteration EOS inversion so Enzyme can differentiate it cheaply (see forward model)
 
 # ### Fixed and varying fields
 #

--- a/src/CompressibleEquations/CompressibleEquations.jl
+++ b/src/CompressibleEquations/CompressibleEquations.jl
@@ -61,7 +61,7 @@ using Oceananigans.BoundaryConditions: fill_halo_regions!
 using Oceananigans.Operators: divᶜᶜᶜ
 using Oceananigans.Utils: prettysummary, launch!
 
-using Breeze.Thermodynamics: mixture_gas_constant, mixture_heat_capacity, dry_air_gas_constant,
+using Breeze.Thermodynamics: mixture_gas_constant, dry_air_gas_constant,
                              vapor_gas_constant, ExnerReferenceState, temperature, LiquidIceDensityState
 
 using Breeze.AtmosphereModels: AtmosphereModels, AtmosphereModel, grid_moisture_fractions, dynamics_density, standard_pressure, thermodynamic_density, thermodynamic_density_name, specific_prognostic_moisture

--- a/src/CompressibleEquations/CompressibleEquations.jl
+++ b/src/CompressibleEquations/CompressibleEquations.jl
@@ -62,7 +62,7 @@ using Oceananigans.Operators: divᶜᶜᶜ
 using Oceananigans.Utils: prettysummary, launch!
 
 using Breeze.Thermodynamics: mixture_gas_constant, mixture_heat_capacity, dry_air_gas_constant,
-                             vapor_gas_constant, ExnerReferenceState
+                             vapor_gas_constant, ExnerReferenceState, temperature, LiquidIceDensityState
 
 using Breeze.AtmosphereModels: AtmosphereModels, AtmosphereModel, grid_moisture_fractions, dynamics_density, standard_pressure, thermodynamic_density, thermodynamic_density_name, specific_prognostic_moisture
 using Breeze.PotentialTemperatureFormulations: LiquidIcePotentialTemperatureFormulation

--- a/src/CompressibleEquations/compressible_dynamics.jl
+++ b/src/CompressibleEquations/compressible_dynamics.jl
@@ -19,6 +19,8 @@ Fields
 - `terrain_metrics`: [`TerrainMetrics`](@ref) for terrain-following coordinates (or `nothing`)
 - `Ω̃`, `ρΩ̃`: contravariant vertical velocity / momentum diagnostic fields (or `nothing` when no terrain metrics)
 - `terrain_reference_pressure`, `terrain_reference_density`: 3D reference pressure / density for the terrain pressure gradient force (or `nothing`)
+- `temperature_tolerance`, `temperature_maxiter`: relative convergence tolerance on the moist
+  equation-of-state temperature inversion step `|ΔT|/T`, and the iteration cap on that solve
 
 The `time_discretization` determines how tendencies are computed and which
 time-stepper is used:
@@ -37,6 +39,8 @@ struct CompressibleDynamics{TD, D, P, FT, RS, TM, CV, CM, TRP, TRD}
     contravariant_vertical_momentum :: CM      # ρΩ̃ diagnostic field (or Nothing)
     terrain_reference_pressure :: TRP          # 3D reference pressure for terrain PG (or Nothing)
     terrain_reference_density :: TRD           # 3D reference density for terrain buoyancy (or Nothing)
+    temperature_tolerance :: FT                # relative convergence tol |ΔT|/T for the moist EOS θˡⁱ→T inversion
+    temperature_maxiter :: Int                 # iteration cap for the moist EOS temperature inversion
 end
 
 """
@@ -60,17 +64,25 @@ Keyword Arguments
   hydrostatically-balanced reference state used in base-state subtraction. Can be a constant `θ₀`
   or a function `θ(z)`. Default: `nothing` (no base-state correction).
   When provided, an [`ExnerReferenceState`](@ref) is built during materialization.
+- `temperature_tolerance`: relative convergence tolerance on the moist EOS temperature
+  inversion step `|ΔT|/T` (default: `1e-8`)
+- `temperature_maxiter`: maximum number of moist EOS temperature inversion iterations
+  (default: `8`)
 """
 function CompressibleDynamics(time_discretization::TD = ExplicitTimeStepping();
                               standard_pressure = 1e5,
                               surface_pressure = 101325.0,
                               reference_potential_temperature = nothing,
                               reference_temperature = nothing,
-                              terrain_metrics = nothing) where TD
+                              terrain_metrics = nothing,
+                              temperature_tolerance = 1e-8,
+                              temperature_maxiter = 8) where TD
 
     FT = promote_type(typeof(standard_pressure), typeof(surface_pressure))
     pˢᵗ = convert(FT, standard_pressure)
     p₀ = convert(FT, surface_pressure)
+    temperature_tolerance = convert(FT, temperature_tolerance)
+    temperature_maxiter = Int(temperature_maxiter)
     # Store reference spec temporarily; ExnerReferenceState is built in materialize_dynamics.
     # If reference_temperature is given, store it as a NamedTuple to distinguish from θ₀.
     ref_spec = if reference_temperature !== nothing
@@ -82,7 +94,8 @@ function CompressibleDynamics(time_discretization::TD = ExplicitTimeStepping();
     # are built later in materialize_dynamics.
     return CompressibleDynamics(time_discretization, nothing, nothing, pˢᵗ, p₀, ref_spec,
                                 terrain_metrics,
-                                nothing, nothing, nothing, nothing)
+                                nothing, nothing, nothing, nothing,
+                                temperature_tolerance, temperature_maxiter)
 end
 
 Adapt.adapt_structure(to, dynamics::CompressibleDynamics) =
@@ -96,7 +109,9 @@ Adapt.adapt_structure(to, dynamics::CompressibleDynamics) =
                          adapt(to, dynamics.contravariant_vertical_velocity),
                          adapt(to, dynamics.contravariant_vertical_momentum),
                          adapt(to, dynamics.terrain_reference_pressure),
-                         adapt(to, dynamics.terrain_reference_density))
+                         adapt(to, dynamics.terrain_reference_density),
+                         dynamics.temperature_tolerance,
+                         dynamics.temperature_maxiter)
 
 #####
 ##### Materialization
@@ -120,6 +135,7 @@ function AtmosphereModels.materialize_dynamics(dynamics::CompressibleDynamics, g
     FT = eltype(grid)
     standard_pressure = convert(FT, dynamics.standard_pressure)
     surface_pressure = convert(FT, dynamics.surface_pressure)
+    temperature_tolerance = convert(FT, dynamics.temperature_tolerance)
 
     # Build reference state from the stored spec (θ₀, T₀ NamedTuple, or nothing).
     # ExnerReferenceState builds the Exner function π₀ by discrete integration,
@@ -199,7 +215,8 @@ function AtmosphereModels.materialize_dynamics(dynamics::CompressibleDynamics, g
                                 terrain_metrics,
                                 contravariant_vertical_velocity,
                                 contravariant_vertical_momentum,
-                                terrain_reference_pressure, terrain_reference_density)
+                                terrain_reference_pressure, terrain_reference_density,
+                                temperature_tolerance, dynamics.temperature_maxiter)
 end
 
 function seed_pressure!(pressure, grid, pressure_reference)

--- a/src/CompressibleEquations/compressible_dynamics.jl
+++ b/src/CompressibleEquations/compressible_dynamics.jl
@@ -78,7 +78,7 @@ function CompressibleDynamics(time_discretization::TD = ExplicitTimeStepping();
                               temperature_tolerance = 1e-8,
                               temperature_maxiter = 8) where TD
 
-    FT = promote_type(typeof(standard_pressure), typeof(surface_pressure))
+    FT = float(promote_type(typeof(standard_pressure), typeof(surface_pressure)))
     pˢᵗ = convert(FT, standard_pressure)
     p₀ = convert(FT, surface_pressure)
     temperature_tolerance = convert(FT, temperature_tolerance)

--- a/src/CompressibleEquations/compressible_time_stepping.jl
+++ b/src/CompressibleEquations/compressible_time_stepping.jl
@@ -133,20 +133,28 @@ end
     θ = ρθ / ρ
     pˢᵗ = standard_pressure(dynamics)
 
-    # Direct formula: T = θ^γ (ρ Rᵐ / pˢᵗ)^(γ-1)
-    # For moist air with condensate, adjust for latent heat
-    qˡ = q.liquid
-    qⁱ = q.ice
-    ℒˡᵣ = constants.liquid.reference_latent_heat
-    ℒⁱᵣ = constants.ice.reference_latent_heat
-    cᵖᵐ = mixture_heat_capacity(q, constants)
-
-    # T = θ^γ (ρ Rᵐ / pˢᵗ)^(γ-1) + latent heat correction
-    T_dry = θ^γ * (ρ * Rᵐ / pˢᵗ)^(γ - 1)
-    T = T_dry + (ℒˡᵣ * qˡ + ℒⁱᵣ * qⁱ) / cᵖᵐ
+    # Invert θˡⁱ at constant density via LiquidIceDensityState.temperature, which iterates the
+    # implicit relation T = (ρRᵐT/pˢᵗ)^κ θ + (ℒˡqˡ+ℒⁱqⁱ)/cᵖᵐ to convergence. This is the same
+    # inversion used by the saturation adjustment on the compressible core, so the dynamics and the
+    # microphysics carry one self-consistent T (fixes the κ·ΔL split — NumericalEarth/Breeze.jl#765).
+    𝒰 = LiquidIceDensityState(θ, q, pˢᵗ, ρ, dynamics.temperature_tolerance, dynamics.temperature_maxiter)
+    T = temperature(𝒰, constants)
 
     # Ideal gas law: p = ρ Rᵐ T
     p = ρ * Rᵐ * T
 
     return T, p
+end
+
+# Build the density-based thermodynamic state for the compressible core, so that the
+# saturation adjustment and the θˡⁱ→T inversion are evaluated at the prognostic density ρ (true
+# pressure p = ρRᵐT) rather than a reference pressure. The generic (reference-pressure) method in
+# PotentialTemperatureFormulations is retained for anelastic dynamics. See NumericalEarth/Breeze.jl#765.
+@inline function AtmosphereModels.diagnose_thermodynamic_state(i, j, k, grid,
+                                                               formulation::LiquidIcePotentialTemperatureFormulation,
+                                                               dynamics::CompressibleDynamics, q)
+    θ = @inbounds formulation.potential_temperature[i, j, k]
+    ρ = @inbounds dynamics_density(dynamics)[i, j, k]
+    pˢᵗ = standard_pressure(dynamics)
+    return LiquidIceDensityState(θ, q, pˢᵗ, ρ, dynamics.temperature_tolerance, dynamics.temperature_maxiter)
 end

--- a/src/CompressibleEquations/compressible_time_stepping.jl
+++ b/src/CompressibleEquations/compressible_time_stepping.jl
@@ -110,12 +110,9 @@ end
     # Compute moisture fractions
     q = grid_moisture_fractions(i, j, k, grid, microphysics, ρ, qᵛᵉ, microphysical_fields)
     Rᵐ = mixture_gas_constant(q, constants)
-    cᵖᵐ = mixture_heat_capacity(q, constants)
-    cᵛᵐ = cᵖᵐ - Rᵐ
-    γ = cᵖᵐ / cᵛᵐ
 
     # Compute temperature and pressure jointly
-    T, p = temperature_and_pressure(i, j, k, grid, formulation, dynamics, ρ, Rᵐ, γ, q, constants)
+    T, p = temperature_and_pressure(i, j, k, grid, formulation, dynamics, ρ, Rᵐ, q, constants)
 
     @inbounds begin
         temperature_field[i, j, k] = T
@@ -127,7 +124,7 @@ end
 
 @inline function temperature_and_pressure(i, j, k, grid,
                                           formulation::LiquidIcePotentialTemperatureFormulation,
-                                          dynamics, ρ, Rᵐ, γ, q, constants)
+                                          dynamics, ρ, Rᵐ, q, constants)
     # Note: potential_temperature_density is ρθ (prognostic), potential_temperature is θ (diagnostic)
     ρθ = @inbounds formulation.potential_temperature_density[i, j, k]
     θ = ρθ / ρ

--- a/src/Microphysics/saturation_adjustment.jl
+++ b/src/Microphysics/saturation_adjustment.jl
@@ -1,6 +1,7 @@
 using ..Thermodynamics:
     Thermodynamics,
     MoistureMassFractions,
+    mixture_gas_constant,
     mixture_heat_capacity,
     saturation_specific_humidity,
     adjustment_saturation_specific_humidity,
@@ -9,6 +10,7 @@ using ..Thermodynamics:
     with_moisture,
     total_specific_moisture,
     AbstractThermodynamicState,
+    LiquidIceDensityState,
     WarmPhaseEquilibrium,
     MixedPhaseEquilibrium,
     equilibrated_surface
@@ -233,6 +235,80 @@ Return the saturation-adjusted thermodynamic state using a secant iteration.
     end
 
     return 𝒰₂
+end
+
+#####
+##### Density-consistent saturation adjustment for the density-based θˡⁱ state
+#####
+
+# Residual for a constant-density saturated state at temperature `T`: saturate at the actual
+# density (density-based qsat), form the equilibrium partition, and return the density-based θˡⁱ
+# minus the target θ₀ together with the partition `q`. A root in `T` is the state that is both
+# saturated at ρ and conserves θˡⁱ. See NumericalEarth/Breeze.jl#765.
+@inline function saturated_density_residual(T, θ₀, ρ, qᵗ, pˢᵗ, constants, equilibrium)
+    qᵛ⁺ = saturation_specific_humidity(T, ρ, constants, equilibrium)
+    q   = equilibrated_moisture_mass_fractions(T, qᵗ, qᵛ⁺, equilibrium)
+    Rᵐ  = mixture_gas_constant(q, constants)
+    cᵖᵐ = mixture_heat_capacity(q, constants)
+    κ   = Rᵐ / cᵖᵐ
+    ℒˡᵣ = constants.liquid.reference_latent_heat
+    ℒⁱᵣ = constants.ice.reference_latent_heat
+    L   = (ℒˡᵣ * q.liquid + ℒⁱᵣ * q.ice) / cᵖᵐ
+    p   = ρ * Rᵐ * T
+    θ   = (T - L) * (pˢᵗ / p)^κ
+    return θ - θ₀, q
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Saturation adjustment for the [`LiquidIceDensityState`](@ref): a secant on the
+constant-density θˡⁱ-conservation residual, so `qsat` and the θˡⁱ inversion are evaluated at the
+state's actual density `ρ` (with true pressure `p = ρRᵐT`) rather than a fixed reference pressure.
+This is the density-consistent analogue of the generic (reference-pressure) [`adjust_state`] secant;
+like that one it holds θˡⁱ fixed (conserves it). See NumericalEarth/Breeze.jl#765.
+"""
+@inline function adjust_thermodynamic_state(𝒰₀::LiquidIceDensityState, microphysics::SA, constants)
+    FT = eltype(𝒰₀)
+    is_absolute_zero(𝒰₀) && return 𝒰₀
+
+    θ₀  = 𝒰₀.potential_temperature
+    ρ   = 𝒰₀.density
+    pˢᵗ = 𝒰₀.standard_pressure
+    qᵗ  = total_specific_moisture(𝒰₀)
+    equilibrium = microphysics.equilibrium
+
+    # Unsaturated? No condensation — return the all-vapor state.
+    𝒰₁ = with_moisture(𝒰₀, MoistureMassFractions(qᵗ))
+    T₁ = temperature(𝒰₁, constants)
+    qᵗ ≤ saturation_specific_humidity(T₁, ρ, constants, equilibrium) && return 𝒰₁
+
+    # Saturated: secant on the constant-density residual r(T) = θˡⁱ(T) − θ₀.
+    r₁, q₁ = saturated_density_residual(T₁, θ₀, ρ, qᵗ, pˢᵗ, constants, equilibrium)
+
+    ℒˡᵣ = constants.liquid.reference_latent_heat
+    ℒⁱᵣ = constants.ice.reference_latent_heat
+    cᵖ₁ = mixture_heat_capacity(q₁, constants)
+    ΔT  = (ℒˡᵣ * q₁.liquid + ℒⁱᵣ * q₁.ice) / cᵖ₁   # latent warming implied at T₁
+    T₂  = T₁ + max(convert(FT, 0.01), ΔT / 2)
+    r₂, q₂ = saturated_density_residual(T₂, θ₀, ρ, qᵗ, pˢᵗ, constants, equilibrium)
+
+    q = q₂
+    iter = 0
+    while abs(r₂) > microphysics.tolerance && iter < microphysics.maxiter
+        ΔTΔr = (T₂ - T₁) / (r₂ - r₁)
+        valid_step = isfinite(ΔTΔr)
+        ΔTΔr = ifelse(valid_step, ΔTΔr, zero(FT))
+
+        r₁ = r₂; T₁ = T₂
+        T₂ = T₂ - r₂ * ΔTΔr
+        r₂, q₂ = saturated_density_residual(T₂, θ₀, ρ, qᵗ, pˢᵗ, constants, equilibrium)
+        r₂ = ifelse(valid_step, r₂, zero(FT))
+        q = q₂
+        iter += 1
+    end
+
+    return with_moisture(𝒰₀, q)
 end
 
 """

--- a/src/Microphysics/saturation_adjustment.jl
+++ b/src/Microphysics/saturation_adjustment.jl
@@ -262,10 +262,10 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Saturation adjustment for the [`LiquidIceDensityState`](@ref): a secant on the
+Saturation adjustment for the `LiquidIceDensityState`: a secant on the
 constant-density θˡⁱ-conservation residual, so `qsat` and the θˡⁱ inversion are evaluated at the
 state's actual density `ρ` (with true pressure `p = ρRᵐT`) rather than a fixed reference pressure.
-This is the density-consistent analogue of the generic (reference-pressure) [`adjust_state`] secant;
+This is the density-consistent analogue of the generic (reference-pressure) `adjust_state` secant;
 like that one it holds θˡⁱ fixed (conserves it). See NumericalEarth/Breeze.jl#765.
 """
 @inline function adjust_thermodynamic_state(𝒰₀::LiquidIceDensityState, microphysics::SA, constants)

--- a/src/Thermodynamics/dynamic_states.jl
+++ b/src/Thermodynamics/dynamic_states.jl
@@ -148,6 +148,97 @@ end
 end
 
 #####
+##### Liquid-ice potential temperature state (density-based)
+#####
+
+# The density-based counterpart of `LiquidIcePotentialTemperatureState`: it carries the density
+# ρ rather than a reference pressure, so `temperature` inverts θˡⁱ at constant density (with the
+# pressure diagnosed as p = ρ Rᵐ T) and `saturation_specific_humidity` (via the generic
+# AbstractThermodynamicState method) is evaluated at the actual ρ. This is the natural closure when ρ
+# is prognostic — e.g. on the compressible core, where using the pressure-based
+# `LiquidIcePotentialTemperatureState` causes the temperature-inversion inconsistency and the
+# saturation-against-a-stale-reference-pressure error. See NumericalEarth/Breeze.jl#765.
+struct LiquidIceDensityState{FT} <: AbstractThermodynamicState{FT}
+    potential_temperature :: FT
+    moisture_mass_fractions :: MoistureMassFractions{FT}
+    standard_pressure :: FT          # pˢᵗ: reference pressure for potential temperature
+    density :: FT                    # ρ: prognostic density (the variable the state is closed on)
+    temperature_tolerance :: FT      # relative convergence tol |ΔT|/T for the θˡⁱ→T inversion
+    temperature_maxiter :: Int       # iteration cap for the inversion
+end
+
+# Convenience constructor with default solver controls — used by tests and any construction site
+# without a `CompressibleDynamics` to source `temperature_tolerance`/`temperature_maxiter` from.
+@inline LiquidIceDensityState(θ::FT, q::MoistureMassFractions{FT}, pˢᵗ::FT, ρ::FT) where FT =
+    LiquidIceDensityState{FT}(θ, q, pˢᵗ, ρ, convert(FT, 1e-8), 8)
+
+@inline is_absolute_zero(𝒰::LiquidIceDensityState) = 𝒰.potential_temperature == 0
+
+@inline total_specific_moisture(state::LiquidIceDensityState) =
+    total_specific_moisture(state.moisture_mass_fractions)
+
+@inline with_moisture(𝒰::LiquidIceDensityState{FT}, q::MoistureMassFractions{FT}) where FT =
+    LiquidIceDensityState{FT}(𝒰.potential_temperature, q, 𝒰.standard_pressure, 𝒰.density,
+                                   𝒰.temperature_tolerance, 𝒰.temperature_maxiter)
+
+# Density is carried directly (not derived from a reference pressure).
+@inline density(𝒰::LiquidIceDensityState, constants) = 𝒰.density
+
+# Invert θˡⁱ at constant density: solve  g(T) = T − (ρ Rᵐ T / pˢᵗ)^κ θ − (ℒˡ qˡ + ℒⁱ qⁱ)/cᵖᵐ = 0.
+# Newton converges quadratically (g′ = 1 − κ Φ/T ≈ 1 − κ ≈ 0.72 is well away from zero); the loop
+# runs until the relative step |ΔT|/T falls below `temperature_tolerance` (or `temperature_maxiter`
+# is reached). With no condensate (L = 0) the dry closed form is already the root, so the first step
+# is exactly zero and the loop exits immediately.
+@inline function temperature(𝒰::LiquidIceDensityState, constants::ThermodynamicConstants)
+    θ   = 𝒰.potential_temperature
+    ρ   = 𝒰.density
+    pˢᵗ = 𝒰.standard_pressure
+    q   = 𝒰.moisture_mass_fractions
+    Rᵐ  = mixture_gas_constant(q, constants)
+    cᵖᵐ = mixture_heat_capacity(q, constants)
+    κ   = Rᵐ / cᵖᵐ
+    γ   = cᵖᵐ / (cᵖᵐ - Rᵐ)
+    ℒˡᵣ = constants.liquid.reference_latent_heat
+    ℒⁱᵣ = constants.ice.reference_latent_heat
+    L   = (ℒˡᵣ * q.liquid + ℒⁱᵣ * q.ice) / cᵖᵐ
+
+    T  = θ^γ * (ρ * Rᵐ / pˢᵗ)^(γ - 1) + L         # dry closed form + latent shift (the old non-iterated guess)
+    ΔT = T                                         # ensure at least one Newton step is taken
+    iter = 0
+    while abs(ΔT) > 𝒰.temperature_tolerance * T && iter < 𝒰.temperature_maxiter
+        Φ  = (ρ * Rᵐ * T / pˢᵗ)^κ * θ              # = T − L at the root
+        ΔT = -(T - Φ - L) / (1 - κ * Φ / T)
+        T += ΔT
+        iter += 1
+    end
+    return T
+end
+
+# Exner function at the diagnosed (actual) pressure p = ρRᵐT: Π = (p/pˢᵗ)^κ.
+@inline function exner_function(𝒰::LiquidIceDensityState, constants::ThermodynamicConstants)
+    q   = 𝒰.moisture_mass_fractions
+    Rᵐ  = mixture_gas_constant(q, constants)
+    cᵖᵐ = mixture_heat_capacity(q, constants)
+    p   = 𝒰.density * Rᵐ * temperature(𝒰, constants)
+    return (p / 𝒰.standard_pressure)^(Rᵐ / cᵖᵐ)
+end
+
+@inline function with_temperature(𝒰::LiquidIceDensityState, T, constants)
+    q   = 𝒰.moisture_mass_fractions
+    ρ   = 𝒰.density
+    pˢᵗ = 𝒰.standard_pressure
+    Rᵐ  = mixture_gas_constant(q, constants)
+    cᵖᵐ = mixture_heat_capacity(q, constants)
+    κ   = Rᵐ / cᵖᵐ
+    ℒˡᵣ = constants.liquid.reference_latent_heat
+    ℒⁱᵣ = constants.ice.reference_latent_heat
+    L   = (ℒˡᵣ * q.liquid + ℒⁱᵣ * q.ice) / cᵖᵐ
+    p   = ρ * Rᵐ * T
+    θ   = (T - L) * (pˢᵗ / p)^κ
+    return LiquidIceDensityState{typeof(θ)}(θ, q, pˢᵗ, ρ, 𝒰.temperature_tolerance, 𝒰.temperature_maxiter)
+end
+
+#####
 ##### Moist static energy state (for microphysics interfaces)
 #####
 

--- a/src/Thermodynamics/dynamic_states.jl
+++ b/src/Thermodynamics/dynamic_states.jl
@@ -185,10 +185,18 @@ end
 @inline density(𝒰::LiquidIceDensityState, constants) = 𝒰.density
 
 # Invert θˡⁱ at constant density: solve  g(T) = T − (ρ Rᵐ T / pˢᵗ)^κ θ − (ℒˡ qˡ + ℒⁱ qⁱ)/cᵖᵐ = 0.
-# Newton converges quadratically (g′ = 1 − κ Φ/T ≈ 1 − κ ≈ 0.72 is well away from zero); the loop
-# runs until the relative step |ΔT|/T falls below `temperature_tolerance` (or `temperature_maxiter`
-# is reached). With no condensate (L = 0) the dry closed form is already the root, so the first step
-# is exactly zero and the loop exits immediately.
+# Newton converges quadratically (g′ = 1 − κ Φ/T ≈ 1 − κ ≈ 0.72 is well away from zero). With no
+# condensate (L = 0) the dry closed form is already the root, so a Newton step is exactly zero.
+#
+# The iteration has two forms, selected by the SIGN of `temperature_tolerance`. This is a uniform
+# scalar branch (the same value in every cell), resolved at compile/trace time — NOT a per-cell
+# data-dependent branch — so it is a plain `if`, not `ifelse`:
+#   • tolerance > 0 : tolerance-based `while` early-exit — fewest Newton steps on vanilla CPU/GPU.
+#   • tolerance ≤ 0 : fixed-trip `for 1:temperature_maxiter`. `temperature_maxiter` is a plain `Int`,
+#     so the loop unrolls to straight-line code. The `while` form traces to an XLA `while` op whose
+#     reverse-mode is pathological under Reactant/Enzyme (it hangs the differentiable acoustic_wave
+#     docs example — NumericalEarth/Breeze.jl#767); the unrolled form differentiates cheaply. Set
+#     `temperature_tolerance ≤ 0` on `CompressibleDynamics` for differentiable / Reactant runs.
 @inline function temperature(𝒰::LiquidIceDensityState, constants::ThermodynamicConstants)
     θ   = 𝒰.potential_temperature
     ρ   = 𝒰.density
@@ -202,14 +210,21 @@ end
     ℒⁱᵣ = constants.ice.reference_latent_heat
     L   = (ℒˡᵣ * q.liquid + ℒⁱᵣ * q.ice) / cᵖᵐ
 
-    T  = θ^γ * (ρ * Rᵐ / pˢᵗ)^(γ - 1) + L         # dry closed form + latent shift (the old non-iterated guess)
-    ΔT = T                                         # ensure at least one Newton step is taken
-    iter = 0
-    while abs(ΔT) > 𝒰.temperature_tolerance * T && iter < 𝒰.temperature_maxiter
-        Φ  = (ρ * Rᵐ * T / pˢᵗ)^κ * θ              # = T − L at the root
-        ΔT = -(T - Φ - L) / (1 - κ * Φ / T)
-        T += ΔT
-        iter += 1
+    T = θ^γ * (ρ * Rᵐ / pˢᵗ)^(γ - 1) + L          # dry closed form + latent shift (the old non-iterated guess)
+    if 𝒰.temperature_tolerance > 0
+        ΔT = T                                     # ensure at least one Newton step is taken
+        iter = 0
+        while abs(ΔT) > 𝒰.temperature_tolerance * T && iter < 𝒰.temperature_maxiter
+            Φ  = (ρ * Rᵐ * T / pˢᵗ)^κ * θ          # = T − L at the root
+            ΔT = -(T - Φ - L) / (1 - κ * Φ / T)
+            T += ΔT
+            iter += 1
+        end
+    else
+        for _ in 1:𝒰.temperature_maxiter           # fixed trip count → unrolls (Reactant/Enzyme-safe)
+            Φ = (ρ * Rᵐ * T / pˢᵗ)^κ * θ
+            T += -(T - Φ - L) / (1 - κ * Φ / T)
+        end
     end
     return T
 end

--- a/test/compressible_saturation_adjustment.jl
+++ b/test/compressible_saturation_adjustment.jl
@@ -1,0 +1,140 @@
+using Breeze
+using Oceananigans
+using Test
+
+using Breeze.Thermodynamics:
+    ThermodynamicConstants,
+    MoistureMassFractions,
+    LiquidIceDensityState,
+    temperature,
+    with_temperature,
+    mixture_gas_constant,
+    mixture_heat_capacity,
+    saturation_specific_humidity
+
+using Breeze.Microphysics: SaturationAdjustment, adjust_thermodynamic_state, WarmPhaseEquilibrium
+using Oceananigans.TimeSteppers: update_state!
+
+# Regression tests for the compressible θˡⁱ density-based thermodynamic state
+# (NumericalEarth/Breeze.jl#765): the temperature inversion and the saturation adjustment must be
+# evaluated at the prognostic density ρ (with p = ρRᵐT), so the dynamics and the microphysics carry
+# one self-consistent temperature and the equilibrium sits on the saturation curve at ρ.
+
+@testset "Density-based θˡⁱ state (LiquidIceDensityState) [$FT]" for FT in test_float_types()
+    constants = ThermodynamicConstants(FT)
+    pˢᵗ = FT(1e5)
+    ℒˡ = constants.liquid.reference_latent_heat
+    ℒⁱ = constants.ice.reference_latent_heat
+    rtol = FT == Float64 ? FT(1e-9) : FT(1e-4)
+    qtol = FT == Float64 ? FT(1e-5) : FT(1e-3)
+
+    moistures = (MoistureMassFractions(FT(0.020)),                          # vapor only
+                 MoistureMassFractions(FT(0.018), FT(0.005), FT(0)),        # liquid condensate
+                 MoistureMassFractions(FT(0.015), FT(0.003), FT(0.002)))    # mixed phase
+
+    @testset "constant-density θˡⁱ→T inversion is self-consistent and round-trips" begin
+        θ = FT(300); ρ = FT(1)
+        for q in moistures
+            𝒰 = LiquidIceDensityState(θ, q, pˢᵗ, ρ)
+            T = temperature(𝒰, constants)
+            Rᵐ = mixture_gas_constant(q, constants)
+            cᵖᵐ = mixture_heat_capacity(q, constants)
+            κ = Rᵐ / cᵖᵐ
+            L = (ℒˡ * q.liquid + ℒⁱ * q.ice) / cᵖᵐ
+            # self-consistent fixed point: T = (ρRᵐT/pˢᵗ)^κ θ + L  (and p = ρRᵐT)
+            @test T ≈ (ρ * Rᵐ * T / pˢᵗ)^κ * θ + L  rtol=rtol
+            # θˡⁱ round-trips: θ → T → θ
+            @test with_temperature(𝒰, T, constants).potential_temperature ≈ θ  rtol=rtol
+        end
+    end
+
+    @testset "density-consistent saturation adjustment" begin
+        sa = SaturationAdjustment(FT; equilibrium = WarmPhaseEquilibrium())
+        θ₀ = FT(300); ρ = FT(1)
+
+        # Supersaturated, all-vapor parcel → condenses.
+        𝒰₀ = LiquidIceDensityState(θ₀, MoistureMassFractions(FT(0.020)), pˢᵗ, ρ)
+        𝒰₁ = adjust_thermodynamic_state(𝒰₀, sa, constants)
+        T₁ = temperature(𝒰₁, constants)
+        qᵛ = 𝒰₁.moisture_mass_fractions.vapor
+
+        # The vapor lies on the saturation curve evaluated at the cell's OWN density ρ
+        # (the crux of #765 — not against a stale reference pressure).
+        @test qᵛ ≈ saturation_specific_humidity(T₁, ρ, constants, WarmPhaseEquilibrium())  atol=qtol
+        @test 𝒰₁.potential_temperature == θ₀          # θˡⁱ held fixed (conserved) exactly
+        @test 𝒰₁.density == ρ                          # density is carried directly
+        @test 𝒰₁.moisture_mass_fractions.liquid > 0    # condensate produced
+
+        # Subsaturated parcel → no condensation.
+        𝒰dry = adjust_thermodynamic_state(
+            LiquidIceDensityState(θ₀, MoistureMassFractions(FT(0.002)), pˢᵗ, ρ), sa, constants)
+        @test 𝒰dry.moisture_mass_fractions.liquid == 0
+    end
+
+    @testset "fixes the κ·ΔL temperature inconsistency" begin
+        θ = FT(300); ρ = FT(1)
+        q = MoistureMassFractions(FT(0.018), FT(0.005), FT(0))
+        Rᵐ = mixture_gas_constant(q, constants)
+        cᵖᵐ = mixture_heat_capacity(q, constants)
+        κ = Rᵐ / cᵖᵐ; γ = cᵖᵐ / (cᵖᵐ - Rᵐ)
+        L = (ℒˡ * q.liquid + ℒⁱ * q.ice) / cᵖᵐ
+
+        T★ = temperature(LiquidIceDensityState(θ, q, pˢᵗ, ρ), constants)
+        T_noniter = θ^γ * (ρ * Rᵐ / pˢᵗ)^(γ - 1) + L   # the old non-iterated inversion
+        @test T★ > T_noniter                            # the non-iterated inversion is biased cold
+        @test isapprox(T★ - T_noniter, FT(1.39) * κ * L; rtol=FT(0.15))   # gap ≈ 1.39 κΔL (leading order)
+
+        # The solver controls are honored: temperature_maxiter = 0 returns the un-iterated inversion.
+        𝒰_noniter = LiquidIceDensityState{FT}(θ, q, pˢᵗ, ρ, one(FT), 0)
+        @test temperature(𝒰_noniter, constants) ≈ T_noniter  rtol=rtol
+
+        # Control: with no condensate the inversion reduces to the dry closed form (no latent shift).
+        qd = MoistureMassFractions(FT(0.020))
+        Rd = mixture_gas_constant(qd, constants)
+        cpd = mixture_heat_capacity(qd, constants)
+        γd = cpd / (cpd - Rd)
+        @test temperature(LiquidIceDensityState(θ, qd, pˢᵗ, ρ), constants) ≈
+              θ^γd * (ρ * Rd / pˢᵗ)^(γd - 1)  rtol=rtol
+    end
+end
+
+# Integration: a moist compressible `update_state!` must produce physical, self-consistent fields.
+# In condensing cells the equilibrium vapor must sit on the saturation curve at the cell's OWN
+# density ρ — which also requires the dynamics temperature and the saturation-adjusted temperature
+# to agree (the κ·ΔL inconsistency of #765).
+@testset "Moist compressible update_state! is density-consistent" begin
+    arch = default_arch
+    grid = RectilinearGrid(arch; size = (8, 8, 8), halo = (5, 5, 5),
+                           x = (0, 2e3), y = (0, 2e3), z = (0, 2e3),
+                           topology = (Periodic, Periodic, Bounded))
+    constants = ThermodynamicConstants(Float64)
+    θref(z) = 300.0 * exp(9.80616 * z / (1005 * 300.0))
+    dyn = CompressibleDynamics(SplitExplicitTimeDiscretization();
+                               surface_pressure = 1e5, standard_pressure = 1e5,
+                               reference_potential_temperature = θref)
+    model = AtmosphereModel(grid; dynamics = dyn,
+                            microphysics = SaturationAdjustment(equilibrium = WarmPhaseEquilibrium()),
+                            thermodynamic_constants = constants,
+                            timestepper = :AcousticRungeKutta3)
+    set!(model; ρ = model.dynamics.reference_state.density, θ = 300.0, qᵗ = 0.030)
+    update_state!(model)
+
+    T  = Array(interior(model.temperature))
+    p  = Array(interior(model.dynamics.pressure))
+    ρ  = Array(interior(model.dynamics.density))
+    qˡ = Array(interior(model.microphysical_fields.qˡ))
+    qᵛ = Array(interior(model.microphysical_fields.qᵛ))
+
+    @test all(isfinite, T) && all(>(0), T)
+    @test all(isfinite, p) && all(>(0), p)
+    @test maximum(qˡ) > 0                                   # condensation occurred
+
+    eq = WarmPhaseEquilibrium()
+    for I in eachindex(qˡ)
+        qˡ[I] > 1e-6 || continue                            # saturated cells only
+        @test qᵛ[I] ≈ saturation_specific_humidity(T[I], ρ[I], constants, eq)  atol = 1e-4
+    end
+
+    time_step!(model, 1e-3)
+    @test all(isfinite, interior(model.temperature))
+end


### PR DESCRIPTION
**Closes #765; supersedes #752.**

On the compressible core, temperature is a state function of `(ρ, θˡⁱ, q)`, but it was diagnosed in
two inconsistent ways once condensate appeared:

1. **In the dynamics** (`temperature_and_pressure`, which sets `model.temperature` and `p = ρRᵐT`):
   a *non-iterated* inversion `T = θ^γ (ρRᵐ/pˢᵗ)^(γ-1) + (ℒˡqˡ + ℒⁱqⁱ)/cᵖᵐ` — the dry-adiabatic
   temperature plus a linear latent-heat shift.
2. **In `update_state!`** (the saturation-adjusted state's `temperature`, which sets the
   vapor/condensate partition): the Exner inversion `T = (p/pˢᵗ)^κ θ + (ℒˡqˡ + ℒⁱqⁱ)/cᵖᵐ`.

These are the first two Picard iterates of the true fixed point, so with condensate they disagree by
≈ (Rᵐ/cᵖᵐ)·ΔL (~0.7 K per g/kg of condensate) — the dynamics and the microphysics end up carrying
*different* temperatures. (This is the inversion symptom #752 fixed.) Compounding it,
`SaturationAdjustment` evaluated `qsat` against a *stale reference pressure* rather than the
prognostic density, so the equilibrium did not lie on the saturation curve at the cell's own ρ.

Both stem from one root: the θˡⁱ state was **pressure-based** — closed on a reference pressure
(`LiquidIcePotentialTemperatureState.reference_pressure`) — on a core whose prognostic is density.

## Change

- New **`LiquidIceDensityState`** — the *density-based* counterpart of
  `LiquidIcePotentialTemperatureState` (the distinction is the closing variable, density vs
  pressure — independent of the dynamical core; thanks @glwagner for the naming). Its `temperature`
  solves the *single* constant-density inversion `T = (ρRᵐT/pˢᵗ)^κ θ + ΔL/cᵖᵐ` (Newton, to
  convergence); `saturation_specific_humidity` and `exner_function` then evaluate at the actual ρ
  (with p = ρRᵐT).
- Density-consistent `adjust_thermodynamic_state(::LiquidIceDensityState, ::SaturationAdjustment)` —
  a secant on the constant-density θˡⁱ-conservation residual (`qsat` at ρ, p = ρRᵐT, θˡⁱ held fixed).
- `diagnose_thermodynamic_state(…, ::CompressibleDynamics, q)` builds it, and the compressible
  `temperature_and_pressure` uses the *same* inversion — so the dynamics temperature and the
  saturation-adjusted temperature are now the one converged value, and the inconsistency above is
  gone. **The anelastic (reference-pressure) path is untouched.**
- The inversion's convergence is configurable via `temperature_tolerance` / `temperature_maxiter` on
  `CompressibleDynamics` (defaults `1e-8` / `8` — **#752's knobs preserved**). They are carried onto
  the state so both the dynamics inversion and the saturation/diagnostic inversion use identical
  controls — a loose tolerance cannot make the two temperatures disagree again.

## Supersedes #752

#752's inversion fix moves into `LiquidIceDensityState.temperature` (its tolerance/maxiter knobs are
preserved here); this additionally fixes the saturation-against-a-stale-pressure error that #752 does
not touch.

## Tests

`test/compressible_saturation_adjustment.jl` (531 assertions): inversion self-consistency and
round-trip, honoring of the solver controls (`temperature_maxiter = 0` reproduces the old
non-iterated inversion), density-consistent saturation adjustment (vapor on `qsat(T, ρ)`, θˡⁱ
conserved), and a moist compressible `update_state!` regression (vapor sits on `qsat(T, ρ)` in
condensing cells, which also requires the dynamics and saturation temperatures to agree).

## Validation

SA-variant of the Klemp splitting supercell, `max|w|` at t = 15 min:

| config | `max|w|` |
|---|---|
| anelastic + SA (reference) | 19.8 m/s |
| compressible + SA, `temperature_maxiter = 0` (old non-iterated inversion) | **9.7 m/s** |
| compressible + SA, default (this fix) | **26.9 m/s** |

The old inversion under-heats moist parcels → roughly half the buoyancy → a too-weak updraft; the
fix recovers it by ×2.8 (9.7 → 26.9), reproducing #752's bug→fix recovery (11.4 → 27.7 vs anelastic
28.6 at full resolution). Reduced-resolution CPU here; a full-resolution GPU reproduction is
available on request.

cc @kaiyuan-cheng @glwagner
