### PR TITLE
Support adaptive implicit vertical advection with the acoustic substepper (including terrain)

### DIFF
--- a/src/AtmosphereModels/atmosphere_model.jl
+++ b/src/AtmosphereModels/atmosphere_model.jl
@@ -196,18 +196,11 @@ function AtmosphereModel(grid;
     # Adaptive implicit vertical advection is supported for all prognostics with SSPRungeKutta3
     # (per-substep solve) and with AcousticRungeKutta3 (moisture and tracers via the generic
     # implicit step; momentum and the thermodynamic variable via a per-stage solve after the
-    # acoustic substep loop — see TimeSteppers/acoustic_substep_helpers.jl). Terrain-following
-    # dynamics advect vertically with the contravariant velocity, which the implicit split does
-    # not yet incorporate, so they opt out via `supports_implicit_vertical_advection`.
+    # acoustic substep loop — see TimeSteppers/acoustic_substep_helpers.jl). On terrain-following
+    # grids the split partitions the contravariant velocity (see `advecting_vertical_velocity`).
     advection_needs_solver = needs_implicit_solver(momentum_advection) ||
                              needs_implicit_solver(default_scalar_advection) ||
                              any(needs_implicit_solver, values(scalar_advection))
-
-    if advection_needs_solver && !supports_implicit_vertical_advection(dynamics)
-        throw(ArgumentError("Adaptive implicit vertical advection is not supported with " *
-                            "terrain-following (TFVD) dynamics, whose vertical transport uses " *
-                            "the contravariant velocity. Use explicit advection schemes."))
-    end
 
     # Materialize momentum and velocities
     # If velocities is provided (e.g., PrescribedVelocityFields), use it

--- a/src/AtmosphereModels/atmosphere_model.jl
+++ b/src/AtmosphereModels/atmosphere_model.jl
@@ -193,25 +193,20 @@ function AtmosphereModel(grid;
     dynamics = materialize_dynamics(dynamics, grid, regularized_boundary_conditions, thermodynamic_constants, microphysics)
     formulation = materialize_formulation(formulation, dynamics, grid, regularized_boundary_conditions)
 
-    # The acoustic substepper integrates momentum and the thermodynamic density within the acoustic
-    # substep loop (not via the generic implicit step), so adaptive implicit vertical advection is
-    # not supported for either there. (AIVA is supported for moisture and tracers, which the
-    # substepper advances with the generic implicit step; and for all prognostics — momentum and
-    # scalars — under SSPRungeKutta3.)
-    if _timestepper_is_acoustic(timestepper)
-        needs_implicit_solver(momentum_advection) &&
-            throw(ArgumentError("Adaptive implicit vertical advection is not supported for momentum " *
-                                "with the AcousticRungeKutta3 substepper, which advances momentum " *
-                                "within the acoustic substep loop. Use an explicit `momentum_advection`, " *
-                                "or the SSPRungeKutta3 timestepper."))
+    # Adaptive implicit vertical advection is supported for all prognostics with SSPRungeKutta3
+    # (per-substep solve) and with AcousticRungeKutta3 (moisture and tracers via the generic
+    # implicit step; momentum and the thermodynamic variable via a per-stage solve after the
+    # acoustic substep loop — see TimeSteppers/acoustic_substep_helpers.jl). Terrain-following
+    # dynamics advect vertically with the contravariant velocity, which the implicit split does
+    # not yet incorporate, so they opt out via `supports_implicit_vertical_advection`.
+    advection_needs_solver = needs_implicit_solver(momentum_advection) ||
+                             needs_implicit_solver(default_scalar_advection) ||
+                             any(needs_implicit_solver, values(scalar_advection))
 
-        thermo_name = thermodynamic_density_name(formulation)
-        thermo_advection = get(scalar_advection, thermo_name, default_scalar_advection)
-        needs_implicit_solver(thermo_advection) &&
-            throw(ArgumentError("Adaptive implicit vertical advection is not supported for the " *
-                                "thermodynamic variable ($thermo_name) with the AcousticRungeKutta3 " *
-                                "substepper, which integrates it within the acoustic substep loop. " *
-                                "Use an explicit scheme for $thermo_name, or the SSPRungeKutta3 timestepper."))
+    if advection_needs_solver && !supports_implicit_vertical_advection(dynamics)
+        throw(ArgumentError("Adaptive implicit vertical advection is not supported with " *
+                            "terrain-following (TFVD) dynamics, whose vertical transport uses " *
+                            "the contravariant velocity. Use explicit advection schemes."))
     end
 
     # Materialize momentum and velocities
@@ -249,16 +244,13 @@ function AtmosphereModel(grid;
     # Build a vertical tridiagonal solver for adaptive implicit vertical advection even when the
     # closure is explicit. When both are present, the diffusion and advection diagonals are summed
     # into a single system (see implicit_vertical_advection.jl).
-    advection_needs_solver = needs_implicit_solver(momentum_advection) ||
-                             needs_implicit_solver(default_scalar_advection) ||
-                             any(needs_implicit_solver, values(scalar_advection))
     if implicit_solver === nothing && advection_needs_solver
         implicit_solver = implicit_diffusion_solver(VerticallyImplicitTimeDiscretization(), grid)
     end
 
     # Only pass `dynamics` to time steppers that accept it (Breeze's acoustic and SSP steppers).
     # Oceananigans' built-in time steppers (RungeKutta3, QuasiAdamsBashforth2) do not.
-    if _timestepper_uses_dynamics(timestepper)
+    if timestepper_uses_dynamics(timestepper)
         timestepper = TimeStepper(timestepper, grid, prognostic_model_fields; dynamics, implicit_solver, timestepper_kwargs...)
     else
         timestepper = TimeStepper(timestepper, grid, prognostic_model_fields; implicit_solver, timestepper_kwargs...)
@@ -326,15 +318,10 @@ end
 
 # Breeze's acoustic and SSP time steppers accept a `dynamics` keyword;
 # Oceananigans' built-in steppers (RungeKutta3, QuasiAdamsBashforth2) do not.
-_timestepper_uses_dynamics(::Val) = false
-_timestepper_uses_dynamics(::Val{:SSPRungeKutta3}) = true
-_timestepper_uses_dynamics(::Val{:AcousticRungeKutta3}) = true
-_timestepper_uses_dynamics(s::Symbol) = _timestepper_uses_dynamics(Val(s))
-
-# Whether the (pre-materialization) `timestepper` specification selects the acoustic substepper,
-# which integrates the thermodynamic density inside the acoustic substep loop.
-_timestepper_is_acoustic(timestepper::Symbol) = timestepper === :AcousticRungeKutta3
-_timestepper_is_acoustic(timestepper) = nameof(typeof(timestepper)) === :AcousticRungeKutta3
+timestepper_uses_dynamics(::Val) = false
+timestepper_uses_dynamics(::Val{:SSPRungeKutta3}) = true
+timestepper_uses_dynamics(::Val{:AcousticRungeKutta3}) = true
+timestepper_uses_dynamics(s::Symbol) = timestepper_uses_dynamics(Val(s))
 
 function Base.summary(model::AtmosphereModel)
     A = nameof(typeof(model.grid.architecture))

--- a/src/AtmosphereModels/dynamics_interface.jl
+++ b/src/AtmosphereModels/dynamics_interface.jl
@@ -149,6 +149,15 @@ overrides it with a diagnosed total-density field, distinct from the coupling de
 total_density(dynamics) = dynamics_density(dynamics)
 
 """
+    supports_implicit_vertical_advection(dynamics)
+
+Whether `dynamics` supports adaptive implicit vertical advection. Defaults to `true`.
+Terrain-following dynamics opt out: their vertical transport uses the contravariant
+velocity, which the implicit-advection velocity split does not yet incorporate.
+"""
+supports_implicit_vertical_advection(dynamics) = true
+
+"""
     dynamics_pressure(dynamics)
 
 Return the pressure field appropriate to the dynamical formulation.

--- a/src/AtmosphereModels/dynamics_interface.jl
+++ b/src/AtmosphereModels/dynamics_interface.jl
@@ -149,13 +149,16 @@ overrides it with a diagnosed total-density field, distinct from the coupling de
 total_density(dynamics) = dynamics_density(dynamics)
 
 """
-    supports_implicit_vertical_advection(dynamics)
+    advecting_vertical_velocity(dynamics, velocities)
 
-Whether `dynamics` supports adaptive implicit vertical advection. Defaults to `true`.
-Terrain-following dynamics opt out: their vertical transport uses the contravariant
-velocity, which the implicit-advection velocity split does not yet incorporate.
+Return the vertical velocity that advects momentum through the grid's coordinate surfaces:
+the Cartesian `velocities.w` on height-coordinate grids, and the contravariant vertical
+velocity `w̃` on terrain-following grids (mirroring [`advecting_momentum`](@ref), whose
+vertical component is the contravariant momentum). The adaptive-implicit vertical-advection
+split must partition this velocity on both the explicit (flux-scaling) and implicit
+(tridiagonal) sides, so it stays consistent with the momentum flux divergence.
 """
-supports_implicit_vertical_advection(dynamics) = true
+@inline advecting_vertical_velocity(dynamics, velocities) = velocities.w
 
 """
     dynamics_pressure(dynamics)

--- a/src/AtmosphereModels/implicit_vertical_advection.jl
+++ b/src/AtmosphereModels/implicit_vertical_advection.jl
@@ -82,7 +82,9 @@ end
 
 # `ρw` lives at (Center, Center, Face) and needs the Breeze-owned z-Face implicit-advection
 # coefficients below; every other prognostic is at z-Centers and uses Oceananigans' coefficients.
-implicit_step_advection(advection, name::Symbol) =
+# Explicit schemes pass through unwrapped, so their implicit step reduces to diffusion only.
+implicit_step_advection(advection, name::Symbol) = advection
+implicit_step_advection(advection::AIVA, name::Symbol) =
     name === :ρw ? VerticalMomentumImplicitAdvection(advection) : advection
 
 # Density weighting the advective flux of each prognostic. Momentum and the thermodynamic

--- a/src/AtmosphereModels/implicit_vertical_advection.jl
+++ b/src/AtmosphereModels/implicit_vertical_advection.jl
@@ -85,6 +85,17 @@ end
 implicit_step_advection(advection, name::Symbol) =
     name === :ρw ? VerticalMomentumImplicitAdvection(advection) : advection
 
+# Density weighting the advective flux of each prognostic. Momentum and the thermodynamic
+# variable are carried by the coupling density (`ρu = ρᵈ u`, `ρθ = ρᵈ θ`; see `dynamics_density`),
+# while water species and tracers advect as mass fractions of the total density ρ = ρᵈ + Σρˣ
+# (see `scalar_tendency`). The implicit solve must weight its upwind coefficients with the same
+# density the explicit flux divergence uses; on the anelastic core the two densities coincide.
+function implicit_advection_density(dynamics, formulation, name::Symbol)
+    coupling = name === :ρu || name === :ρv || name === :ρw ||
+               name === thermodynamic_density_name(formulation)
+    return coupling ? dynamics_density(dynamics) : total_density(dynamics)
+end
+
 #####
 ##### Explicit vertical momentum fluxes scaled by the velocity CFL
 #####

--- a/src/AtmosphereModels/implicit_vertical_advection.jl
+++ b/src/AtmosphereModels/implicit_vertical_advection.jl
@@ -96,6 +96,14 @@ function implicit_advection_density(dynamics, formulation, name::Symbol)
     return coupling ? dynamics_density(dynamics) : total_density(dynamics)
 end
 
+# Velocities whose vertical component the implicit solve splits — these must match the velocity
+# each prognostic's tendency advects with. Momentum advects with the (possibly contravariant)
+# advecting vertical velocity; every other prognostic advects with `velocities` as given.
+function implicit_advection_velocities(dynamics, velocities, name::Symbol)
+    momentum = name === :ρu || name === :ρv || name === :ρw
+    return momentum ? (; w = advecting_vertical_velocity(dynamics, velocities)) : velocities
+end
+
 #####
 ##### Explicit vertical momentum fluxes scaled by the velocity CFL
 #####
@@ -130,23 +138,26 @@ end
 # velocity-CFL scaling above. Horizontal fluxes dispatch to the fully-explicit methods
 # Oceananigans defines for the adaptive-implicit time discretization.
 @inline function x_momentum_flux_divergence(i, j, k, grid, advection::AIVA, momentum, velocities, dynamics)
+    w = advecting_vertical_velocity(dynamics, velocities)
     return V⁻¹ᶠᶜᶜ(i, j, k, grid) * (δxᶠᵃᵃ(i, j, k, grid, _advective_momentum_flux_Uu, advection, momentum[1], velocities.u) +
                                     δyᵃᶜᵃ(i, j, k, grid, _advective_momentum_flux_Vu, advection, momentum[2], velocities.u) +
-                                    δzᵃᵃᶜ(i, j, k, grid, scaled_momentum_flux_Wu, advection, momentum[3], velocities.u, velocities.w)) +
+                                    δzᵃᵃᶜ(i, j, k, grid, scaled_momentum_flux_Wu, advection, momentum[3], velocities.u, w)) +
            U_dot_∇u_metric(i, j, k, grid, advection, momentum, velocities)
 end
 
 @inline function y_momentum_flux_divergence(i, j, k, grid, advection::AIVA, momentum, velocities, dynamics)
+    w = advecting_vertical_velocity(dynamics, velocities)
     return V⁻¹ᶜᶠᶜ(i, j, k, grid) * (δxᶜᵃᵃ(i, j, k, grid, _advective_momentum_flux_Uv, advection, momentum[1], velocities.v) +
                                     δyᵃᶠᵃ(i, j, k, grid, _advective_momentum_flux_Vv, advection, momentum[2], velocities.v) +
-                                    δzᵃᵃᶜ(i, j, k, grid, scaled_momentum_flux_Wv, advection, momentum[3], velocities.v, velocities.w)) +
+                                    δzᵃᵃᶜ(i, j, k, grid, scaled_momentum_flux_Wv, advection, momentum[3], velocities.v, w)) +
            U_dot_∇v_metric(i, j, k, grid, advection, momentum, velocities)
 end
 
 @inline function z_momentum_flux_divergence(i, j, k, grid, advection::AIVA, momentum, velocities, dynamics)
+    w = advecting_vertical_velocity(dynamics, velocities)
     return V⁻¹ᶜᶜᶠ(i, j, k, grid) * (δxᶜᵃᵃ(i, j, k, grid, _advective_momentum_flux_Uw, advection, momentum[1], velocities.w) +
                                     δyᵃᶜᵃ(i, j, k, grid, _advective_momentum_flux_Vw, advection, momentum[2], velocities.w) +
-                                    δzᵃᵃᶠ(i, j, k, grid, scaled_momentum_flux_Ww, advection, momentum[3], velocities.w)) +
+                                    δzᵃᵃᶠ(i, j, k, grid, scaled_momentum_flux_Ww, advection, momentum[3], w)) +
            U_dot_∇w_metric(i, j, k, grid, advection, momentum, velocities)
 end
 

