### PR TITLE
Terrain-following: sample topography at ξnode/ηnode for lat-lon support

### DIFF
--- a/src/TerrainFollowingDiscretization/TerrainFollowingDiscretization.jl
+++ b/src/TerrainFollowingDiscretization/TerrainFollowingDiscretization.jl
@@ -27,7 +27,7 @@ using Adapt: Adapt, adapt
 using DocStringExtensions: TYPEDSIGNATURES, TYPEDEF
 using GPUArraysCore: @allowscalar
 using KernelAbstractions: @kernel, @index
-using Oceananigans: Center, Face, CenterField, XFaceField, YFaceField, interior
+using Oceananigans: Center, Face, CenterField, XFaceField, YFaceField, interior, set!
 using Oceananigans.Architectures: architecture
 using Oceananigans.Grids: ξnode, ηnode, rnode
 using Oceananigans.ImmersedBoundaries: MutableGridOfSomeKind

--- a/src/TerrainFollowingDiscretization/TerrainFollowingDiscretization.jl
+++ b/src/TerrainFollowingDiscretization/TerrainFollowingDiscretization.jl
@@ -29,7 +29,7 @@ using GPUArraysCore: @allowscalar
 using KernelAbstractions: @kernel, @index
 using Oceananigans: Center, Face, CenterField, XFaceField, YFaceField, interior
 using Oceananigans.Architectures: architecture
-using Oceananigans.Grids: xnode, ynode, rnode
+using Oceananigans.Grids: ξnode, ηnode, rnode
 using Oceananigans.ImmersedBoundaries: MutableGridOfSomeKind
 using Oceananigans.Utils: launch!
 using Oceananigans.Operators: δxᶠᶜᶜ, δyᶜᶠᶜ, Δx⁻¹ᶠᶜᶜ, Δy⁻¹ᶜᶠᶜ, ℑxᶠᵃᵃ, ℑyᵃᶠᵃ, ℑxyᶠᶠᵃ

