### PR TITLE
Rename `adiabatic_balance!` to `balance_adiabatically!`

### DIFF
--- a/src/Breeze.jl
+++ b/src/Breeze.jl
@@ -33,7 +33,7 @@ export
     CubicRamp,
     Sin2Ramp,
     ExplicitTimeStepping,
-    adiabatic_balance!,
+    balance_adiabatically!,
     PrescribedDensity,
     PrescribedDynamics,
     KinematicModel,
@@ -246,7 +246,7 @@ using .CompressibleEquations: CompressibleDynamics, CompressibleModel, AcousticS
 # initial_fields method for CompressibleModel / AnelasticModel.
 using DocStringExtensions: TYPEDSIGNATURES
 using Oceananigans.TimeSteppers: update_state!, reset!
-include("adiabatic_balance.jl")
+include("balance_adiabatically.jl")
 
 include("KinematicDriver/KinematicDriver.jl")
 using .KinematicDriver: PrescribedDensity, PrescribedDynamics, KinematicModel

--- a/src/balance_adiabatically.jl
+++ b/src/balance_adiabatically.jl
@@ -33,14 +33,14 @@ The initial fields that are modified depend on the dynamics:
 reset to `t = 0` on exit. `Δt` is the forward/backward step size, taken with the
 model's own time stepper.
 
-`adiabatic_balance!` performs *adiabatic* dynamics only. The caller must
+`balance_adiabatically!` performs *adiabatic* dynamics only. The caller must
 pass a model built without physics (`microphysics = nothing`), without an upper
 sponge (`sponge = nothing`), and without forcing — these run inside
 `update_state!`/`time_step!` and would corrupt the spin-up. Boundary conditions
 are not modified; pass a model whose boundaries are time-invariant (e.g. frozen
 at the analysis time) so the symmetric excursion stays nearly reversible.
 """
-function adiabatic_balance!(model::AtmosphereModel; Δt, cycles = 1, weight = 2)
+function balance_adiabatically!(model::AtmosphereModel; Δt, cycles = 1, weight = 2)
     snapshot = snapshot_initial_fields(model)
 
     for _ in 1:cycles

--- a/test/balance_adiabatically.jl
+++ b/test/balance_adiabatically.jl
@@ -1,5 +1,5 @@
 #####
-##### Tests for `adiabatic_balance!` (FV3-SHiELD `na_init`).
+##### Tests for `balance_adiabatically!` (FV3-SHiELD `na_init`).
 #####
 ##### - Nudge algebra: the slow-field blend is exactly (x + weight·x₀)/(1+weight),
 #####   and ρw is never snapshotted/nudged.
@@ -53,7 +53,7 @@ function _set_discrete_rest!(model)
     return nothing
 end
 
-@testset "adiabatic_balance!" begin
+@testset "balance_adiabatically!" begin
 
     @testset "nudge algebra (initial fields blended, ρw untouched)" begin
         model = _build_adiabatic_model(default_arch)
@@ -87,7 +87,7 @@ end
         ρ₀  = Array(interior(ρ))
         ρθ₀ = Array(interior(ρθ))
 
-        adiabatic_balance!(model; Δt = 1.0, cycles = 1)
+        balance_adiabatically!(model; Δt = 1.0, cycles = 1)
 
         @test maximum(abs, Array(interior(ρ))  .- ρ₀)  <= 1e-9 * maximum(abs, ρ₀)
         @test maximum(abs, Array(interior(ρθ)) .- ρθ₀) <= 1e-9 * maximum(abs, ρθ₀)
@@ -110,7 +110,7 @@ end
 
         # Acoustic Δt; default forward_weight = 0.65 damps the resolved
         # acoustic branch within the symmetric excursion.
-        adiabatic_balance!(model; Δt = 0.1, cycles = 1)
+        balance_adiabatically!(model; Δt = 0.1, cycles = 1)
         w_after = maximum(abs, Array(interior(model.momentum.ρw)))
 
         @test w_before > 0
@@ -143,7 +143,7 @@ end
         ρθ₀ = Array(interior(ρθ))
 
         # Exercises the backward step time_step!(anelastic, -Δt).
-        adiabatic_balance!(model; Δt = 1.0, cycles = 1)
+        balance_adiabatically!(model; Δt = 1.0, cycles = 1)
 
         @test all(isfinite, Array(interior(model.momentum.ρu)))
         @test maximum(abs, Array(interior(ρθ)) .- ρθ₀) <= 1e-6 * maximum(abs, ρθ₀)


### PR DESCRIPTION
Follow-up to #764, addressing @glwagner's final review comment on the naming.

A `!` function reads most clearly as an imperative verb:

```julia
balance_adiabatically!(model)   # an action performed on `model`
```

whereas a noun-phrase name like `adiabatic_balance` would suggest the form

```julia
balanced_state = adiabatic_balance(model)   # compute and return a state
```

## Changes

- Rename `adiabatic_balance!` → `balance_adiabatically!`
- Rename `src/adiabatic_balance.jl` → `src/balance_adiabatically.jl`
- Rename `test/adiabatic_balance.jl` → `test/balance_adiabatically.jl` (auto-rediscovered by `find_tests`; no registration change needed)
- Update the export in `src/Breeze.jl`

Behavior is unchanged — this is a pure rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)