--- a/src/CompressibleEquations/terrain_compressible_physics.jl
+++ b/src/CompressibleEquations/terrain_compressible_physics.jl
@@ -36,6 +36,10 @@ using Breeze.TerrainFollowingDiscretization: TerrainMetrics, SlopeOutsideInterpo
 const TerrainCompressibleDynamics = CompressibleDynamics{<:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:TerrainMetrics}
 const TerrainCompressibleModel = AtmosphereModel{<:TerrainCompressibleDynamics}
 
+# Vertical transport on terrain-following grids uses the contravariant velocity w̃, which the
+# adaptive-implicit velocity split (and its tridiagonal coefficients) does not yet incorporate.
+AtmosphereModels.supports_implicit_vertical_advection(::TerrainCompressibleDynamics) = false
+
 """
 $(TYPEDEF)
 

--- a/src/CompressibleEquations/terrain_compressible_physics.jl
+++ b/src/CompressibleEquations/terrain_compressible_physics.jl
@@ -36,9 +36,11 @@ using Breeze.TerrainFollowingDiscretization: TerrainMetrics, SlopeOutsideInterpo
 const TerrainCompressibleDynamics = CompressibleDynamics{<:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:TerrainMetrics}
 const TerrainCompressibleModel = AtmosphereModel{<:TerrainCompressibleDynamics}
 
-# Vertical transport on terrain-following grids uses the contravariant velocity w̃, which the
-# adaptive-implicit velocity split (and its tridiagonal coefficients) does not yet incorporate.
-AtmosphereModels.supports_implicit_vertical_advection(::TerrainCompressibleDynamics) = false
+# Vertical transport on terrain-following grids goes through the tilted coordinate surfaces:
+# momentum advects with the contravariant momentum ρw̃ (see `advecting_momentum` below), so the
+# adaptive-implicit vertical-advection split partitions the contravariant velocity w̃.
+@inline AtmosphereModels.advecting_vertical_velocity(dynamics::TerrainCompressibleDynamics, velocities) =
+    dynamics.contravariant_vertical_velocity
 
 """
 $(TYPEDEF)

