### PR TITLE
[CI] Temporarily sidestep PkgServer

### DIFF
--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -22,6 +22,7 @@ env:
   # Don't make Reactant occupy all the GPU memory
   XLA_REACTANT_GPU_PREALLOCATE: 'false'
   JULIA_PKG_SERVER_REGISTRY_PREFERENCE: 'eager'
+  JULIA_PKG_SERVER: ''
 
 jobs:
   run-benchmarks:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,6 +29,7 @@ env:
   # Don't make Reactant occupy all the GPU memory
   XLA_REACTANT_GPU_PREALLOCATE: 'false'
   JULIA_PKG_SERVER_REGISTRY_PREFERENCE: 'eager'
+  JULIA_PKG_SERVER: ''
 
 jobs:
   test:

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -28,6 +28,7 @@ env:
   JULIA_PKG_SERVER_REGISTRY_PREFERENCE: 'eager'
   # Silence most messages coming from XLA
   TF_CPP_MIN_LOG_LEVEL: '3'
+  JULIA_PKG_SERVER: ''
 
 jobs:
   build-docs:

--- a/.github/workflows/Validation.yml
+++ b/.github/workflows/Validation.yml
@@ -29,6 +29,7 @@ permissions:
 
 env:
   JULIA_PKG_SERVER_REGISTRY_PREFERENCE: 'eager'
+  JULIA_PKG_SERVER: ''
 
 jobs:
   validate:


### PR DESCRIPTION
There's currently an outage in PkgServer, which backtracked to using an older version of the registry.  By setting   `JULIA_PKG_SERVER=''` we avoid using the PkgServer entirely (which however has other downsides, so shouldn't be a permanent solution).