### PR TITLE
[docs] Remove flaky URL

### DIFF
--- a/docs/src/breeze.bib
+++ b/docs/src/breeze.bib
@@ -116,7 +116,6 @@
   number={11},
   pages={4393--4421},
   doi={10.1175/MWR-D-14-00319.1},
-  url={https://journals.ametsoc.org/view/journals/mwre/143/11/mwr-d-14-00319.1.xml}
 }
 
 @article{Maxwell2020,


### PR DESCRIPTION
I've seen this URL [failing linkcheck](https://github.com/NumericalEarth/Breeze.jl/actions/runs/28840283259/job/85532709658#step:10:92) a few times already
```
┌ Error: `curl -sI --proto =http,https,ftp,ftps -g -H 'accept-encoding: gzip, deflate, br' --user-agent 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36' https://journals.ametsoc.org/view/journals/mwre/143/11/mwr-d-14-00319.1.xml --max-time 10 -o /dev/null --write-out '%{http_code} %{url_effective} %{redirect_url}'` failed:
│   exception =
│    failed process: Process(`curl -sI --proto =http,https,ftp,ftps -g -H 'accept-encoding: gzip, deflate, br' --user-agent 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36' https://journals.ametsoc.org/view/journals/mwre/143/11/mwr-d-14-00319.1.xml --max-time 10 -o /dev/null --write-out '%{http_code} %{url_effective} %{redirect_url}'`, ProcessExited(28)) [28]
│    
└ @ Documenter /usr/local/share/julia/packages/Documenter/AXNMp/src/utilities/utilities.jl:47
```
I think this is at least redundant, because we have the DOI already which points to the same page, so let's reduce the opportunities for failure.