### PR TITLE
[test] Split Reactant WENO compilation tests into multiple files

### DIFF
--- a/test/reactant/weno5.jl
+++ b/test/reactant/weno5.jl
@@ -1,0 +1,3 @@
+include("weno_compilation_setup.jl")
+
+run_weno_tests("WENO(order=5)", WENO(order=5))

--- a/test/reactant/weno5_bounds01.jl
+++ b/test/reactant/weno5_bounds01.jl
@@ -1,0 +1,3 @@
+include("weno_compilation_setup.jl")
+
+run_weno_tests("WENO(order=5, bounds=(0,1))", WENO(order=5, bounds=(0, 1)))

--- a/test/reactant/weno_compilation_setup.jl
+++ b/test/reactant/weno_compilation_setup.jl
@@ -38,11 +38,6 @@ topologies = [
     ("Bounded, Bounded, Bounded",   (Bounded, Bounded, Bounded), 3),
 ]
 
-schemes = [
-    ("WENO(order=5)",               WENO(order=5)),
-    ("WENO(order=5, bounds=(0,1))", WENO(order=5, bounds=(0, 1))),
-]
-
 #####
 ##### Helpers
 #####
@@ -92,10 +87,10 @@ end
 ##### Tests
 #####
 
-@testset "reactant_weno_compilation" begin
-    Δt = 0.02
+function run_weno_tests(scheme_label, scheme)
+    @testset "reactant_weno_compilation - $scheme_label" begin
+        Δt = 0.02
 
-    @testset "$scheme_label" for (scheme_label, scheme) in schemes
         @testset "$label" for (label, topo, nd) in topologies
             grid = make_grid(topo, nd)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,9 @@ args = parse_args(ARGS)
 
 const REACTANT_COMPAT = VERSION < v"1.13-" && Base.JLOptions().check_bounds != 1
 
+# This isn't a test file, it's only used as a setup for other files.
+delete!(testsuite, "reactant/weno_compilation_setup")
+
 if filter_tests!(testsuite, args)
     # Reactant compilation tests require --check-bounds=auto (Reactant/Enzyme
     # limitation).


### PR DESCRIPTION
I noticed that #836 added 15-20 minutes to the test run time just because the Reactant WENO compilation test now takes longer.  Let's see if splitting it into multiple files helps anything.