### PR TITLE
Disable LLVM auto-vectorizers in acoustic_wave AD example to fix EnzymeXLA raising

### DIFF
--- a/examples/acoustic_wave.jl
+++ b/examples/acoustic_wave.jl
@@ -258,6 +258,16 @@ using Reactant: @trace
 
 Reactant.set_default_backend("cpu")
 
+# Disable LLVM's auto-vectorizers before any kernels are compiled. Otherwise LLVM
+# packs scalar per-grid-point arithmetic (e.g. `qᵈ Rᵈ + qᵛ Rᵛ`, advection stencils)
+# into `vector<2xf64>` ops, which EnzymeXLA's raise-to-StableHLO pass cannot lower —
+# producing "failed to raise func" errors during differentiated compilation. With the
+# kernels kept scalar, raising succeeds; XLA re-vectorizes across grid points anyway,
+# so the compiled executable is not slowed down. This sets global LLVM state for the
+# session, so prefer a session dedicated to the Reactant/AD workflow.
+# (`Reactant.LLVM` is Reactant's own LLVM dependency — no extra package needed.)
+Reactant.LLVM.clopts("-vectorize-slp=false", "-vectorize-loops=false")
+
 # Rebuild the grid and model on `ReactantState`.
 
 grid_ad = RectilinearGrid(ReactantState(); size = (Nx, Nz),
@@ -371,7 +381,7 @@ du, J = compiled_grad(model_ad, dmodel_ad, uᵢ, duᵢ, ρ_total, ρᵇᵍ, θ�
 xs_u = xnodes(grid_ad, Face())
 zs   = znodes(grid_ad, Center())
 
-@info @sprintf("Surface-mean (ρ - ρ̄)² = %.6e after %d steps", Float64(only(J)), Nsteps)
+@info @sprintf("Surface-mean (ρ - ρ̄)² = %.6e after %d steps", Reactant.to_number(only(J)), Nsteps)
 
 # ### Sensitivity visualization
 #


### PR DESCRIPTION
## Summary

Fixes NumericalEarth/Breeze.jl#796.

The differentiable section of `examples/acoustic_wave.jl` failed to compile with<br>`Reactant.@compile raise=true raise_first=true`. EnzymeXLA's raise-to-StableHLO<br>pass could not lower packed `vector<2xf64>` ops that LLVM produced by<br>auto-vectorizing scalar per-grid-point arithmetic (e.g. the moist-air gas<br>constant `qᵈ Rᵈ + qᵛ Rᵛ`, advection stencils), giving:

```julia
error: cannot raise op to stablehlo
  %6 = "llvm.mlir.constant"() <{value = dense<[461.52998157091315, 287.00250666206421]> : vector<2xf64>}> : () -> vector<2xf64>
failed to raise func: func.func private @"...gpu_compute_potential_temperature_tendency..."
```

## Fix

Disable LLVM's SLP and loop vectorizers before any kernels are compiled, so the<br>kernels stay scalar and the raise pass succeeds:

```julia
Reactant.LLVM.clopts("-vectorize-slp=false", "-vectorize-loops=false")
```

XLA re-vectorizes across grid points downstream, so the compiled executable is<br>not slowed down. `Reactant.LLVM` is Reactant's own LLVM dependency — no new<br>package is required. The flag sets global LLVM state for the session, which is<br>noted in a comment.

Also switches the diagnostic print from `Float64(only(J))` to<br>`Reactant.to_number(only(J))` so it works on the traced scalar result.

## Notes

* Changes are confined to `examples/acoustic_wave.jl`; no source or `Project.toml`<br>dependency changes.

## Test plan

- [X] `include("examples/acoustic_wave.jl")` runs end-to-end: forward simulation,<br>    differentiated compilation, and the gradient/sensitivity output, with no<br>    "failed to raise func" errors.