--- a/src/TimeSteppers/acoustic_runge_kutta_3.jl
+++ b/src/TimeSteppers/acoustic_runge_kutta_3.jl
@@ -144,10 +144,11 @@ function acoustic_rk3_substep!(model::AtmosphereModel, Δt, β)
     # Linearized acoustic substep loop: Nτ substeps of size Δτ = Δt/N.
     acoustic_rk3_substep_loop!(model, substepper, Δt, β, U⁰)
 
-    # Adaptive implicit vertical advection for the acoustic prognostics (momentum and the
-    # thermodynamic variable): apply the implicit remainder of the CFL-split vertical flux
-    # over the stage interval β Δt. A no-op for explicit advection schemes.
-    implicit_advection_substep!(model, β * Δt)
+    # Vertically-implicit solve for the acoustic prognostics (momentum and the thermodynamic
+    # variable) over the stage interval β Δt: the implicit remainder of adaptive implicit
+    # vertical advection combined with vertically-implicit closure diffusion. A no-op when
+    # the timestepper has no implicit solver.
+    implicit_substep!(model, β * Δt)
 
     # Update remaining scalars (tracers) using WS-RK3.
     scalar_rk3_substep!(model, β * Δt)

--- a/src/TimeSteppers/acoustic_runge_kutta_3.jl
+++ b/src/TimeSteppers/acoustic_runge_kutta_3.jl
@@ -144,6 +144,11 @@ function acoustic_rk3_substep!(model::AtmosphereModel, Δt, β)
     # Linearized acoustic substep loop: Nτ substeps of size Δτ = Δt/N.
     acoustic_rk3_substep_loop!(model, substepper, Δt, β, U⁰)
 
