### PR TITLE
Add missing import of `Oceananigans.Fields.CenterField`

### DIFF
--- a/src/Thermodynamics/reference_states.jl
+++ b/src/Thermodynamics/reference_states.jl
@@ -1,7 +1,7 @@
 using Oceananigans: Oceananigans, Center, Field, set!, fill_halo_regions!
 using Oceananigans.Architectures: architecture
 using Oceananigans.BoundaryConditions: FieldBoundaryConditions, ValueBoundaryCondition
-using Oceananigans.Fields: ZeroField
+using Oceananigans.Fields: CenterField, ZeroField
 using Oceananigans.Grids: znode
 using Oceananigans.Operators: Δzᶜᶜᶜ, Δzᶜᶜᶠ
 using Oceananigans.Operators: ℑzᵃᵃᶠ, Δzᶜᶜᶠ


### PR DESCRIPTION
This is used in https://github.com/NumericalEarth/Breeze.jl/blob/f9a98cfdae74d0887545a33c1b5a72a9d9a053cf/src/Thermodynamics/reference_states.jl#L756-L765 but it's not imported from anywhere and is undefined (found with `JET.jl`).  This also points out that this code path is untested.