### PR TITLE
Resolve possible issues detected by JET

### DIFF
--- a/src/AtmosphereModels/set_to_mean.jl
+++ b/src/AtmosphereModels/set_to_mean.jl
@@ -76,6 +76,11 @@ fields are left as-is and only diagnostics are recomputed.
 function set_to_mean!(ref::ReferenceState, model; rescale_densities=false)
     constants = model.thermodynamic_constants
 
+    if rescale_densities
+        ρᵣ_old = similar(dynamics_density(model.dynamics))
+        parent(ρᵣ_old) .= parent(dynamics_density(model.dynamics))
+    end
+
     # Update reference temperature and moisture from horizontal means
     mean!(ref.temperature, model.temperature)
     fill_halo_regions!(ref.temperature)
@@ -88,8 +93,6 @@ function set_to_mean!(ref::ReferenceState, model; rescale_densities=false)
     compute_hydrostatic_reference!(ref, constants)
 
     if rescale_densities
-        ρᵣ_old = similar(dynamics_density(model.dynamics))
-        parent(ρᵣ_old) .= parent(dynamics_density(model.dynamics))
         rescale_density_weighted_fields!(model, ρᵣ_old)
     end
 

--- a/src/AtmosphereModels/set_to_mean.jl
+++ b/src/AtmosphereModels/set_to_mean.jl
@@ -76,11 +76,6 @@ fields are left as-is and only diagnostics are recomputed.
 function set_to_mean!(ref::ReferenceState, model; rescale_densities=false)
     constants = model.thermodynamic_constants
 
-    if rescale_densities
-        ρᵣ_old = similar(dynamics_density(model.dynamics))
-        parent(ρᵣ_old) .= parent(dynamics_density(model.dynamics))
-    end
-
     # Update reference temperature and moisture from horizontal means
     mean!(ref.temperature, model.temperature)
     fill_halo_regions!(ref.temperature)
@@ -93,6 +88,8 @@ function set_to_mean!(ref::ReferenceState, model; rescale_densities=false)
     compute_hydrostatic_reference!(ref, constants)
 
     if rescale_densities
+        ρᵣ_old = similar(dynamics_density(model.dynamics))
+        parent(ρᵣ_old) .= parent(dynamics_density(model.dynamics))
         rescale_density_weighted_fields!(model, ρᵣ_old)
     end
 

--- a/src/CompressibleEquations/acoustic_substepping.jl
+++ b/src/CompressibleEquations/acoustic_substepping.jl
@@ -1454,7 +1454,7 @@ Execute one Wicker–Skamarock RK3 stage of the linearized acoustic
 substep loop. Number and size of substeps in this stage depend on
 `substepper.substep_distribution`.
 """
-function acoustic_rk3_substep_loop!(model, substepper, Δt, β_stage, Uᴸ)
+function acoustic_rk3_substep_loop!(model::AtmosphereModel, substepper, Δt, β_stage, Uᴸ)
     grid = model.grid
     arch = architecture(grid)
 

--- a/src/TimeSteppers/acoustic_runge_kutta_3.jl
+++ b/src/TimeSteppers/acoustic_runge_kutta_3.jl
@@ -117,7 +117,7 @@ Run one Wicker–Skamarock RK3 stage: compute slow tendencies, then
 execute the linearized-acoustic substep loop, then update remaining
 scalars.
 """
-function acoustic_rk3_substep!(model, Δt, β)
+function acoustic_rk3_substep!(model::AtmosphereModel, Δt, β)
     ts = model.timestepper
     substepper = ts.substepper
     U⁰ = ts.U⁰
@@ -152,7 +152,7 @@ end
 ##### Scalar update with time-averaged velocities
 #####
 
-function scalar_rk3_substep!(model, Δt_stage)
+function scalar_rk3_substep!(model::AtmosphereModel, Δt_stage)
     grid = model.grid
     Δt_FT = kernel_time_step(grid.architecture, grid, Δt_stage)
     return scalar_substep!(model, _rk3_substep!, Δt_stage, Δt_FT)


### PR DESCRIPTION
This resolves
```julia-repl
julia> using Breeze, JET, LinearAlgebra, Oceananigans, MPI, StaticArraysCore, JLD2

julia> JET.test_package(Breeze; ignored_modules=(Base, LinearAlgebra, Oceananigans, MPI, StaticArraysCore, JLD2))
JET-test failed at /home/mose/.julia/packages/JET/Nf2tu/src/JETBase.jl:1400
  Expression: (JET.report_package)(Breeze; toplevel_logger = nothing, ignored_modules = (Base, LinearAlgebra, Oceananigans, MPI, StaticArraysCore, JLD2))
  ═════ 2 possible errors found ═════
  ┌ set_to_mean!(ref::ReferenceState, model::Any; rescale_densities::Any) @ Breeze.AtmosphereModels /home/mose/.julia/dev/Breeze/src/AtmosphereModels/set_to_mean.jl:96
  │ local variable `ρᵣ_old` may be undefined: ρᵣ_old::Any
  └────────────────────
  ┌ acoustic_rk3_substep_loop!(model::Any, substepper::Any, Δt::Any, β_stage::Any, Uᴸ::Any) @ Breeze.CompressibleEquations /home/mose/.julia/dev/Breeze/src/CompressibleEquations/acoustic_substepping.jl:1640
  │ no matching method found `compute_velocities!(::HydrostaticFreeSurfaceModel)`, `compute_velocities!(::NonhydrostaticModel)` (2/3 union split): (Breeze.CompressibleEquations.AtmosphereModels).compute_velocities!::typeof(Breeze.AtmosphereModels.compute_velocities!)(model::Any)
  └────────────────────
  
ERROR: There was an error during testing
```
These are minor issues, it's mainly about the ability of the compiler to understand the code more easily.

Together with #784, JET would be clean after these PRs.