### PR TITLE
Fix specific-keyed Relaxation forcings under Oceananigans ≥ 0.110.7: materialize SpecificForcing's inner forcing against the specific field

### DIFF
--- a/src/Forcings/specific_forcing.jl
+++ b/src/Forcings/specific_forcing.jl
@@ -86,14 +86,7 @@ function AtmosphereModels.materialize_atmosphere_model_forcing(forcing::Specific
     # name to look up the field they advect or apply at.
     specific_name = startswith(string(name), "ρ") ?
                     Symbol(string(name)[nextind(string(name), 1):end]) : name
-    # Materialize the inner forcing against the *specific* field, not the ρ-weighted
-    # prognostic: forcing types that capture the forced field at materialization
-    # (Oceananigans ≥ v0.110.7 `Relaxation`) must relax the specific variable the
-    # forcing is keyed on, or a fringe relaxation of u computes rate·(u_target − ρu).
-    # The specific diagnostic fields (u, v, w, θ/e, moisture) are refreshed in place
-    # by `update_state!`, so the captured reference stays live; they share the
-    # prognostic's location, so location-only consumers are unaffected. Prognostics
-    # without a specific diagnostic (user tracers) fall back to the prognostic field.
+    # Materialize the inner forcing against the *specific* field, not the ρ-weighted prognostic.
     specific_field = get(context.specific_fields, specific_name, field)
     inner = materialize_atmosphere_model_forcing(forcing.forcing, specific_field, specific_name,
                                                  model_field_names, context)

--- a/src/Forcings/specific_forcing.jl
+++ b/src/Forcings/specific_forcing.jl
@@ -86,7 +86,16 @@ function AtmosphereModels.materialize_atmosphere_model_forcing(forcing::Specific
     # name to look up the field they advect or apply at.
     specific_name = startswith(string(name), "ρ") ?
                     Symbol(string(name)[nextind(string(name), 1):end]) : name
-    inner = materialize_atmosphere_model_forcing(forcing.forcing, field, specific_name,
+    # Materialize the inner forcing against the *specific* field, not the ρ-weighted
+    # prognostic: forcing types that capture the forced field at materialization
+    # (Oceananigans ≥ v0.110.7 `Relaxation`) must relax the specific variable the
+    # forcing is keyed on, or a fringe relaxation of u computes rate·(u_target − ρu).
+    # The specific diagnostic fields (u, v, w, θ/e, moisture) are refreshed in place
+    # by `update_state!`, so the captured reference stays live; they share the
+    # prognostic's location, so location-only consumers are unaffected. Prognostics
+    # without a specific diagnostic (user tracers) fall back to the prognostic field.
+    specific_field = get(context.specific_fields, specific_name, field)
+    inner = materialize_atmosphere_model_forcing(forcing.forcing, specific_field, specific_name,
                                                  model_field_names, context)
     ρ = context.density
     target_location = instantiated_location(field)

--- a/test/specific_forcing.jl
+++ b/test/specific_forcing.jl
@@ -193,7 +193,7 @@ end
     ρᵣ = model.dynamics.reference_state.density
     θ = model.formulation.potential_temperature
     expected = ρᵣ * rate * (θ_target - θ)
-    @test maximum(abs(Gρθ - expected)) ≈ 0 atol = 100 * eps(FT) * maximum(abs(expected))
+    @test Gρθ ≈ expected rtol=100 * eps(FT)
 
     # Face path: u relaxation. ρᵣ varies only in z, so its x-Face interpolation equals
     # the Center value and Gρu = ρᵣ · rate · (u_target − u).
@@ -205,7 +205,7 @@ end
 
     Gρu = model.timestepper.Gⁿ.ρu
     expected_u = ρᵣ * rate * (u_target - u₀)
-    @test maximum(abs(Gρu - expected_u)) ≈ 0 atol = 100 * eps(FT) * maximum(abs(expected_u))
+    @test Gρu ≈ expected_u rtol=100 * eps(FT)
 end
 
 #####

--- a/test/specific_forcing.jl
+++ b/test/specific_forcing.jl
@@ -189,11 +189,11 @@ end
     set!(model; θ=θ₀)
     update_state!(model)
 
-    Gρθ = interior(model.timestepper.Gⁿ.ρθ) |> Array
-    ρᵣ = interior(model.dynamics.reference_state.density) |> Array
-    θ = interior(model.formulation.potential_temperature) |> Array
-    expected = ρᵣ .* rate .* (θ_target .- θ)
-    @test maximum(abs.(Gρθ .- expected)) < 100 * eps(FT) * maximum(abs.(expected))
+    Gρθ = model.timestepper.Gⁿ.ρθ
+    ρᵣ = model.dynamics.reference_state.density
+    θ = model.formulation.potential_temperature
+    expected = ρᵣ * rate * (θ_target - θ)
+    @test maximum(abs(Gρθ - expected)) ≈ 0 atol = 100 * eps(FT) * maximum(abs(expected))
 
     # Face path: u relaxation. ρᵣ varies only in z, so its x-Face interpolation equals
     # the Center value and Gρu = ρᵣ · rate · (u_target − u).
@@ -203,9 +203,9 @@ end
     set!(model; θ=θ₀, u=u₀)
     update_state!(model)
 
-    Gρu = interior(model.timestepper.Gⁿ.ρu) |> Array
-    expected_u = ρᵣ .* rate .* (u_target - u₀)
-    @test maximum(abs.(Gρu .- expected_u)) < 100 * eps(FT) * maximum(abs.(expected_u))
+    Gρu = model.timestepper.Gⁿ.ρu
+    expected_u = ρᵣ * rate * (u_target - u₀)
+    @test maximum(abs(Gρu - expected_u)) ≈ 0 atol = 100 * eps(FT) * maximum(abs(expected_u))
 end
 
 #####

--- a/test/specific_forcing.jl
+++ b/test/specific_forcing.jl
@@ -2,7 +2,7 @@ using Breeze
 using Breeze: SpecificForcing
 using Breeze.AtmosphereModels: is_density_tendency_forcing
 using Oceananigans: Oceananigans, prognostic_fields
-using Oceananigans.Forcings: MultipleForcings
+using Oceananigans.Forcings: MultipleForcings, Relaxation
 using Oceananigans.Fields: interior
 using Oceananigans.TimeSteppers: update_state!
 using Test
@@ -167,6 +167,45 @@ end
     ρᵣ = interior(model.dynamics.reference_state.density) |> Array
     expected = ρᵣ .* F_θ_specific .+ F_ρθ_density
     @test maximum(abs.(Gρθ .- expected)) < eps(FT) * 100
+end
+
+@testset "Specific-keyed Relaxation relaxes the specific variable [$(FT)]" for FT in test_float_types()
+    # Regression test for the Oceananigans ≥ v0.110.7 Relaxation rework (Oceananigans
+    # #5620): `materialize_forcing(::Relaxation, field, name, …)` now captures `field`
+    # as the relaxed variable instead of binding `name`. SpecificForcing must therefore
+    # materialize its inner forcing against the *specific* field — otherwise a
+    # specific-keyed relaxation (e.g. a Davies fringe on θ) computes
+    # rate·(θ_target − ρθ) instead of rate·(θ_target − θ).
+    Oceananigans.defaults.FloatType = FT
+    grid = RectilinearGrid(default_arch; size=(4, 4, 4), x=(0, 100), y=(0, 100), z=(0, 100))
+
+    rate = FT(1/100)
+
+    # Center path: θ relaxation. With uniform θ and zero velocity the tendency is
+    # forcing-only, so Gρθ = ρᵣ · rate · (θ_target − θ).
+    θ_target = FT(310)
+    model = AtmosphereModel(grid; forcing=(; θ=Relaxation(; rate, target=θ_target)))
+    θ₀ = model.dynamics.reference_state.potential_temperature
+    set!(model; θ=θ₀)
+    update_state!(model)
+
+    Gρθ = interior(model.timestepper.Gⁿ.ρθ) |> Array
+    ρᵣ = interior(model.dynamics.reference_state.density) |> Array
+    θ = interior(model.formulation.potential_temperature) |> Array
+    expected = ρᵣ .* rate .* (θ_target .- θ)
+    @test maximum(abs.(Gρθ .- expected)) < 100 * eps(FT) * maximum(abs.(expected))
+
+    # Face path: u relaxation. ρᵣ varies only in z, so its x-Face interpolation equals
+    # the Center value and Gρu = ρᵣ · rate · (u_target − u).
+    u_target = FT(10)
+    u₀ = FT(2)
+    model = AtmosphereModel(grid; forcing=(; u=Relaxation(; rate, target=u_target)))
+    set!(model; θ=θ₀, u=u₀)
+    update_state!(model)
+
+    Gρu = interior(model.timestepper.Gⁿ.ρu) |> Array
+    expected_u = ρᵣ .* rate .* (u_target - u₀)
+    @test maximum(abs.(Gρu .- expected_u)) < 100 * eps(FT) * maximum(abs.(expected_u))
 end
 
 #####


### PR DESCRIPTION
## Summary

Oceananigans v0.110.7 ([CliMA/Oceananigans.jl#5620](https://github.com/CliMA/Oceananigans.jl/pull/5620)) reworked `Relaxation` so that `materialize_forcing(::Relaxation, field, field_name, …)` **captures `field` as the relaxed variable** instead of binding `field_name` (which previously routed through `ContinuousForcing(…, field_dependencies=field_name)`).

`SpecificForcing` materializes its inner forcing with the **ρ-weighted prognostic** and only the **specific name**. That pairing was correct under the old name-based binding, but under the new field-capture binding — and Breeze main's compat is already `Oceananigans = "0.110.8"` — every specific-keyed `Relaxation` silently relaxes the prognostic instead of the specific variable:

- `forcing = (; u = Relaxation(rate, mask, target))` computes `rate·mask·(u_target − ρu)` — an O((ρ−1)·u) ≈ 15 % velocity-scale spurious force;
- a θ fringe computes `(θ_target − ρθ) ≈ −45 K` at standard surface density — a large fictitious cooling wherever the mask is active, on **both** the explicit and split-explicit paths.

In a compressible open-boundary vortex validation case with a 5-cell Davies fringe on u/v/θ, this drives `max|w|` from 5×10⁻⁴-class to >150 m/s within 30 s of model time; the failure bisects exactly to the Oceananigans 0.110.6 → 0.110.7 boundary and disappears with the fringe disabled (trajectories then bit-identical across versions).

## Fix

Materialize the inner forcing against `context.specific_fields[specific_name]` — the same pattern `SubsidenceForcing` already uses (`src/Forcings/subsidence_forcing.jl:127`) — falling back to the prognostic for names with no specific diagnostic (user tracers). The specific fields (`u`, `v`, `w`, `θ`/`e`, moisture) are refreshed in place by `update_state!`, so the captured reference stays live; they share the prognostic's staggered location, so location-only consumers are unaffected. On Oceananigans ≤ 0.110.6 (name-based binding) the change is a verified no-op.

## Verification

- **New regression test** (`test/specific_forcing.jl`): a specific-keyed `Relaxation` must produce `Gρϕ = ρ·rate·(target − ϕ)` on both the Center (θ) and Face (u) paths. On Oceananigans 0.110.8 it **fails before** this change (θ residual 0.77 = rate·(ρ−1)·θ-scale; u residual 5.4×10⁻³) and **passes after**.
- Full `test/specific_forcing.jl` and `test/geostrophic_subsidence_forcings.jl` pass with the change (CPU, Float64).
- Integration: the vortex case above, run on Oceananigans 0.110.8 with this fix, recovers the clean 0.110.6 trajectory (`max|w|` 5.2497 vs 5.2498, matching to 0.002 %; unfixed: 161.7).
- No-op check: the same case on Oceananigans 0.110.6 with this fix reproduces the unfixed 0.110.6 result exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)