### PR TITLE
Damp the θ-flux divergence (fix split-explicit cold-start blow-up)

### DIFF
--- a/src/CompressibleEquations/acoustic_substepping.jl
+++ b/src/CompressibleEquations/acoustic_substepping.jl
@@ -147,8 +147,8 @@ Per-column scratch (column kernel only):
 
 - `density_predictor`, `density_potential_temperature_predictor`: explicit
   predictors built before the implicit vertical solve.
-- `previous_density_potential_temperature_perturbation`: ``η`` from the
-  previous substep, used by Klemp 2018 damping.
+- `horizontal_divergence`: scratch for the horizontal mass divergence
+  ``∂x(ρu)′ + ∂y(ρv)′``, recomputed each substep for the Klemp 2018 damping.
 
 Time-averaged velocity for non-acoustic scalar transport (WRF/MPAS-style
 dynamics-transport split):
@@ -204,7 +204,7 @@ struct AcousticSubstepper{N, FT, D, AD, US, CF, MP, TAV, GT, TS}
 
     density_predictor :: CF
     density_potential_temperature_predictor :: CF
-    previous_density_potential_temperature_perturbation :: CF
+    horizontal_divergence :: CF
 
     # Time-averaged velocities for non-acoustic scalar advection (WRF/MPAS
     # dynamics-transport split).
@@ -250,7 +250,7 @@ Adapt.adapt_structure(to, a::AcousticSubstepper) =
                         w = adapt(to, a.momentum_perturbation.w)),
                        adapt(to, a.density_predictor),
                        adapt(to, a.density_potential_temperature_predictor),
-                       adapt(to, a.previous_density_potential_temperature_perturbation),
+                       adapt(to, a.horizontal_divergence),
                        (u = adapt(to, a.time_averaged_velocities.u),
                         v = adapt(to, a.time_averaged_velocities.v),
                         w = adapt(to, a.time_averaged_velocities.w)),
