### PR TITLE
Default BackgroundAtmosphere ozone to a standard climatological profile

### DIFF
--- a/src/AtmosphereModels/AtmosphereModels.jl
+++ b/src/AtmosphereModels/AtmosphereModels.jl
@@ -66,6 +66,7 @@ export
     # Radiation (implemented by extensions)
     RadiativeTransferModel,
     BackgroundAtmosphere,
+    standard_ozone_profile,
     materialize_background_atmosphere,
     GrayOptics,
     ClearSkyOptics,

--- a/src/AtmosphereModels/radiation_interface.jl
+++ b/src/AtmosphereModels/radiation_interface.jl
@@ -231,6 +231,23 @@ end
 """
 $(TYPEDSIGNATURES)
 
+An idealized climatological ozone volume mixing ratio (mol/mol) as a function of height
+`z` (m): a weak tropospheric background increasing toward the tropopause, blended into a
+Gaussian stratospheric layer peaking near 25 km. Keeps the stratospheric column near
+radiative balance in deep-column simulations — without ozone the upper column is far from
+radiative equilibrium and destabilizes when the spectral fluxes recompute. Not a substitute
+for an observed or model ozone climatology.
+"""
+@inline function standard_ozone_profile(z)
+    troposphere_O₃  = 3e-8 * (1 + 0.5 * z / 1e3)
+    stratosphere_O₃ = 8e-6 * exp(-((z - 25e3) / 5e3)^2)
+    χˢᵗ = 1 / (1 + exp(-(z - 15e3) / 2))
+    return troposphere_O₃ * (1 - χˢᵗ) + stratosphere_O₃ * χˢᵗ
+end
+
+"""
+$(TYPEDSIGNATURES)
+
 Construct a `BackgroundAtmosphere` with volume mixing ratios for radiatively active gases.
 All values are dimensionless molar fractions.
 
@@ -245,7 +262,8 @@ RRTMGP supports spatially-varying VMR only for H₂O and O₃. Other gases use g
 - Hydrofluorocarbons: `HFC₁₂₅`, `HFC₁₃₄ₐ`, `HFC₁₄₃ₐ`, `HFC₂₃`, `HFC₃₂`
 - Spatially-varying: `O₃` (can be Number or Function)
 
-Defaults are approximate modern atmospheric values; halocarbons default to zero.
+Defaults are approximate modern atmospheric values; halocarbons default to zero, and ozone
+defaults to [`standard_ozone_profile`](@ref) (pass `O₃ = 0` for an ozone-free atmosphere).
 Note: H₂O is computed from the model's prognostic moisture field.
 
 # Example
@@ -254,12 +272,13 @@ Note: H₂O is computed from the model's prognostic moisture field.
 julia> using Breeze
 
 julia> background = BackgroundAtmosphere(CO₂ = 400e-6)
-BackgroundAtmosphere with 5 active gases:
+BackgroundAtmosphere with 6 active gases:
   N₂ = 0.78084
   O₂ = 0.20946
   CO₂ = 400.0 ppm
   CH₄ = 1.8 ppm
   N₂O = 330.0 ppb
+  O₃ = standard_ozone_profile (generic function with 1 method)
 
 julia> tropical_ozone(z) = 30e-9 * (1 + z / 10000);
 
@@ -280,7 +299,7 @@ function BackgroundAtmosphere(; N₂  = 0.78084,      # Nitrogen (~78%)
                                 N₂O = 330e-9,       # Nitrous oxide (~330 ppb)
                                 CO  = 0.0,          # Carbon monoxide
                                 NO₂ = 0.0,          # Nitrogen dioxide
-                                O₃  = 0.0,          # Ozone (can be profile function)
+                                O₃  = standard_ozone_profile,   # Ozone (Number or profile function; 0 disables)
                                 CFC₁₁ = 0.0,        # Trichlorofluoromethane
                                 CFC₁₂ = 0.0,        # Dichlorodifluoromethane
                                 CFC₂₂ = 0.0,        # Chlorodifluoromethane

--- a/src/Breeze.jl
+++ b/src/Breeze.jl
@@ -45,6 +45,7 @@ export
     LiquidIcePotentialTemperatureFormulation,
     RadiativeTransferModel,
     BackgroundAtmosphere,
+    standard_ozone_profile,
     GrayOptics,
     ClearSkyOptics,
     AllSkyOptics,

--- a/test/unit_tests.jl
+++ b/test/unit_tests.jl
@@ -537,7 +537,7 @@ using Breeze.AtmosphereModels: BackgroundAtmosphere,
         @test atm.CO₂ ≈ 420e-6
         @test atm.CH₄ ≈ 1.8e-6
         @test atm.N₂O ≈ 330e-9
-        @test atm.O₃ == 0.0
+        @test atm.O₃ === Breeze.standard_ozone_profile
         @test atm.CFC₁₁ == 0.0
     end
 

--- a/test/unit_tests.jl
+++ b/test/unit_tests.jl
@@ -548,6 +548,14 @@ using Breeze.AtmosphereModels: BackgroundAtmosphere,
         @test atm.N₂ ≈ 0.78084  # default preserved
     end
 
+    @testset "standard_ozone_profile" begin
+        O₃ = Breeze.standard_ozone_profile
+        @test O₃(0) ≈ 3e-8 rtol=1e-3           # tropospheric background at the surface
+        @test O₃(25e3) ≈ 8e-6 rtol=1e-3        # stratospheric peak
+        @test O₃(50e3) < O₃(25e3)              # decays above the peak
+        @test all(z -> O₃(z) > 0, 0:1e3:60e3)
+    end
+
     @testset "Function-based O₃" begin
         ozone(z) = 30e-9 * (1 + z / 10000)
         atm = BackgroundAtmosphere(O₃ = ozone)


### PR DESCRIPTION
## Summary

`BackgroundAtmosphere()` defaults to `O₃ = 0`. Without ozone a deep column sits far from stratospheric radiative equilibrium, and the upper levels destabilize when the spectral fluxes recompute — which is why the slab-land example (and downstream configurations in NumericalEarth.jl) all hand-roll the same analytic ozone profile.

This PR promotes that profile to a documented, exported `standard_ozone_profile(z)` (weak tropospheric background blended into a Gaussian stratospheric layer peaking near 25 km) and makes it the `BackgroundAtmosphere` default.

## Behavior change

Configurations relying on the implicit ozone-free default now get climatological ozone; pass `O₃ = 0` explicitly to recover the old behavior. Deliberately loud-by-default: an ozone-free deep column is almost never what a realistic setup wants, and the failure mode (slow stratospheric destabilization) is hard to diagnose.

Updated: constructor docstring + jldoctest (the default-constructor example now shows 6 active gases) and the `BackgroundAtmosphere` unit test.

## Motivation

Downstream, the goal is `RadiativeTransferModel(grid, AllSkyOptics(), constants; surface_temperature, surface_albedo, solar_position)` with everything else defaulted — after this PR, ozone no longer needs to be one of the manual knobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)