### PR TITLE
[CI] Always run docs jobs, and internally filter based on files

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,7 +40,6 @@ jobs:
         with:
           filters: |
             docfiles:
-              - ".github/workflows/CI.yml"
               - "ext/**"
               - "src/**"
               - "test/**"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,14 +4,7 @@ on:
   push:
     branches:
       - "main"
-    paths: &paths
-      - ".github/workflows/CI.yml"
-      - "ext/**"
-      - "src/**"
-      - "test/**"
-      - "Project.toml"
   pull_request:
-    paths: *paths
   workflow_dispatch:
 
 concurrency:
@@ -31,7 +24,31 @@ env:
   JULIA_PKG_SERVER_REGISTRY_PREFERENCE: 'eager'
 
 jobs:
+  check-files:
+    name: Check for modified files
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      files: ${{ steps.filter.outputs.files }}
+    steps:
+      - name: "Check out repository"
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        id: filter
+        with:
+          filters: |
+            docfiles:
+              - ".github/workflows/CI.yml"
+              - "ext/**"
+              - "src/**"
+              - "test/**"
+              - "Project.toml"
+
   test:
+    needs: check-files
+    if: ${{ needs.check-files.outputs.files == 'true' }}
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - check-bounds ${{ matrix.check-bounds }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 75
@@ -84,7 +101,7 @@ jobs:
         run: |
           df -hT
       - name: "Check out repository"
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: "Install Julia"
         uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3.0.2
         # On the self-hosted GPU runners we use a Docker image with Julia pre-installed.

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,7 +4,14 @@ on:
   push:
     branches:
       - "main"
+    paths: &paths
+      - ".github/workflows/CI.yml"
+      - "ext/**"
+      - "src/**"
+      - "test/**"
+      - "Project.toml"
   pull_request:
+    paths: *paths
   workflow_dispatch:
 
 concurrency:
@@ -24,30 +31,7 @@ env:
   JULIA_PKG_SERVER_REGISTRY_PREFERENCE: 'eager'
 
 jobs:
-  check-files:
-    name: Check for modified files
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    outputs:
-      files: ${{ steps.filter.outputs.files }}
-    steps:
-      - name: "Check out repository"
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
-        id: filter
-        with:
-          filters: |
-            docfiles:
-              - "ext/**"
-              - "src/**"
-              - "test/**"
-              - "Project.toml"
-
   test:
-    needs: check-files
-    if: ${{ needs.check-files.outputs.files == 'true' }}
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - check-bounds ${{ matrix.check-bounds }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 75
@@ -100,7 +84,7 @@ jobs:
         run: |
           df -hT
       - name: "Check out repository"
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: "Install Julia"
         uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3.0.2
         # On the self-hosted GPU runners we use a Docker image with Julia pre-installed.

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -38,7 +38,6 @@ jobs:
         with:
           filters: |
             files:
-              - ".github/workflows/Documentation.yml"
               - "docs/**"
               - "examples/**"
               - "src/**"

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           filters: |
             files:
+              - ".github/workflows/Documentation.yml"
               - "docs/**"
               - "examples/**"
               - "src/**"

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -5,15 +5,7 @@ on:
     branches:
       - main
     tags: "*"
-    paths: &paths
-      - ".github/workflows/Documentation.yml"
-      - "docs/**"
-      - "examples/**"
-      - "src/**"
-      - "Project.toml"
-      - "CHANGELOG.md"
   pull_request:
-    paths: *paths
 
 concurrency:
   # Skip intermediate builds: always.
@@ -30,7 +22,31 @@ env:
   TF_CPP_MIN_LOG_LEVEL: '3'
 
 jobs:
+  check-files:
+    name: Check for modified files
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      files: ${{ steps.filter.outputs.files }}
+    steps:
+      - name: "Check out repository"
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        id: filter
+        with:
+          filters: |
+            files:
+              - ".github/workflows/Documentation.yml"
+              - "docs/**"
+              - "examples/**"
+              - "src/**"
+              - "Project.toml"
+
   build-docs:
+    needs: check-files
+    if: ${{ needs.check-files.outputs.files == 'true' }}
     permissions:
       actions: write
       contents: write
@@ -56,7 +72,7 @@ jobs:
         run: |
           df -hT
       - name: "Check out repository"
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set BREEZE_BUILD_ALL_EXAMPLES
         shell: bash
         run: |


### PR DESCRIPTION
This works around GitHub's limitation that required jobs are _**always**_
required to run, even when they should be skipped.  With this strategy the jobs
are always started, but we only actually run the tests/build the docs if needed,
based on the modified files.