@@ -314,7 +314,7 @@ function AcousticSubstepper(grid, split_explicit::SplitExplicitTimeDiscretizatio
 
     density_predictor                                = CenterField(grid)
     density_potential_temperature_predictor          = CenterField(grid)
-    previous_density_potential_temperature_perturbation = CenterField(grid)
+    horizontal_divergence = CenterField(grid)
 
     # Substep-averaged velocities for scalar transport.
     time_averaged_velocities = (u = XFaceField(grid),
@@ -348,7 +348,7 @@ function AcousticSubstepper(grid, split_explicit::SplitExplicitTimeDiscretizatio
                               momentum_perturbation,
                               density_predictor,
                               density_potential_temperature_predictor,
-                              previous_density_potential_temperature_perturbation,
+                              horizontal_divergence,
                               time_averaged_velocities,
                               slow_vertical_momentum_tendency,
                               vertical_solver)
@@ -873,8 +873,8 @@ function initialize_stage_perturbations!(substepper, model, Uᴸ_outer)
     grid = model.grid
     arch = architecture(grid)
 
-    # Auxiliary workspaces: zero.
-    fill!(parent(substepper.previous_density_potential_temperature_perturbation), 0)
+    # Auxiliary workspaces: zero. (`horizontal_divergence` is recomputed each
+    # substep before the damping, so it needs no stage-init zero.)
     fill!(parent(substepper.density_predictor), 0)
     fill!(parent(substepper.density_potential_temperature_predictor), 0)
 
@@ -1140,68 +1140,73 @@ end
     return (convert(FT, ω) * base, convert(FT, one_minus_ω) * base)
 end
 
-# Klemp, Skamarock & Ha (2018) acoustic divergence damping (MPAS form).
-# In the linearized acoustic mode,
-#   (ρθ)′ − (ρθ)′ˢ⁻ ≈ −Δτ · θᴸ · ∇·((ρu)′, (ρv)′, (ρw)′)
-# so D ≡ ((ρθ)′ − (ρθ)′ˢ⁻) / θᴸ is a discrete proxy for −Δτ · ∇·(ρu)′.
-# The default per-substep momentum correction is horizontal:
-#   Δ(ρu)′ = −γ · ∂x D , Δ(ρv)′ = −γ · ∂y D
-# with per-direction horizontal diffusivities:
-#   γˣ = α · Δx² / Δτ,   γʸ = α · Δy² / Δτ
-# or, when `length_scale = ℓ` is specified, fixed diffusivity
-#   γ = α · ℓ² / Δτ
-# in both horizontal directions.
-# If `damp_vertical = true`, the vertical contribution
-#   γ_z = α · Δz² / Δτ
-# is folded into the column tridiag instead of applied as a post-substep
-# correction.
-# `α` is the dimensionless Klemp 2018 coefficient (`config_smdiv` in MPAS,
-# default 0.1). Linear stability of the explicit forward-Euler horizontal
-# step gives `A(k) = 1 − 4α · Σᵢ sin²(kᵢ Δxᵢ/2)`; worst case (2-D Nyquist)
-# is `8α ≤ 2 → α ≤ 0.25`; we default to 0.1 for margin. The optional
-# vertical component is not applied by default; the default vertical acoustic
-# damping comes from off-centering (`forward_weight > 0.5`) in the implicit
-# column solve.
+# Klemp, Skamarock & Ha (2018) acoustic divergence damping (MPAS form), applied
+# per substep to the horizontal mass divergence
+#   δ ≡ ∂x(ρu)′ + ∂y(ρv)′          (terrain-aware `div_xyᶜᶜᶜ`)
+# as a horizontal momentum correction
+#   Δ(ρu)′ = γˣ · ∂x δ ,   Δ(ρv)′ = γʸ · ∂y δ
+# with per-direction diffusivities γˣ = α·Δx², γʸ = α·Δy² (or, when
+# `length_scale = ℓ` is given, the fixed γ = α·ℓ²). This is a Laplacian
+# diffusion of δ (Δδ = γ ∇²δ, mode gain 1 − γk²), strictly dissipative for
+# α ≤ 2/π² ≈ 0.2, so it damps grid-scale horizontal-acoustic divergence; we
+# default α = 0.1.
+#
+# NOTE: an earlier version damped the (ρθ)′ tendency `(ρθ)′ − (ρθ)′ˢ⁻` (a proxy
+# for −Δτ·θᴸ·∇·m) with diffusivity α·Δx²/Δτ. The Δτ cancels only when that change
+# is divergence-dominated; for an unbalanced cold start the (ρθ)′ change is O(1)
+# (hydrostatic/PGF adjustment, not divergence), so the proxy left a spurious
+# `∝ α/Δτ` horizontal force that blew up the split cold start. Damping the true
+# horizontal divergence is equivalent for a balanced acoustic wave but robust
+# (Δτ-independent, dissipative) for the transient.
+#
+# `α` is the dimensionless Klemp 2018 coefficient (`config_smdiv` in MPAS).
+# `damp_vertical = true` folds the vertical Laplacian on (ρw)′ into the column
+# tridiag (see `implicit_damping_factors`); the default vertical damping comes
+# from off-centering (`forward_weight > 0.5`).
 function apply_divergence_damping!(damping::ThermalDivergenceDamping, substepper, grid, Δτ, thermodynamic_constants)
-    FT    = eltype(grid)
-    arch  = architecture(grid)
-    α     = convert(FT, damping.coefficient)
-    Δτ_FT = convert(FT, Δτ)
+    FT   = eltype(grid)
+    arch = architecture(grid)
+    α    = convert(FT, damping.coefficient)
 
     TX, TY, _ = topology(grid)
-    x_damping_scale = TX === Flat ? NoHorizontalDampingScale() :
-                      horizontal_damping_scale(damping, α, Δτ_FT)
-    y_damping_scale = TY === Flat ? NoHorizontalDampingScale() :
-                      horizontal_damping_scale(damping, α, Δτ_FT)
+    x_damping_scale = TX === Flat ? NoHorizontalDampingScale() : horizontal_damping_scale(damping, α)
+    y_damping_scale = TY === Flat ? NoHorizontalDampingScale() : horizontal_damping_scale(damping, α)
 
-    launch!(arch, grid, :xyz, _thermal_divergence_damping!,
-            substepper.momentum_perturbation.u,
-            substepper.momentum_perturbation.v,
-            substepper.density_potential_temperature_perturbation,
-            substepper.previous_density_potential_temperature_perturbation,
-            substepper.linearization_potential_temperature,
-            grid, x_damping_scale, y_damping_scale)
+    ρu′ = substepper.momentum_perturbation.u
+    ρv′ = substepper.momentum_perturbation.v
+    δ   = substepper.horizontal_divergence
+
+    # Compute δ = ∂x(ρu)′ + ∂y(ρv)′ everywhere and fill its halos, then damp it.
+    # Two kernels: the damping reads δ at neighbours while writing ρu′/ρv′, so δ
+    # must be complete before the second launch.
+    launch!(arch, grid, :xyz, _compute_horizontal_divergence!, δ, ρu′, ρv′, grid)
+    fill_halo_regions!(δ)
+    launch!(arch, grid, :xyz, _thermal_divergence_damping!, ρu′, ρv′, δ, grid,
+            x_damping_scale, y_damping_scale)
 
     return nothing
 end
 
-@inline dρθ′(i, j, k, grid, ρθ′, ρθ′ˢ⁻) = @inbounds ρθ′[i, j, k] - ρθ′ˢ⁻[i, j, k]
+@kernel function _compute_horizontal_divergence!(δ, ρu′, ρv′, grid)
+    i, j, k = @index(Global, NTuple)
+    @inbounds δ[i, j, k] = div_xyᶜᶜᶜ(i, j, k, grid, ρu′, ρv′)
+end
 
 struct NoHorizontalDampingScale end
 struct LocalHorizontalDampingScale{FT}
-    coefficient_over_Δτ :: FT
+    coefficient :: FT
 end
 
 struct FixedHorizontalDampingScale{FT}
     diffusivity :: FT
 end
 
-@inline horizontal_damping_scale(damping::ThermalDivergenceDamping{FT, Nothing}, α, Δτ) where FT =
-    LocalHorizontalDampingScale(α / Δτ)
+@inline horizontal_damping_scale(damping::ThermalDivergenceDamping{FT, Nothing}, α) where FT =
+    LocalHorizontalDampingScale(α)
 
-@inline function horizontal_damping_scale(damping::ThermalDivergenceDamping, α, Δτ)
+@inline function horizontal_damping_scale(damping::ThermalDivergenceDamping, α)
     ℓ = convert(typeof(α), damping.length_scale)
-    return FixedHorizontalDampingScale(α * ℓ^2 / Δτ)
+    return FixedHorizontalDampingScale(α * ℓ^2)
 end
 
 @inline x_damping_diffusivity(i, j, k, grid, ::NoHorizontalDampingScale) = zero(grid)
@@ -1214,36 +1219,27 @@ end
     scale.diffusivity
 
 @inline x_damping_diffusivity(i, j, k, grid, scale::LocalHorizontalDampingScale) =
-    scale.coefficient_over_Δτ * Δxᶠᶜᶜ(i, j, k, grid)^2
+    scale.coefficient * Δxᶠᶜᶜ(i, j, k, grid)^2
 
 @inline y_damping_diffusivity(i, j, k, grid, scale::LocalHorizontalDampingScale) =
-    scale.coefficient_over_Δτ * Δyᶜᶠᶜ(i, j, k, grid)^2
+    scale.coefficient * Δyᶜᶠᶜ(i, j, k, grid)^2
 
 
-# Horizontal divergence damping in the form of Klemp, Skamarock & Ha (2018)
-# eq. (36): per-substep momentum correction is the gradient of the (ρθ)′
-# tendency, divided by θᴸ at the face,
-#   Δ(ρu)′ = −γˣ · ∂x[(ρθ)′ − (ρθ)′ˢ⁻] / ℑxᶠᵃᵃ(θᴸ)
-#   Δ(ρv)′ = −γʸ · ∂y[(ρθ)′ − (ρθ)′ˢ⁻] / ℑyᵃᶠᵃ(θᴸ)
-# with local default diffusivities γˣ = α Δx² / Δτ and γʸ = α Δy² / Δτ.
-# If the user passes a fixed `length_scale`, both directions use the fixed
-# diffusivity γ = α length_scale² / Δτ for backwards-compatible tuning.
-# The vertical component lives in the column tridiag (it's a Laplacian on
-# (ρw)′ folded into the implicit acoustic solve), not here.
-@kernel function _thermal_divergence_damping!(ρu′, ρv′, ρθ′, ρθ′ˢ⁻, θᴸ, grid,
+# Damp the horizontal mass divergence δ as a Laplacian diffusion:
+#   Δ(ρu)′ = γˣ · ∂x δ ,   Δ(ρv)′ = γʸ · ∂y δ ,   γ = α·Δx² (Δτ-independent).
+# δ (`div_xyᶜᶜᶜ`) is precomputed and halo-filled by `apply_divergence_damping!`.
+# The vertical component lives in the column tridiag (a Laplacian on (ρw)′ folded
+# into the implicit acoustic solve), not here.
+@kernel function _thermal_divergence_damping!(ρu′, ρv′, δ, grid,
                                               x_damping_scale, y_damping_scale)
     i, j, k = @index(Global, NTuple)
 
     @inbounds begin
-        ∂x_div = ∂xᶠᶜᶜ(i, j, k, grid, dρθ′, ρθ′, ρθ′ˢ⁻)
-        θᴸᶠᶜᶜ  = ℑxᶠᵃᵃ(i, j, k, grid, θᴸ)
         γˣ = x_damping_diffusivity(i, j, k, grid, x_damping_scale)
-        ρu′[i, j, k] -= γˣ * ∂x_div / θᴸᶠᶜᶜ
+        ρu′[i, j, k] += γˣ * ∂xᶠᶜᶜ(i, j, k, grid, δ)
 
-        ∂y_div = ∂yᶜᶠᶜ(i, j, k, grid, dρθ′, ρθ′, ρθ′ˢ⁻)
-        θᴸᶜᶠᶜ  = ℑyᵃᶠᵃ(i, j, k, grid, θᴸ)
         γʸ = y_damping_diffusivity(i, j, k, grid, y_damping_scale)
-        ρv′[i, j, k] -= γʸ * ∂y_div / θᴸᶜᶠᶜ
+        ρv′[i, j, k] += γʸ * ∂yᶜᶠᶜ(i, j, k, grid, δ)
     end
 end
 
@@ -1518,11 +1514,6 @@ function acoustic_rk3_substep_loop!(model::AtmosphereModel, substepper, Δt, β_
 
         fill_halo_regions!(substepper.momentum_perturbation.u)
         fill_halo_regions!(substepper.momentum_perturbation.v)
-
-
-        # Save (ρθ)′ before the column kernel for damping use
-        parent(substepper.previous_density_potential_temperature_perturbation) .=
-            parent(substepper.density_potential_temperature_perturbation)
 
         # CN time-step weights for this substep. δτᵐ⁺ = ω·Δτ is the
         # new-side weight (used by the matrix and the post-solve);

--- a/src/CompressibleEquations/acoustic_substepping.jl
+++ b/src/CompressibleEquations/acoustic_substepping.jl
@@ -147,8 +147,8 @@ Per-column scratch (column kernel only):
 
 - `density_predictor`, `density_potential_temperature_predictor`: explicit
   predictors built before the implicit vertical solve.
-- `horizontal_divergence`: scratch for the horizontal mass divergence
-  ``∂x(ρu)′ + ∂y(ρv)′``, recomputed each substep for the Klemp 2018 damping.
+- `horizontal_divergence`: scratch for the horizontal θ-flux divergence
+  ``∂x(θᴸ(ρu)′) + ∂y(θᴸ(ρv)′)``, recomputed each substep for the Klemp 2018 damping.
 
 Time-averaged velocity for non-acoustic scalar transport (WRF/MPAS-style
 dynamics-transport split):
@@ -1140,24 +1140,28 @@ end
     return (convert(FT, ω) * base, convert(FT, one_minus_ω) * base)
 end
 
-# Klemp, Skamarock & Ha (2018) acoustic divergence damping (MPAS form), applied
-# per substep to the horizontal mass divergence
-#   δ ≡ ∂x(ρu)′ + ∂y(ρv)′          (terrain-aware `div_xyᶜᶜᶜ`)
+# Klemp, Skamarock & Ha (2018) acoustic divergence damping (MPAS form, eq. 36),
+# applied per substep to the horizontal θ-flux divergence
+#   δ ≡ ∂x(θᴸ(ρu)′) + ∂y(θᴸ(ρv)′)
 # as a horizontal momentum correction
-#   Δ(ρu)′ = γˣ · ∂x δ ,   Δ(ρv)′ = γʸ · ∂y δ
+#   Δ(ρu)′ = γˣ · ∂x δ / θᴸ ,   Δ(ρv)′ = γʸ · ∂y δ / θᴸ
 # with per-direction diffusivities γˣ = α·Δx², γʸ = α·Δy² (or, when
-# `length_scale = ℓ` is given, the fixed γ = α·ℓ²). This is a Laplacian
-# diffusion of δ (Δδ = γ ∇²δ, mode gain 1 − γk²), strictly dissipative for
-# α ≤ 2/π² ≈ 0.2, so it damps grid-scale horizontal-acoustic divergence; we
-# default α = 0.1.
+# `length_scale = ℓ` is given, the fixed γ = α·ℓ²). KSH18 (eq. 1) show that the
+# divergence specific to the acoustic modes is the ρθ-flux divergence
+# `D = ∇·(ρθ𝐯)`, and that the damping divergence must be numerically the same as
+# the divergence in the Θ = ρθ equation — here it is exactly `∇ʰ_θM` from the
+# column kernel (`theta_face_{x,y}_flux`). The momentum correction divides that
+# by θᴸ at the face per eq. (36). To leading order this is a Laplacian diffusion
+# of δ (mode gain 1 − γk²), strictly dissipative for α ≤ 2/π² ≈ 0.2; we default
+# α = 0.1.
 #
-# NOTE: an earlier version damped the (ρθ)′ tendency `(ρθ)′ − (ρθ)′ˢ⁻` (a proxy
-# for −Δτ·θᴸ·∇·m) with diffusivity α·Δx²/Δτ. The Δτ cancels only when that change
-# is divergence-dominated; for an unbalanced cold start the (ρθ)′ change is O(1)
-# (hydrostatic/PGF adjustment, not divergence), so the proxy left a spurious
-# `∝ α/Δτ` horizontal force that blew up the split cold start. Damping the true
-# horizontal divergence is equivalent for a balanced acoustic wave but robust
-# (Δτ-independent, dissipative) for the transient.
+# NOTE: an earlier version recovered the divergence from the (ρθ)′ tendency
+# `(ρθ)′ − (ρθ)′ˢ⁻` (eq. 36 uses (Θᵗ⁺ᐩ − Θᵗ)/Δτ = −D) with diffusivity α·Δx²/Δτ.
+# That identity holds only when the per-substep (ρθ)′ change equals −Δτ·D; for an
+# unbalanced cold start the change carries an O(1), Δτ-independent component
+# (hydrostatic/PGF adjustment, not divergence), so the `/Δτ` left a spurious
+# `∝ α/Δτ` horizontal force that blew up the split cold start. Computing D
+# directly each substep is exact (no proxy) and Δτ-independent.
 #
 # `α` is the dimensionless Klemp 2018 coefficient (`config_smdiv` in MPAS).
 # `damp_vertical = true` folds the vertical Laplacian on (ρw)′ into the column
@@ -1175,21 +1179,27 @@ function apply_divergence_damping!(damping::ThermalDivergenceDamping, substepper
     ρu′ = substepper.momentum_perturbation.u
     ρv′ = substepper.momentum_perturbation.v
     δ   = substepper.horizontal_divergence
+    θᴸ  = substepper.linearization_potential_temperature
 
-    # Compute δ = ∂x(ρu)′ + ∂y(ρv)′ everywhere and fill its halos, then damp it.
-    # Two kernels: the damping reads δ at neighbours while writing ρu′/ρv′, so δ
-    # must be complete before the second launch.
-    launch!(arch, grid, :xyz, _compute_horizontal_divergence!, δ, ρu′, ρv′, grid)
+    # Compute δ = ∇ʰ·(θᴸ𝐦′) everywhere and fill its halos, then damp it. Two
+    # kernels: the damping reads δ at neighbours while writing ρu′/ρv′, so δ must
+    # be complete before the second launch.
+    launch!(arch, grid, :xyz, _compute_horizontal_divergence!, δ, ρu′, ρv′, θᴸ, grid)
     fill_halo_regions!(δ)
-    launch!(arch, grid, :xyz, _thermal_divergence_damping!, ρu′, ρv′, δ, grid,
+    launch!(arch, grid, :xyz, _thermal_divergence_damping!, ρu′, ρv′, δ, θᴸ, grid,
             x_damping_scale, y_damping_scale)
 
     return nothing
 end
 
-@kernel function _compute_horizontal_divergence!(δ, ρu′, ρv′, grid)
+# δ = ∇ʰ·(θᴸ𝐦′) at cell centers — the same area-weighted θ-flux divergence the
+# column kernel uses for the (ρθ)′ predictor (`theta_face_{x,y}_flux`), so the
+# damping and the Θ equation see numerically identical divergences (KSH18).
+@kernel function _compute_horizontal_divergence!(δ, ρu′, ρv′, θᴸ, grid)
     i, j, k = @index(Global, NTuple)
-    @inbounds δ[i, j, k] = div_xyᶜᶜᶜ(i, j, k, grid, ρu′, ρv′)
+    @inbounds δ[i, j, k] = (δxᶜᵃᵃ(i, j, k, grid, theta_face_x_flux, θᴸ, ρu′) +
+                            δyᵃᶜᵃ(i, j, k, grid, theta_face_y_flux, θᴸ, ρv′)) /
+                           Vᶜᶜᶜ(i, j, k, grid)
 end
 
 struct NoHorizontalDampingScale end
@@ -1225,21 +1235,23 @@ end
     scale.coefficient * Δyᶜᶠᶜ(i, j, k, grid)^2
 
 
-# Damp the horizontal mass divergence δ as a Laplacian diffusion:
-#   Δ(ρu)′ = γˣ · ∂x δ ,   Δ(ρv)′ = γʸ · ∂y δ ,   γ = α·Δx² (Δτ-independent).
-# δ (`div_xyᶜᶜᶜ`) is precomputed and halo-filled by `apply_divergence_damping!`.
-# The vertical component lives in the column tridiag (a Laplacian on (ρw)′ folded
-# into the implicit acoustic solve), not here.
-@kernel function _thermal_divergence_damping!(ρu′, ρv′, δ, grid,
+# Damp the θ-flux divergence δ = ∇ʰ·(θᴸ𝐦′) per KSH18 eq. (36):
+#   Δ(ρu)′ = γˣ · ∂x δ / θᴸ ,   Δ(ρv)′ = γʸ · ∂y δ / θᴸ ,   γ = α·Δx² (Δτ-independent).
+# δ is precomputed and halo-filled by `apply_divergence_damping!`; the face θᴸ in
+# the denominator matches the θᴸ weighting inside δ (eq. 36 corrects V = ρ𝐯, so
+# the θ used to form the divergence is divided back out). The vertical component
+# lives in the column tridiag (a Laplacian on (ρw)′ folded into the implicit
+# acoustic solve), not here.
+@kernel function _thermal_divergence_damping!(ρu′, ρv′, δ, θᴸ, grid,
                                               x_damping_scale, y_damping_scale)
     i, j, k = @index(Global, NTuple)
 
     @inbounds begin
         γˣ = x_damping_diffusivity(i, j, k, grid, x_damping_scale)
-        ρu′[i, j, k] += γˣ * ∂xᶠᶜᶜ(i, j, k, grid, δ)
+        ρu′[i, j, k] += γˣ * ∂xᶠᶜᶜ(i, j, k, grid, δ) / ℑxᶠᵃᵃ(i, j, k, grid, θᴸ)
 
         γʸ = y_damping_diffusivity(i, j, k, grid, y_damping_scale)
-        ρv′[i, j, k] += γʸ * ∂yᶜᶠᶜ(i, j, k, grid, δ)
+        ρv′[i, j, k] += γʸ * ∂yᶜᶠᶜ(i, j, k, grid, δ) / ℑyᵃᶠᵃ(i, j, k, grid, θᴸ)
     end
 end
 

--- a/test/acoustic_substepping.jl
+++ b/test/acoustic_substepping.jl
@@ -1190,16 +1190,17 @@ for arch in arches
 end
 
 #####
-##### Horizontal divergence damping (Klemp 2018, MPAS form).
+##### Horizontal divergence damping (Klemp, Skamarock & Ha 2018, eq. 36).
 #####
-##### The damper acts on the TRUE horizontal mass divergence δ = ∂x(ρu)′ + ∂y(ρv)′
-##### (terrain-aware `div_xyᶜᶜᶜ`) as a Δτ-independent Laplacian diffusion
-##### Δ(ρu)′ = α·Δx²·∂x δ. It must (1) be dissipative — reduce ‖δ‖ — both with and
-##### without terrain, and (2) use diffusivity α·Δx² with NO 1/Δτ factor (the old
-##### `(ρθ)′`-change proxy with γ = α·Δx²/Δτ injected a spurious ∝α/Δτ force that
-##### blew up the split cold start).
+##### The damper acts on the θ-flux divergence δ = ∂x(θᴸ(ρu)′) + ∂y(θᴸ(ρv)′) — the
+##### acoustic-mode divergence ∇·(ρθ𝐯) (KSH18 eq. 1), numerically identical to the
+##### divergence in the Θ = ρθ equation — as a Δτ-independent momentum correction
+##### Δ(ρu)′ = α·Δx²·∂x δ / θᴸ. It must (1) be dissipative — reduce ‖δ‖ — both with
+##### and without terrain, and (2) use diffusivity α·Δx² with NO 1/Δτ factor (the
+##### old `(ρθ)′`-change proxy with γ = α·Δx²/Δτ injected a spurious ∝α/Δτ force
+##### that blew up the split cold start).
 #####
-@testset "Horizontal divergence damping (true-divergence reformulation)" begin
+@testset "Horizontal divergence damping (θ-flux divergence, KSH18 eq. 36)" begin
     arch = default_arch
     Nx = Ny = 16; Nz = 6
     Lx = Ly = 4000.0; Lz = 3000.0
@@ -1216,22 +1217,26 @@ end
     scale = LocalHorizontalDampingScale(α)
     divergence_norm(δ) = sqrt(sum(interior(δ) .^ 2))
 
-    # (1) dissipative — with and without terrain
+    # (1) dissipative — with and without terrain. A uniform θᴸ isolates the
+    # Laplacian dissipativity (mode gain 1 − γk²); the terrain grid still
+    # exercises the metric/area factors in the θ-flux divergence.
     for (label, grid) in (("flat", flat_grid), ("terrain", terrain_grid))
         @testset "dissipative on the horizontal divergence [$label]" begin
             ρu = XFaceField(grid); ρv = YFaceField(grid); δ = CenterField(grid)
+            θᴸ = CenterField(grid)
+            set!(θᴸ, (x, y, z) -> 300.0); fill_halo_regions!(θᴸ)
             set!(ρu, (x, y, z) -> sin(6π * x / Lx) * cos(2π * y / Ly))
             set!(ρv, (x, y, z) -> cos(2π * x / Lx) * sin(6π * y / Ly))
             fill_halo_regions!(ρu); fill_halo_regions!(ρv)
 
-            launch!(arch, grid, :xyz, _compute_horizontal_divergence!, δ, ρu, ρv, grid)
+            launch!(arch, grid, :xyz, _compute_horizontal_divergence!, δ, ρu, ρv, θᴸ, grid)
             fill_halo_regions!(δ)
             div_before = divergence_norm(δ)
             @test div_before > 0
 
-            launch!(arch, grid, :xyz, _thermal_divergence_damping!, ρu, ρv, δ, grid, scale, scale)
+            launch!(arch, grid, :xyz, _thermal_divergence_damping!, ρu, ρv, δ, θᴸ, grid, scale, scale)
             fill_halo_regions!(ρu); fill_halo_regions!(ρv)
-            launch!(arch, grid, :xyz, _compute_horizontal_divergence!, δ, ρu, ρv, grid)
+            launch!(arch, grid, :xyz, _compute_horizontal_divergence!, δ, ρu, ρv, θᴸ, grid)
             div_after = divergence_norm(δ)
 
             @test div_after < div_before               # the damping reduced the divergence

--- a/test/acoustic_substepping.jl
+++ b/test/acoustic_substepping.jl
@@ -15,6 +15,9 @@ using Breeze.CompressibleEquations: ExplicitTimeStepping, SplitExplicitTimeDiscr
                                     AcousticTridiagLower, AcousticTridiagDiagonal,
                                     AcousticTridiagUpper
 using Breeze.CompressibleEquations: _explicit_horizontal_step!
+using Breeze.CompressibleEquations: _compute_horizontal_divergence!, _thermal_divergence_damping!,
+                                    LocalHorizontalDampingScale, x_damping_diffusivity
+using Breeze.TerrainFollowingDiscretization: TerrainFollowingVerticalDiscretization, materialize_terrain!
 using Breeze.AtmosphereModels: SlowTendencyMode, HorizontalSlowMode,
                                x_pressure_gradient, y_pressure_gradient, z_pressure_gradient,
                                buoyancy_forceᶜᶜᶜ, dynamics_density, thermodynamic_density
@@ -1184,4 +1187,61 @@ for arch in arches
         @test model.dynamics.reference_state === nothing
     end
 
+end
+
+#####
+##### Horizontal divergence damping (Klemp 2018, MPAS form).
+#####
+##### The damper acts on the TRUE horizontal mass divergence δ = ∂x(ρu)′ + ∂y(ρv)′
+##### (terrain-aware `div_xyᶜᶜᶜ`) as a Δτ-independent Laplacian diffusion
+##### Δ(ρu)′ = α·Δx²·∂x δ. It must (1) be dissipative — reduce ‖δ‖ — both with and
+##### without terrain, and (2) use diffusivity α·Δx² with NO 1/Δτ factor (the old
+##### `(ρθ)′`-change proxy with γ = α·Δx²/Δτ injected a spurious ∝α/Δτ force that
+##### blew up the split cold start).
+#####
+@testset "Horizontal divergence damping (true-divergence reformulation)" begin
+    arch = default_arch
+    Nx = Ny = 16; Nz = 6
+    Lx = Ly = 4000.0; Lz = 3000.0
+
+    flat_grid = RectilinearGrid(arch; size = (Nx, Ny, Nz), x = (0, Lx), y = (0, Ly), z = (0, Lz),
+                                halo = (5, 5, 5), topology = (Periodic, Periodic, Bounded))
+
+    z_faces = TerrainFollowingVerticalDiscretization(collect(range(0, Lz, length = Nz + 1)))
+    terrain_grid = RectilinearGrid(arch; size = (Nx, Ny, Nz), x = (0, Lx), y = (0, Ly), z = z_faces,
+                                   halo = (5, 5, 5), topology = (Periodic, Periodic, Bounded))
+    materialize_terrain!(terrain_grid, (x, y) -> 300.0 * sin(2π * x / Lx) * sin(2π * y / Ly))
+
+    α = 0.1
+    scale = LocalHorizontalDampingScale(α)
+    divergence_norm(δ) = sqrt(sum(interior(δ) .^ 2))
+
+    # (1) dissipative — with and without terrain
+    for (label, grid) in (("flat", flat_grid), ("terrain", terrain_grid))
+        @testset "dissipative on the horizontal divergence [$label]" begin
+            ρu = XFaceField(grid); ρv = YFaceField(grid); δ = CenterField(grid)
+            set!(ρu, (x, y, z) -> sin(6π * x / Lx) * cos(2π * y / Ly))
+            set!(ρv, (x, y, z) -> cos(2π * x / Lx) * sin(6π * y / Ly))
+            fill_halo_regions!(ρu); fill_halo_regions!(ρv)
+
+            launch!(arch, grid, :xyz, _compute_horizontal_divergence!, δ, ρu, ρv, grid)
+            fill_halo_regions!(δ)
+            div_before = divergence_norm(δ)
+            @test div_before > 0
+
+            launch!(arch, grid, :xyz, _thermal_divergence_damping!, ρu, ρv, δ, grid, scale, scale)
+            fill_halo_regions!(ρu); fill_halo_regions!(ρv)
+            launch!(arch, grid, :xyz, _compute_horizontal_divergence!, δ, ρu, ρv, grid)
+            div_after = divergence_norm(δ)
+
+            @test div_after < div_before               # the damping reduced the divergence
+            @test all(isfinite, interior(δ))
+        end
+    end
+
+    # (2) diffusivity is α·Δx², independent of Δτ (the fix to the blow-up)
+    @testset "diffusivity is α·Δx² (Δτ-independent)" begin
+        Δx = Lx / Nx
+        @test @allowscalar(x_damping_diffusivity(2, 2, 2, flat_grid, scale)) ≈ α * Δx^2
+    end
 end


### PR DESCRIPTION
Fixes #793.

The Klemp–Skamarock–Ha (2018) horizontal divergence damping (`ThermalDivergenceDamping`) used the `(ρθ)′` tendency `(ρθ)′ − (ρθ)′ˢ⁻` as the divergence proxy, with diffusivity `γ = α·Δx²/Δτ`. On an unbalanced cold start that tendency is O(1) — driven by the hydrostatic/pressure-gradient adjustment, not by divergence — so the `Δτ` stops cancelling and the damper leaves a spurious `∝ α/Δτ` horizontal force that blows up the split-explicit integrator (interior winds far past the flow). Explicit stepping has no divergence damping and stays clean.

**Fix:** compute the acoustic (Θ-equation) divergence directly — `δ = ∇·(θᴸ 𝐦′) = ∂x(θᴸ(ρu)′) + ∂y(θᴸ(ρv)′)`, per KSH18 eq. (36) — and damp it as a Δτ-**independent** Laplacian diffusion `Δ(ρu)′ = α·Δx²·∂x δ / θᴸ`. This is equivalent to the previous scheme for a balanced acoustic wave but dissipative and `1/Δτ`-free for the transient. Two kernels (`_compute_horizontal_divergence!` → halo fill → `_thermal_divergence_damping!`) avoid a read/write race; the damping scratch field is renamed `previous_density_potential_temperature_perturbation` → `horizontal_divergence`. The diffusion-number stability bound (`α ≤ 0.25`) is unchanged.

**Verification:**
- Reproducer from #793 (isothermal rest + horizontal warm patch, Δx ≈ 9 km): split `max|u|` 12.5 → 1.45 ≈ explicit 1.5.
- 3-D ERA5-driven slab (real terrain; from rest and with the jet): split now tracks explicit (`max|u|` 37 vs the previous 97).
- New tests (`test/acoustic_substepping.jl`): the damper reduces `‖∇·(θᴸ𝐦)′‖` on flat **and** terrain-following grids, and the diffusivity is `α·Δx²` (no `1/Δτ`). 7/7 pass.

A separate, smaller top-lid `w`-mode (≈10 vs explicit ≈4) remains — a distinct follow-up, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