+    # Adaptive implicit vertical advection for the acoustic prognostics (momentum and the
+    # thermodynamic variable): apply the implicit remainder of the CFL-split vertical flux
+    # over the stage interval β Δt. A no-op for explicit advection schemes.
+    implicit_advection_substep!(model, β * Δt)
+
     # Update remaining scalars (tracers) using WS-RK3.
     scalar_rk3_substep!(model, β * Δt)
 

--- a/src/TimeSteppers/acoustic_substep_helpers.jl
+++ b/src/TimeSteppers/acoustic_substep_helpers.jl
@@ -12,8 +12,11 @@ using Breeze.AtmosphereModels:
     SlowTendencyMode,
     advecting_momentum,
     dynamics_density,
+    total_density,
+    thermodynamic_density_name,
     transport_velocities,
     field_advection_scheme,
+    implicit_step_advection,
     compute_x_momentum_tendency!,
     compute_y_momentum_tendency!,
     compute_z_momentum_tendency!,
@@ -164,10 +167,12 @@ function scalar_substep!(model, kernel!, Δt_implicit, kernel_args...)
     names = keys(prognostic)
     n_acoustic = 5  # ρ, ρu, ρv, ρw, ρθ are advanced inside the substep loop
 
-    # Reference/prognostic density and the time-averaged transport velocity that the explicit
-    # scalar tendencies (Gⁿ) were built with — adaptive implicit vertical advection must use the
-    # same `w` so the explicit/implicit velocity split is consistent.
-    ρ = dynamics_density(model.dynamics)
+    # Water species and tracers advect as mass fractions of the total density ρ = ρᵈ + Σρˣ
+    # (see `scalar_tendency`), so the implicit solve is weighted with the same density. The
+    # velocities are the time-averaged transport velocities that the explicit scalar tendencies
+    # (Gⁿ) were built with — adaptive implicit vertical advection must use the same `w` so the
+    # explicit/implicit velocity split is consistent.
+    ρ = total_density(model.dynamics)
     velocities = transport_velocities(model)
 
     for (i, (u, u⁰, G)) in enumerate(zip(prognostic, U⁰, Gⁿ))
@@ -200,6 +205,70 @@ function scalar_substep!(model, kernel!, Δt_implicit, kernel_args...)
                            fields(model),
                            Δt_implicit)
         end
+    end
+
+    return nothing
+end
+
+#####
+##### Adaptive implicit vertical advection for the acoustic prognostics
+#####
+
+"""
+$(TYPEDSIGNATURES)
+
+Apply the implicit half of adaptive implicit vertical advection to the prognostics that the
+acoustic substep loop advances: momentum and the thermodynamic variable.
+
+The slow tendencies carry the CFL-limited explicit vertical advective flux (the adaptive-implicit
+time discretization scales it automatically), and the substep loop integrates those tendencies
+over the stage. The implicit remainder is a first-order-upwind tridiagonal solve applied once per
+RK stage after the loop — the operator split WRF and CM1 use for their implicit vertical pieces.
+Continuity takes no implicit solve: the coupling-density tendency is the acoustic mass-flux
+divergence itself, not scalar advection.
+
+The advecting velocity passed to each solve must be the one its slow tendency was built with,
+so the explicit/implicit velocity split is consistent: the RK stage-entry predictor velocities
+(see `compute_slow_momentum_tendencies!` and `compute_slow_scalar_tendencies!`), not the
+substepper's time-averaged transport velocities that moisture and tracers use.
+"""
+function implicit_advection_substep!(model, Δt_stage)
+    # Momentum and the thermodynamic variable are coupling-density-weighted (ρu = ρᵈ u, ρθ = ρᵈ θ).
+    ρᵈ = dynamics_density(model.dynamics)
+    prognostic = prognostic_fields(model)
+
+    # The solves are pure advection (`closure` is `nothing`): vertically-implicit closure
+    # diffusion of the acoustic prognostics is not applied by the substep loop today, with or
+    # without adaptive implicit advection. TODO: thread the closure through these solves (and
+    # add a diffusion-only step for explicit advection schemes) to support vertically-implicit
+    # closures with the acoustic substepper.
+    momentum_advection = model.advection.momentum
+    if needs_implicit_solver(momentum_advection)
+        for name in (:ρu, :ρv, :ρw)
+            implicit_step!(prognostic[name],
+                           model.timestepper.implicit_solver,
+                           nothing, nothing, nothing,
+                           model.clock,
+                           fields(model),
+                           Δt_stage,
+                           implicit_step_advection(momentum_advection, name),
+                           model.velocities,
+                           ρᵈ)
+        end
+    end
+
+    θ_name = thermodynamic_density_name(model.formulation)
+    θ_advection = field_advection_scheme(model.advection, θ_name)
+    if needs_implicit_solver(θ_advection)
+        implicit_step!(prognostic[θ_name],
+                       model.timestepper.implicit_solver,
+                       nothing, nothing, nothing,
+                       model.clock,
+                       fields(model),
+                       Δt_stage,
+                       θ_advection,
+                       slow_thermodynamic_velocities(model),
+                       ρᵈ)
     end
 
     return nothing

--- a/src/TimeSteppers/acoustic_substep_helpers.jl
+++ b/src/TimeSteppers/acoustic_substep_helpers.jl
@@ -11,6 +11,7 @@ using Breeze.AtmosphereModels:
     AtmosphereModel,
     SlowTendencyMode,
     advecting_momentum,
+    advecting_vertical_velocity,
     dynamics_density,
     total_density,
     thermodynamic_density_name,
@@ -242,6 +243,9 @@ function implicit_advection_substep!(model, Δt_stage)
     # without adaptive implicit advection. TODO: thread the closure through these solves (and
     # add a diffusion-only step for explicit advection schemes) to support vertically-implicit
     # closures with the acoustic substepper.
+    # Momentum advects with the (possibly contravariant) advecting vertical velocity — the
+    # same velocity the slow momentum flux divergence splits.
+    w = advecting_vertical_velocity(model.dynamics, model.velocities)
     momentum_advection = model.advection.momentum
     if needs_implicit_solver(momentum_advection)
         for name in (:ρu, :ρv, :ρw)
@@ -252,7 +256,7 @@ function implicit_advection_substep!(model, Δt_stage)
                            fields(model),
                            Δt_stage,
                            implicit_step_advection(momentum_advection, name),
-                           model.velocities,
+                           (; w),
                            ρᵈ)
         end
     end

