### PR TITLE
Label Reactant benchmark w/ default backend

### DIFF
--- a/benchmarking/src/metadata.jl
+++ b/benchmarking/src/metadata.jl
@@ -39,6 +39,13 @@ function BenchmarkMetadata(arch)
     elseif arch isa GPU{MetalBackend}
         gpu_name = string(Metal.device().name)
         cuda_version = "unknown"
+    elseif arch isa ReactantState
+        # Non-CUDA Reactant (e.g. TPU): label by the XLA platform ("TPU") so
+        # these results aren't recorded with a `nothing` device.
+        try
+        catch
+            gpu_name = "Reactant"
+        end
     end
 
     # Get CPU model

--- a/benchmarking/src/metadata.jl
+++ b/benchmarking/src/metadata.jl
@@ -43,6 +43,7 @@ function BenchmarkMetadata(arch)
         # Non-CUDA Reactant (e.g. TPU): label by the XLA platform ("TPU") so
         # these results aren't recorded with a `nothing` device.
         try
+            gpu_name = uppercase(Reactant.XLA.platform_name(Reactant.XLA.default_backend()))
         catch
             gpu_name = "Reactant"
         end


### PR DESCRIPTION
Accomodates Enzyme-JAX CI which also runs on TPU.