### PR TITLE
[CI] Run all GPU jobs on larger runners

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -62,7 +62,7 @@ jobs:
           # `--check-bounds=auto` is necessary for testing Reactant workloads
           # until https://github.com/EnzymeAD/Reactant.jl/issues/2347 is fixed.
           - version: "1.12.6"
-            os: aws-linux-nvidia-gpu-l4
+            os: aws-linux-nvidia-gpu-l4-4xl
             arch: "default"
             check-bounds: "auto"
           - version: "1.11.9"


### PR DESCRIPTION
We're often running out of memory in julia v1.12 jobs, because they currently use smaller runners.