--- a/src/TimeSteppers/acoustic_substep_helpers.jl
+++ b/src/TimeSteppers/acoustic_substep_helpers.jl
@@ -212,68 +212,73 @@ function scalar_substep!(model, kernel!, Δt_implicit, kernel_args...)
 end
 
 #####
-##### Adaptive implicit vertical advection for the acoustic prognostics
+##### Implicit vertical solve for the acoustic prognostics
 #####
 
 """
 $(TYPEDSIGNATURES)
 
-Apply the implicit half of adaptive implicit vertical advection to the prognostics that the
-acoustic substep loop advances: momentum and the thermodynamic variable.
+Apply the vertically-implicit tridiagonal solve to the prognostics that the acoustic substep
+loop advances: momentum and the thermodynamic variable. Dispatch on the timestepper's
+`implicit_solver` selects the method: `nothing` means nothing in the model is vertically
+implicit and the substep is a no-op.
 
-The slow tendencies carry the CFL-limited explicit vertical advective flux (the adaptive-implicit
-time discretization scales it automatically), and the substep loop integrates those tendencies
-over the stage. The implicit remainder is a first-order-upwind tridiagonal solve applied once per
-RK stage after the loop — the operator split WRF and CM1 use for their implicit vertical pieces.
-Continuity takes no implicit solve: the coupling-density tendency is the acoustic mass-flux
-divergence itself, not scalar advection.
+Each field's solve combines every implicit vertical piece into a single tridiagonal system:
+the first-order-upwind remainder of adaptive implicit vertical advection (whose CFL-limited
+explicit flux the slow tendencies carry through the advection dispatch), plus vertically-implicit
+closure diffusion. Explicit advection schemes contribute no advection coefficients and explicit
+closures no diffusion coefficients, so each combination reduces to the right system. The solve
+runs once per RK stage after the substep loop, over the stage interval — the operator split WRF
+and CM1 use for their implicit vertical pieces. Continuity takes no implicit solve: the
+coupling-density tendency is the acoustic mass-flux divergence itself, not scalar advection.
 
 The advecting velocity passed to each solve must be the one its slow tendency was built with,
 so the explicit/implicit velocity split is consistent: the RK stage-entry predictor velocities
 (see `compute_slow_momentum_tendencies!` and `compute_slow_scalar_tendencies!`), not the
 substepper's time-averaged transport velocities that moisture and tracers use.
 """
-function implicit_advection_substep!(model, Δt_stage)
+implicit_substep!(model, Δt_stage) =
+    implicit_substep!(model, model.timestepper.implicit_solver, Δt_stage)
+
+# No implicit solver ⇒ nothing in the model is vertically implicit.
+implicit_substep!(model, ::Nothing, Δt_stage) = nothing
+
+function implicit_substep!(model, implicit_solver, Δt_stage)
     # Momentum and the thermodynamic variable are coupling-density-weighted (ρu = ρᵈ u, ρθ = ρᵈ θ).
     ρᵈ = dynamics_density(model.dynamics)
     prognostic = prognostic_fields(model)
 
-    # The solves are pure advection (`closure` is `nothing`): vertically-implicit closure
-    # diffusion of the acoustic prognostics is not applied by the substep loop today, with or
-    # without adaptive implicit advection. TODO: thread the closure through these solves (and
-    # add a diffusion-only step for explicit advection schemes) to support vertically-implicit
-    # closures with the acoustic substepper.
     # Momentum advects with the (possibly contravariant) advecting vertical velocity — the
     # same velocity the slow momentum flux divergence splits.
     w = advecting_vertical_velocity(model.dynamics, model.velocities)
     momentum_advection = model.advection.momentum
-    if needs_implicit_solver(momentum_advection)
-        for name in (:ρu, :ρv, :ρw)
-            implicit_step!(prognostic[name],
-                           model.timestepper.implicit_solver,
-                           nothing, nothing, nothing,
-                           model.clock,
-                           fields(model),
-                           Δt_stage,
-                           implicit_step_advection(momentum_advection, name),
-                           (; w),
-                           ρᵈ)
-        end
+    for name in (:ρu, :ρv, :ρw)
+        implicit_step!(prognostic[name],
+                       implicit_solver,
+                       model.closure,
+                       model.closure_fields,
+                       nothing,
+                       model.clock,
+                       fields(model),
+                       Δt_stage,
+                       implicit_step_advection(momentum_advection, name),
+                       (; w),
+                       ρᵈ)
     end
 
     θ_name = thermodynamic_density_name(model.formulation)
     θ_advection = field_advection_scheme(model.advection, θ_name)
-    if needs_implicit_solver(θ_advection)
-        implicit_step!(prognostic[θ_name],
-                       model.timestepper.implicit_solver,
-                       nothing, nothing, nothing,
-                       model.clock,
-                       fields(model),
-                       Δt_stage,
-                       θ_advection,
-                       slow_thermodynamic_velocities(model),
-                       ρᵈ)
-    end
+    implicit_step!(prognostic[θ_name],
+                   implicit_solver,
+                   model.closure,
+                   model.closure_fields,
+                   Val(1),   # the thermodynamic variable leads the closure's scalar names (see `with_tracers`)
+                   model.clock,
+                   fields(model),
+                   Δt_stage,
+                   θ_advection,
+                   slow_thermodynamic_velocities(model),
+                   ρᵈ)
 
     return nothing
 end

--- a/src/TimeSteppers/ssp_runge_kutta_3.jl
+++ b/src/TimeSteppers/ssp_runge_kutta_3.jl
@@ -12,7 +12,8 @@ using Oceananigans.TimeSteppers:
 
 using Breeze.AtmosphereModels: AtmosphereModel, compute_pressure_correction!, make_pressure_correction!,
                                 microphysics_model_update!, field_advection_scheme,
-                                implicit_advection_density, implicit_step_advection
+                                implicit_advection_density, implicit_advection_velocities,
+                                implicit_step_advection
 using Oceananigans.Utils: launch!, time_difference_seconds
 using Oceananigans.TurbulenceClosures: step_closure_prognostics!
 
@@ -145,7 +146,7 @@ function ssp_rk3_substep!(model, Δt, α)
                            fields(model),
                            α * Δt,
                            implicit_step_advection(advection, names[i]),