--- a/src/TerrainFollowingDiscretization/follow_terrain.jl
+++ b/src/TerrainFollowingDiscretization/follow_terrain.jl
@@ -70,7 +70,7 @@ function follow_terrain!(grid, topography, ::BasicTerrainFollowing, pressure_gra
     h_field = CenterField(grid, indices=(:, :, 1))
 
     # Set topography values and fill halos
-    set_topography!(h_field, grid, topography)
+    set_topography!(h_field, topography)
     fill_halo_regions!(h_field)
 
     # Compute sigma and eta on the grid
@@ -90,18 +90,22 @@ function follow_terrain!(grid, topography, ::BasicTerrainFollowing, pressure_gra
     return TerrainMetrics(h_field, ∂x_h, ∂y_h, z_top, pressure_gradient_stencil)
 end
 
-# Set topography from a function: always evaluate on CPU, then copy to device.
-# This supports arbitrary user-defined functions (including those that reference
-# non-const globals) without requiring GPU-compatible code.
-# Note: Oceananigans' set!(field, func) requires func(x, y, z) and evaluates on-device,
-# which would fail for non-GPU-compatible user functions. The manual copyto! pattern here
-# is intentionally more general.
-function set_topography!(h_field, grid, topography::Function)
+# Set topography from a function, evaluating it on the CPU and copying to the device.
+#
+# We deliberately don't use Oceananigans' `set!(h_field, topography)`. `set!`
+# evaluates a FunctionField at the field's location, which (1) requires the
+# function's arity to match the grid dimensionality — `f(x, y, z)` on a 3D grid,
+# whereas the topography API is the two-argument `h(x, y)` — and (2) on a 2D x–z
+# (Flat) grid drops the Flat direction and calls `f(x, z)`, leaking the vertical
+# coordinate into the meridional slot.
+#
+# Sampling `ξnode`/`ηnode` directly keeps the documented `h(x, y)` API and always
+# feeds horizontal-only coordinates: `(x, y)` on a RectilinearGrid, `(λ, φ)` on a
+# LatitudeLongitudeGrid, and `nothing` for a Flat direction — never z. Evaluating
+# on the CPU also supports user functions that reference non-const globals.
+function set_topography!(h_field, topography::Function)
+    grid = h_field.grid
     Nx, Ny = size(grid, 1), size(grid, 2)
-    # ξnode/ηnode are grid-agnostic horizontal coordinates: (x, y) on a
-    # RectilinearGrid, (λ, φ) on a LatitudeLongitudeGrid. Unlike `node`, they
-    # don't drop Flat directions, so the second argument is always the
-    # meridional coordinate (never z) on a 2D x–z grid.
     cpu_h = [topography(ξnode(i, j, 1, grid, Center(), Center(), Center()),
                         ηnode(i, j, 1, grid, Center(), Center(), Center()))
               for i in 1:Nx, j in 1:Ny]

--- a/src/TerrainFollowingDiscretization/follow_terrain.jl
+++ b/src/TerrainFollowingDiscretization/follow_terrain.jl
@@ -98,7 +98,12 @@ end
 # is intentionally more general.
 function set_topography!(h_field, grid, topography::Function)
     Nx, Ny = size(grid, 1), size(grid, 2)
-    cpu_h = [topography(xnode(i, grid, Center()), ynode(j, grid, Center()))
+    # ξnode/ηnode are grid-agnostic horizontal coordinates: (x, y) on a
+    # RectilinearGrid, (λ, φ) on a LatitudeLongitudeGrid. Unlike `node`, they
+    # don't drop Flat directions, so the second argument is always the
+    # meridional coordinate (never z) on a 2D x–z grid.
+    cpu_h = [topography(ξnode(i, j, 1, grid, Center(), Center(), Center()),
+                        ηnode(i, j, 1, grid, Center(), Center(), Center()))
               for i in 1:Nx, j in 1:Ny]
     copyto!(interior(h_field, :, :, 1), cpu_h)
     return nothing

--- a/src/TerrainFollowingDiscretization/follow_terrain.jl
+++ b/src/TerrainFollowingDiscretization/follow_terrain.jl
@@ -90,6 +90,11 @@ function follow_terrain!(grid, topography, ::BasicTerrainFollowing, pressure_gra
     return TerrainMetrics(h_field, ∂x_h, ∂y_h, z_top, pressure_gradient_stencil)
 end
 
+# Generic fallback: an array, Field, or number is handed straight to Oceananigans'
+# `set!`, which copies/broadcasts it onto `h_field` directly. Only the `::Function`
+# method below needs special coordinate handling.
+set_topography!(h_field, topography) = (set!(h_field, topography); nothing)
+
 # Set topography from a function, evaluating it on the CPU and copying to the device.
 #
 # We deliberately don't use Oceananigans' `set!(h_field, topography)`. `set!`

--- a/test/terrain_following.jl
+++ b/test/terrain_following.jl
@@ -1,6 +1,6 @@
 using Breeze
 using Oceananigans
-using Oceananigans.Grids: MutableVerticalDiscretization, rnode, xnode, znode
+using Oceananigans.Grids: MutableVerticalDiscretization, rnode, xnode, ynode, znode, λnode, φnode
 using Breeze.Thermodynamics: hydrostatic_pressure
 using Test
 
@@ -158,6 +158,40 @@ using Test
         @test isfinite(maximum(abs, model.dynamics.contravariant_vertical_velocity))
     end
 
+    @testset "Terrain-following CompressibleDynamics on a LatitudeLongitudeGrid" begin
+        # Spherical-geometry insurance: the same terrain physics must run on a
+        # LatitudeLongitudeGrid, where the metric terms carry cos(φ) factors and
+        # the topography is sampled at (λ, φ) rather than (x, y).
+        Nλ, Nφ, Nz = 8, 8, 8
+        Lz = 5000.0
+
+        z_faces = MutableVerticalDiscretization(collect(range(0, Lz, length=Nz+1)))
+        grid = LatitudeLongitudeGrid(CPU(); size=(Nλ, Nφ, Nz),
+                                     longitude=(-2, 2), latitude=(40, 44), z=z_faces)
+
+        h(λ, φ) = 200 * exp(-(λ^2 + (φ - 42)^2) / 0.5)
+        metrics = follow_terrain!(grid, h)
+
+        dynamics = CompressibleDynamics(ExplicitTimeStepping(); terrain_metrics=metrics)
+        model = AtmosphereModel(grid; dynamics)
+
+        @test model isa AtmosphereModel
+        @test model.dynamics.terrain_metrics isa TerrainMetrics
+        @test model.dynamics.contravariant_vertical_velocity !== nothing
+
+        θ₀ = 300.0
+        p₀ = 101325.0
+        pˢᵗ = 1e5
+        constants = model.thermodynamic_constants
+        ρᵢ(λ, φ, z) = adiabatic_hydrostatic_density(z, p₀, θ₀, pˢᵗ, constants)
+        set!(model, ρ=ρᵢ, θ=θ₀)
+
+        Δt = 0.1
+        time_step!(model, Δt)
+        @test isfinite(maximum(abs, model.velocities.w))
+        @test isfinite(maximum(abs, model.dynamics.contravariant_vertical_velocity))
+    end
+
     @testset "Contravariant velocity for horizontal flow over terrain" begin
         Nx, Nz = 16, 8
         Lx, Lz = 10000.0, 5000.0
@@ -297,5 +331,48 @@ using Test
         i_flat = 1
         i_peak = Nx÷2
         @test p_ref[i_peak, 1, 1] < p_ref[i_flat, 1, 1]
+    end
+
+    @testset "set_topography! horizontal coordinates (Flat, 3D, lat-lon)" begin
+        # The horizontal coordinates passed to topography(...) come from
+        # ξnode/ηnode (see follow_terrain.jl::set_topography!). This guards two
+        # properties that a naive `node(...)[1:2]` would break:
+        #   (a) on a 2D x–z (Flat) grid the second argument is the degenerate
+        #       meridional node `nothing`, NOT the vertical coordinate z;
+        #   (b) the coordinates generalize to (λ, φ) on a LatitudeLongitudeGrid.
+
+        # (a) Flat grid: probe returns a sentinel iff the second arg is `nothing`.
+        #     If z ever leaked into that slot, the probe would return 2.0 instead.
+        Nx, Nz = 8, 6
+        zf = MutableVerticalDiscretization(collect(range(0, 500.0, length=Nz+1)))
+        flat_grid = RectilinearGrid(CPU(); size=(Nx, Nz), x=(-500, 500), z=zf,
+                                    topology=(Periodic, Flat, Bounded))
+        h_probe(x, y) = y === nothing ? 1.0 : 2.0
+        m_flat = follow_terrain!(flat_grid, h_probe)
+        @test all(m_flat.topography[i, 1, 1] == 1.0 for i in 1:Nx)
+
+        # (b) 3D grid: topography receives the true (x, y).
+        Nx3, Ny3, Nz3 = 5, 4, 3
+        zf3 = MutableVerticalDiscretization(collect(range(0, 300.0, length=Nz3+1)))
+        grid3 = RectilinearGrid(CPU(); size=(Nx3, Ny3, Nz3), x=(0, 100), y=(0, 80),
+                                z=zf3, topology=(Periodic, Periodic, Bounded))
+        h_xy(x, y) = x + 2y
+        m3 = follow_terrain!(grid3, h_xy)
+        for i in 1:Nx3, j in 1:Ny3
+            expected = xnode(i, grid3, Center()) + 2 * ynode(j, grid3, Center())
+            @test m3.topography[i, j, 1] ≈ expected
+        end
+
+        # (c) LatitudeLongitudeGrid: topography receives (λ, φ) in degrees.
+        Nλ, Nφ, Nzll = 6, 5, 4
+        zfll = MutableVerticalDiscretization(collect(range(0, 4000.0, length=Nzll+1)))
+        llg = LatitudeLongitudeGrid(CPU(); size=(Nλ, Nφ, Nzll),
+                                    longitude=(-5, 5), latitude=(40, 50), z=zfll)
+        h_λφ(λ, φ) = 100.0 + λ + 2φ
+        m_ll = follow_terrain!(llg, h_λφ)
+        for i in 1:Nλ, j in 1:Nφ
+            expected = h_λφ(λnode(i, llg, Center()), φnode(j, llg, Center()))
+            @test m_ll.topography[i, j, 1] ≈ expected
+        end
     end
 end

--- a/test/terrain_following.jl
+++ b/test/terrain_following.jl
@@ -375,4 +375,22 @@ using Test
             @test m_ll.topography[i, j, 1] ≈ expected
         end
     end
+
+    @testset "set_topography! generic fallback (Number, Array)" begin
+        # Non-Function topography (a constant or a precomputed height field)
+        # is handed straight to Oceananigans' set!, bypassing coordinate sampling.
+        Nx, Nz = 8, 6
+        zf = MutableVerticalDiscretization(collect(range(0, 500.0, length=Nz+1)))
+        grid = RectilinearGrid(CPU(); size=(Nx, Nz), x=(-500, 500), z=zf,
+                               topology=(Periodic, Flat, Bounded))
+
+        # Constant terrain height
+        m_const = follow_terrain!(grid, 250.0)
+        @test all(m_const.topography[i, 1, 1] == 250.0 for i in 1:Nx)
+
+        # Precomputed array of heights
+        heights = reshape(Float64.(1:Nx), Nx, 1, 1)
+        m_arr = follow_terrain!(grid, heights)
+        @test all(m_arr.topography[i, 1, 1] == i for i in 1:Nx)
+    end
 end


### PR DESCRIPTION
## Summary

`set_topography!` sampled the user terrain function at `xnode(i, grid, Center())` / `ynode(j, grid, Center())`, which are `RectilinearGrid`-oriented and don't generalize: on a `LatitudeLongitudeGrid` those accessors don't hand the topography function the horizontal `(λ, φ)` it expects.

This switches to **`ξnode`/`ηnode`** — the grid-agnostic horizontal node accessors:

- `(x, y)` on a `RectilinearGrid`
- `(λ, φ)` on a `LatitudeLongitudeGrid` → terrain-following now works on lat-lon LAMs
- `nothing` for the degenerate meridional node on a 2D x–z `(Periodic, Flat, Bounded)` grid — exactly matching prior behavior

### Why not `node(...)[1:2]`?

The obvious grid-agnostic substitute is wrong on Flat grids: `node` *drops* Flat directions from its returned tuple, so on a 2D x–z grid it yields `(x, z)` and leaks the **vertical** coordinate into the meridional slot. `ξnode`/`ηnode` are the primitives `node` is built from but never drop Flat directions. A regression test pins this down.

## Tests

- **Horizontal-coordinate handling** across Flat / 3D / lat-lon grids. The Flat-grid case uses a probe `h(x, y) = y === nothing ? 1.0 : 2.0` asserting the second argument is `nothing` (not `z`) — this assertion fails against the `node[1:2]` approach.
- **`LatitudeLongitudeGrid` terrain-physics testset** mirroring the existing rectilinear one: `follow_terrain!` + `CompressibleDynamics(...; terrain_metrics)` + one `time_step!` → finite `w` and contravariant vertical velocity. Cheap insurance that the metric terms behave under spherical geometry.

Full `test/terrain_following.jl` passes 664/664; `quality_assurance` (ExplicitImports/Aqua) passes 36/36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)