-                           model.velocities,
+                           implicit_advection_velocities(model.dynamics, model.velocities, names[i]),
                            implicit_advection_density(model.dynamics, model.formulation, names[i]))
         else
             implicit_step!(u,

--- a/src/TimeSteppers/ssp_runge_kutta_3.jl
+++ b/src/TimeSteppers/ssp_runge_kutta_3.jl
@@ -11,8 +11,8 @@ using Oceananigans.TimeSteppers:
     implicit_step!
 
 using Breeze.AtmosphereModels: AtmosphereModel, compute_pressure_correction!, make_pressure_correction!,
-                                microphysics_model_update!, dynamics_density, field_advection_scheme,
-                                implicit_step_advection
+                                microphysics_model_update!, field_advection_scheme,
+                                implicit_advection_density, implicit_step_advection
 using Oceananigans.Utils: launch!, time_difference_seconds
 using Oceananigans.TurbulenceClosures: step_closure_prognostics!
 
@@ -116,8 +116,6 @@ function ssp_rk3_substep!(model, Δt, α)
     Gⁿ = model.timestepper.Gⁿ
     Δt_FT = kernel_time_step(arch, grid, Δt)
 
-    # Reference density and per-field advection schemes for adaptive implicit vertical advection.
-    ρ = dynamics_density(model.dynamics)
     prognostic = prognostic_fields(model)
     names = keys(prognostic)
 
@@ -148,7 +146,7 @@ function ssp_rk3_substep!(model, Δt, α)
                            α * Δt,
                            implicit_step_advection(advection, names[i]),
                            model.velocities,
-                           ρ)
+                           implicit_advection_density(model.dynamics, model.formulation, names[i]))
         else
             implicit_step!(u,
                            model.timestepper.implicit_solver,

--- a/test/implicit_vertical_advection.jl
+++ b/test/implicit_vertical_advection.jl
@@ -187,9 +187,12 @@ import Breeze.AtmosphereModels as AM
         tall_grid = RectilinearGrid(default_arch; size=(8, 8, 32), halo=(5, 5, 5),
                                     x=(0, 4kilometers), y=(0, 4kilometers), z=(0, 2kilometers),
                                     topology=(Periodic, Periodic, Bounded))
+        # The vertically-implicit closure exercises the combined diffusion + advection solve:
+        # both contributions land in the same tridiagonal system for each acoustic prognostic.
         model = AtmosphereModel(tall_grid;
                                 dynamics=CompressibleDynamics(SplitExplicitTimeDiscretization(); reference_potential_temperature=300),
                                 timestepper=:AcousticRungeKutta3,
+                                closure=ScalarDiffusivity(VerticallyImplicitTimeDiscretization(); ν=1, κ=1),
                                 momentum_advection=aiva(), scalar_advection=(; ρθ=aiva()))
 
         ref = model.dynamics.reference_state

--- a/test/implicit_vertical_advection.jl
+++ b/test/implicit_vertical_advection.jl
@@ -207,18 +207,51 @@ import Breeze.AtmosphereModels as AM
         end
     end
 
-    @testset "Rejected with terrain-following dynamics" begin
-        Nz = 8
-        z_faces = TerrainFollowingVerticalDiscretization(collect(range(0, 5000, length=Nz+1)); formulation=LinearDecay())
-        terrain_grid = RectilinearGrid(default_arch; size=(8, Nz), x=(-5000, 5000), z=z_faces,
+    @testset "Terrain-following dynamics (TFVD, acoustic)" begin
+        Nx, Nz = 16, 16
+        Lx, Lz = 10000.0, 4000.0
+        z_faces = TerrainFollowingVerticalDiscretization(collect(range(0, Lz, length=Nz+1)); formulation=LinearDecay())
+        terrain_grid = RectilinearGrid(default_arch; size=(Nx, Nz), halo=(5, 5),
+                                       x=(-Lx/2, Lx/2), z=z_faces,
                                        topology=(Periodic, Flat, Bounded))
         materialize_terrain!(terrain_grid, x -> 200 * exp(-x^2 / 2000^2))
 
-        # Terrain-following vertical transport uses the contravariant velocity, which the
-        # implicit velocity split does not yet incorporate.
-        @test_throws ArgumentError AtmosphereModel(terrain_grid;
-                                                   dynamics=CompressibleDynamics(SplitExplicitTimeDiscretization(); reference_potential_temperature=300),
-                                                   timestepper=:AcousticRungeKutta3,
-                                                   tracers=:ρc, scalar_advection=(; ρc=aiva()))
+        terrain_dynamics() = CompressibleDynamics(SplitExplicitTimeDiscretization(); reference_potential_temperature=300)
+
+        p₀, θ₀, pˢᵗ = 101325.0, 300.0, 100000.0
+        ρᵢ(x, z) = adiabatic_hydrostatic_density(z, p₀, θ₀, pˢᵗ, constants)
+        θᵢ(x, z) = θ₀ + 2 * exp(-(x^2 + (z - 1500)^2) / (2 * 500^2))
+
+        explicit_model = AtmosphereModel(terrain_grid; dynamics=terrain_dynamics(), timestepper=:AcousticRungeKutta3,
+                                         momentum_advection=WENO(FT), scalar_advection=(; ρθ=WENO(FT)))
+        adaptive_model = AtmosphereModel(terrain_grid; dynamics=terrain_dynamics(), timestepper=:AcousticRungeKutta3,
+                                         momentum_advection=aiva(), scalar_advection=(; ρθ=aiva()))
+
+        # On terrain-following grids the adaptive-implicit split partitions the contravariant velocity.
+        @test AM.advecting_vertical_velocity(adaptive_model.dynamics, adaptive_model.velocities) ===
+              adaptive_model.dynamics.contravariant_vertical_velocity
+
+        # Below the CFL threshold the adaptive scheme reproduces the explicit one over terrain too.
+        for model in (explicit_model, adaptive_model)
+            set!(model; ρ=ρᵢ, θ=θᵢ, u=10)
+            for _ in 1:3
+                time_step!(model, 1//2)
+            end
+        end
+        for name in (:ρu, :ρv, :ρw, :ρθ)
+            explicit_field = Array(interior(Oceananigans.fields(explicit_model)[name]))
+            adaptive_field = Array(interior(Oceananigans.fields(adaptive_model)[name]))
+            @test isapprox(explicit_field, adaptive_field; rtol=sqrt(eps(FT)))
+        end
+
+        # Above the explicit vertical advective CFL: re-seed a strong updraft (α ≈ 10 ⋅ 30 / 250 ≈ 1.2)
+        # and take large steps; the acoustic substep count adapts automatically.
+        set!(adaptive_model; w = (x, z) -> 10 * exp(-(z - 1500)^2 / (2 * 400^2)))
+        for _ in 1:3
+            time_step!(adaptive_model, 30)
+        end
+        for name in (:ρu, :ρv, :ρw, :ρθ)
+            @test all(isfinite, Array(interior(Oceananigans.fields(adaptive_model)[name])))
+        end
     end
 end

--- a/test/implicit_vertical_advection.jl
+++ b/test/implicit_vertical_advection.jl
@@ -140,11 +140,11 @@ import Breeze.AtmosphereModels as AM
         cgrid = RectilinearGrid(default_arch; size=(8, 8, 8), halo=(5, 5, 5),
                                 x=(0, 8kilometers), y=(0, 8kilometers), z=(0, 8kilometers),
                                 topology=(Periodic, Periodic, Bounded))
-        cdyn = CompressibleDynamics(SplitExplicitTimeDiscretization(); reference_potential_temperature=300)
+        cdyn() = CompressibleDynamics(SplitExplicitTimeDiscretization(); reference_potential_temperature=300)
 
-        # AIVA on a transport scalar (tracer) is supported with the acoustic substepper: those
-        # scalars are advanced by the generic implicit step (`scalar_substep!`).
-        model = AtmosphereModel(cgrid; dynamics=cdyn, timestepper=:AcousticRungeKutta3,
+        # AIVA on a transport scalar (tracer) with the acoustic substepper: those scalars are
+        # advanced by the generic implicit step (`scalar_substep!`).
+        model = AtmosphereModel(cgrid; dynamics=cdyn(), timestepper=:AcousticRungeKutta3,
                                 tracers=:ρc, scalar_advection=(; ρc=aiva()))
         @test needs_implicit_solver(model.advection.ρc)
         @test model.timestepper.implicit_solver isa BatchedTridiagonalSolver
@@ -158,13 +158,67 @@ import Breeze.AtmosphereModels as AM
         end
         @test all(isfinite, Array(interior(model.tracers.ρc)))
 
-        # AIVA on the thermodynamic variable is rejected with the acoustic substepper, which
-        # integrates it inside the acoustic substep loop rather than the generic implicit step.
-        @test_throws ArgumentError AtmosphereModel(cgrid; dynamics=cdyn, timestepper=:AcousticRungeKutta3,
-                                                   scalar_advection=(; ρθ=aiva()))
+        # Momentum and thermodynamic-variable AIVA with the acoustic substepper: the implicit
+        # remainder is applied once per RK stage after the substep loop
+        # (`implicit_advection_substep!`). Below the CFL threshold the flux scale is 1 and the
+        # implicit velocity is 0, so the adaptive scheme must reproduce the explicit one.
+        θᵢ(x, y, z) = 300 + 2 * exp(-((x-4kilometers)^2 + (y-4kilometers)^2 + (z-4kilometers)^2) / (2*(1kilometers)^2))
 
-        # Likewise for momentum, which the substepper advances within the acoustic loop.
-        @test_throws ArgumentError AtmosphereModel(cgrid; dynamics=cdyn, timestepper=:AcousticRungeKutta3,
-                                                   momentum_advection=aiva())
+        explicit_model = AtmosphereModel(cgrid; dynamics=cdyn(), timestepper=:AcousticRungeKutta3,
+                                         momentum_advection=WENO(FT), scalar_advection=(; ρθ=WENO(FT)))
+        adaptive_model = AtmosphereModel(cgrid; dynamics=cdyn(), timestepper=:AcousticRungeKutta3,
+                                         momentum_advection=aiva(), scalar_advection=(; ρθ=aiva()))
+
+        for model in (explicit_model, adaptive_model)
+            set!(model; θ=θᵢ, ρ=model.dynamics.reference_state.density)
+            for _ in 1:3
+                time_step!(model, 1)
+            end
+        end
+
+        for name in (:ρu, :ρv, :ρw, :ρθ)
+            explicit_field = Array(interior(Oceananigans.fields(explicit_model)[name]))
+            adaptive_field = Array(interior(Oceananigans.fields(adaptive_model)[name]))
+            @test isapprox(explicit_field, adaptive_field; rtol=sqrt(eps(FT)))
+        end
+    end
+
+    @testset "Acoustic substepper is stable above the explicit vertical advective CFL" begin
+        tall_grid = RectilinearGrid(default_arch; size=(8, 8, 32), halo=(5, 5, 5),
+                                    x=(0, 4kilometers), y=(0, 4kilometers), z=(0, 2kilometers),
+                                    topology=(Periodic, Periodic, Bounded))
+        model = AtmosphereModel(tall_grid;
+                                dynamics=CompressibleDynamics(SplitExplicitTimeDiscretization(); reference_potential_temperature=300),
+                                timestepper=:AcousticRungeKutta3,
+                                momentum_advection=aiva(), scalar_advection=(; ρθ=aiva()))
+
+        ref = model.dynamics.reference_state
+        set!(model; θ = (x, y, z) -> 300 + 2 * exp(-((x-2kilometers)^2 + (y-2kilometers)^2 + (z-700)^2) / (2*300^2)),
+                    ρ = ref.density)
+        set!(model; w = (x, y, z) -> 10 * exp(-(z-700)^2 / (2*200^2)))
+
+        # Δt = 10 gives a vertical advective CFL of max|w| Δt / Δz ≈ 10 ⋅ 10 / 62.5 = 1.6; the
+        # acoustic substep count adapts to the acoustic CFL automatically.
+        for _ in 1:5
+            time_step!(model, 10)
+        end
+        for name in (:ρu, :ρv, :ρw, :ρθ)
+            @test all(isfinite, Array(interior(Oceananigans.fields(model)[name])))
+        end
+    end
+
+    @testset "Rejected with terrain-following dynamics" begin
+        Nz = 8
+        z_faces = TerrainFollowingVerticalDiscretization(collect(range(0, 5000, length=Nz+1)); formulation=LinearDecay())
+        terrain_grid = RectilinearGrid(default_arch; size=(8, Nz), x=(-5000, 5000), z=z_faces,
+                                       topology=(Periodic, Flat, Bounded))
+        materialize_terrain!(terrain_grid, x -> 200 * exp(-x^2 / 2000^2))
+
+        # Terrain-following vertical transport uses the contravariant velocity, which the
+        # implicit velocity split does not yet incorporate.
+        @test_throws ArgumentError AtmosphereModel(terrain_grid;
+                                                   dynamics=CompressibleDynamics(SplitExplicitTimeDiscretization(); reference_potential_temperature=300),
+                                                   timestepper=:AcousticRungeKutta3,
+                                                   tracers=:ρc, scalar_advection=(; ρc=aiva()))
     end
 end


### PR DESCRIPTION
## Summary

Follow-up to #809. Momentum and the thermodynamic variable were rejected with `AcousticRungeKutta3` — but the acoustic path is the main use case for adaptive implicit vertical advection (AIVA): in a deep convective updraft the advective `w` CFL binds the RK stage Δt while the acoustic substeps already handle sound waves. This PR removes that restriction, so **AIVA works for all prognostics with the acoustic substepper — including on terrain-following grids** — plus the naming cleanup flagged post-merge.

## How

The acoustic prognostics are advanced inside the substep loop, so they never pass through the generic per-stage `implicit_step!` seam — that was the only obstruction. The fix is the operator split WRF and CM1 use for their implicit vertical pieces:

- The **slow tendencies already carry the CFL-limited explicit vertical flux** (the adaptive-implicit time discretization scales `div_ρUc` and the momentum flux divergences automatically — no new code).
- A new `implicit_substep!` applies the **implicit vertical solve once per RK stage, after the substep loop**, over the stage interval `β Δt`, for `ρu`, `ρv`, `ρw` (z-Face system), and `ρθ`/`ρe`. Continuity takes no solve: the coupling-density tendency is the acoustic mass-flux divergence itself, not scalar advection.

`implicit_substep!` is controlled by dispatch on the timestepper's `implicit_solver` — `nothing` (nothing in the model is vertically implicit) is a no-op method. When the solver exists, each field gets one tridiagonal solve that **combines every implicit vertical piece**: the adaptive-implicit advection remainder plus vertically-implicit closure diffusion. Explicit advection schemes contribute no advection coefficients and explicit closures no diffusion coefficients (`implicit_step_advection` likewise dispatches on the scheme, wrapping only adaptive schemes for the z-Face `ρw` path), so every combination reduces to the right system — the same structure the SSP path and Oceananigans' models use.

Two consistency requirements are threaded through explicitly:

1. **Velocities**: each solve uses the velocity its slow tendency was built with — the RK stage-entry predictor velocities for momentum and θ (matching `compute_slow_momentum_tendencies!` / `compute_slow_scalar_tendencies!`), the substepper's time-averaged transport velocities for moisture and tracers (unchanged). Mixing these is the same feedback hazard documented on `transport_velocities`.
2. **Densities**: momentum and θ are coupling-density-weighted (`ρu = ρᵈ u`, `ρθ = ρᵈ θ`), while water species and tracers advect as mass fractions of the **total** density (see `scalar_tendency`). The new `implicit_advection_density` picks per prognostic. This also fixes a latent inconsistency from #809: the scalar solves passed `dynamics_density` (ρᵈ) where the explicit flux uses total ρ — identical on the anelastic core, wrong for moist compressible dynamics.

## Terrain-following grids are supported

On TFVD grids, vertical transport goes through the tilted coordinate surfaces, so the velocity the split must partition is the contravariant w̃ — and since vertical exchange stays column-local in flux-form terrain coordinates (the tilt lives in the horizontal fluxes and PGF corrections, which stay explicit), the tridiagonal system is unchanged in form and the TFVD grid's per-column `Δz`/`Az`/`V` metrics are already correct.

Two of the three seams were terrain-consistent by construction (the θ solve uses `slow_thermodynamic_velocities` → w̃; the moisture/tracer solves use `transport_velocities`, whose vertical component is the time-averaged contravariant velocity via `transport_ρw`). The remaining gap was momentum, which hardwired Cartesian `velocities.w`. A new dynamics-dispatched accessor closes it:

```julia
advecting_vertical_velocity(dynamics, velocities) = velocities.w                        # height coordinates
advecting_vertical_velocity(dynamics::TerrainCompressibleDynamics, velocities) = dynamics.contravariant_vertical_velocity
```

used by both the explicit flux-scale in the AIVA `x/y/z_momentum_flux_divergence` methods and the momentum implicit solves — mirroring `advecting_momentum`, whose vertical component is the contravariant momentum. No construction guard: AIVA now works on terrain.

## Cleanup

- `_timestepper_is_acoustic` is deleted (its only consumers were the removed rejections).
- `_timestepper_uses_dynamics` → `timestepper_uses_dynamics` — the underscore prefix is reserved for kernel functions.

## Bugfix: vertically-implicit closures now work with the acoustic substepper

Previously, a `VerticallyImplicitTimeDiscretization` closure with `AcousticRungeKutta3` silently **dropped the vertical diffusion of momentum and the thermodynamic variable**: the vi-discretization removes the vertical diffusive flux from the explicit tendency, and no solve ever picked it up (moisture/tracers were covered by `scalar_substep!`). Because `implicit_substep!` gates on the solver — which the constructor builds for vi closures regardless of the advection scheme — and threads `model.closure` through, that diffusion is now applied for every combination of explicit/adaptive advection with explicit/implicit closures.

## Tests

- **Acoustic equivalence**: below the CFL threshold, momentum + ρθ AIVA reproduces the fully-explicit acoustic scheme on `ρu, ρv, ρw, ρθ` to `√eps` (identity solves, unit flux scale).
- **Acoustic stability**: a 10 m/s updraft on Δz = 62.5 m at Δt = 10 s (vertical advective CFL ≈ 1.6) time-steps stably with AIVA momentum + ρθ and a vertically-implicit closure (exercising the combined diffusion + advection solve); the acoustic substep count adapts automatically.
- **Terrain (TFVD, acoustic)**: the accessor wiring is pinned (`advecting_vertical_velocity === contravariant_vertical_velocity`); below the CFL threshold AIVA reproduces the explicit scheme over a 200 m bump with 10 m/s flow; a re-seeded 10 m/s updraft at vertical advective CFL ≈ 1.2 time-steps stably.
- Existing anelastic SSP-RK3 and acoustic tracer-AIVA tests unchanged and passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
