### PR TITLE
Allow constructing a RadiativeTransferModel without a surface temperature

### DIFF
--- a/ext/BreezeRRTMGPExt/all_sky_radiative_transfer_model.jl
+++ b/ext/BreezeRRTMGPExt/all_sky_radiative_transfer_model.jl
@@ -57,7 +57,9 @@ RRTMGP loads lookup tables from netCDF via an extension.
 - `background_atmosphere`: Background atmospheric gas composition (default: `BackgroundAtmosphere()`).
   O₃ can be a Number or Function of `z`; other gases are global mean constants.
   O₃ can be a Number, Function, or Field; other gases are global mean constants.
-- `surface_temperature`: Surface temperature in Kelvin (required).
+- `surface_temperature`: Surface temperature in Kelvin, a `Number` or 2D `Field`. Default: `nothing` —
+  bind one before the first radiation update (a coupled model wires its interface surface
+  temperature into the radiation automatically).
 - `solar_position`: Specification of the solar zenith angle. See [`AbstractSolarPosition`](@ref) and its subtypes:
   - [`ApparentSolarPosition`](@ref) (default) — time-varying, computed from the model clock and grid (or explicit) longitude/latitude.
   - [`FixedCosineZenith`](@ref) — constant cos(θ_z), independent of the clock.
@@ -75,7 +77,7 @@ function AtmosphereModels.RadiativeTransferModel(grid::AbstractGrid,
                                                  ::AllSkyOptics,
                                                  constants::ThermodynamicConstants;
                                                  background_atmosphere = BackgroundAtmosphere(),
-                                                 surface_temperature,
+                                                 surface_temperature = nothing,
                                                  solar_position::AbstractSolarPosition = ApparentSolarPosition(),
                                                  surface_emissivity = 0.98,
                                                  direct_surface_albedo = nothing,
@@ -270,6 +272,7 @@ $(TYPEDSIGNATURES)
 Update the all-sky (gas + cloud) full-spectrum radiative fluxes from the current model state.
 """
 function AtmosphereModels._update_radiation!(rtm::AllSkyRadiativeTransferModel, model)
+    assert_bound_surface_temperature(rtm)
     grid = model.grid
     clock = model.clock
     solver = rtm.longwave_solver

--- a/ext/BreezeRRTMGPExt/clear_sky_radiative_transfer_model.jl
+++ b/ext/BreezeRRTMGPExt/clear_sky_radiative_transfer_model.jl
@@ -38,7 +38,9 @@ RRTMGP loads lookup tables from netCDF via an extension.
 # Keyword Arguments
 - `background_atmosphere`: Background atmospheric gas composition (default: `BackgroundAtmosphere()`).
   O₃ can be a Number or Function of `z`; other gases are global mean constants.
-- `surface_temperature`: Surface temperature in Kelvin (required).
+- `surface_temperature`: Surface temperature in Kelvin, a `Number` or 2D `Field`. Default: `nothing` —
+  bind one before the first radiation update (a coupled model wires its interface surface
+  temperature into the radiation automatically).
 - `solar_position`: Specification of the solar zenith angle. See [`AbstractSolarPosition`](@ref) and its subtypes:
   - [`ApparentSolarPosition`](@ref) (default) — time-varying, computed from the model clock and grid (or explicit) longitude/latitude.
   - [`FixedCosineZenith`](@ref) — constant cos(θ_z), independent of the clock.
@@ -53,7 +55,7 @@ function AtmosphereModels.RadiativeTransferModel(grid::AbstractGrid,
                                                  ::ClearSkyOptics,
                                                  constants::ThermodynamicConstants;
                                                  background_atmosphere = BackgroundAtmosphere(),
-                                                 surface_temperature,
+                                                 surface_temperature = nothing,
                                                  solar_position::AbstractSolarPosition = ApparentSolarPosition(),
                                                  surface_emissivity = 0.98,
                                                  direct_surface_albedo = nothing,
@@ -283,6 +285,7 @@ $(TYPEDSIGNATURES)
 Update the clear-sky full-spectrum radiative fluxes from the current model state.
 """
 function AtmosphereModels._update_radiation!(rtm::ClearSkyRadiativeTransferModel, model)
+    assert_bound_surface_temperature(rtm)
     grid = model.grid
     clock = model.clock
     solver = rtm.longwave_solver

--- a/ext/BreezeRRTMGPExt/gray_radiative_transfer_model.jl
+++ b/ext/BreezeRRTMGPExt/gray_radiative_transfer_model.jl
@@ -51,7 +51,9 @@ Construct a gray atmosphere radiative transfer model for the given grid.
 
 # Keyword Arguments
 - `optical_thickness`: Optical thickness parameterization (default: `GrayOpticalThicknessOGorman2008(FT)`).
-- `surface_temperature`: Surface temperature in Kelvin (required).
+- `surface_temperature`: Surface temperature in Kelvin, a `Number` or 2D `Field`. Default: `nothing` —
+  bind one before the first radiation update (a coupled model wires its interface surface
+  temperature into the radiation automatically).
 - `solar_position`: Specification of the solar zenith angle. See [`AbstractSolarPosition`](@ref) and its subtypes:
   - [`ApparentSolarPosition`](@ref) (default) — time-varying, computed from the model clock and grid (or explicit) longitude/latitude.
   - [`FixedCosineZenith`](@ref) — constant cos(θ_z), independent of the clock.
@@ -66,7 +68,7 @@ function AtmosphereModels.RadiativeTransferModel(grid::AbstractGrid,
                                                  ::GrayOptics,
                                                  constants::ThermodynamicConstants;
                                                  optical_thickness = GrayOpticalThicknessOGorman2008(eltype(grid)),
-                                                 surface_temperature,
+                                                 surface_temperature = nothing,
                                                  solar_position::AbstractSolarPosition = ApparentSolarPosition(),
                                                  surface_emissivity = 0.98,
                                                  direct_surface_albedo = nothing,
@@ -292,6 +294,7 @@ This function:
 Sign convention: positive flux = upward, negative flux = downward.
 """
 function AtmosphereModels._update_radiation!(rtm::GrayRadiativeTransferModel, model)
+    assert_bound_surface_temperature(rtm)
     grid = model.grid
     clock = model.clock
 

--- a/ext/BreezeRRTMGPExt/rrtmgp_shared_utilities.jl
+++ b/ext/BreezeRRTMGPExt/rrtmgp_shared_utilities.jl
@@ -169,3 +169,13 @@ end
     # Flux divergence: -dF/dz (positive when flux convergence warms)
     @inbounds flux_div[i, j, k] = -(F_k1 - F_k) / Δz
 end
+
+# The constructors accept `surface_temperature = nothing` so that a coupled model can bind
+# its interface surface temperature after construction; solving without one is an error.
+function assert_bound_surface_temperature(rtm)
+    isnothing(rtm.surface_properties.surface_temperature) && throw(ArgumentError(
+        "This RadiativeTransferModel has no surface temperature: construct it with " *
+        "`surface_temperature = ...`, or bind one before the first radiation update " *
+        "(coupled models wire their interface surface temperature automatically)."))
+    return nothing
+end

--- a/test/all_sky_radiative_transfer.jl
+++ b/test/all_sky_radiative_transfer.jl
@@ -35,6 +35,20 @@ using RRTMGP
                                                           surface_temperature = 300)
     end
 
+    @testset "Optional surface temperature" begin
+        Oceananigans.defaults.FloatType = FT
+        topology = (Flat, Flat, Bounded)
+        grid = RectilinearGrid(default_arch; size=4, x=0, y=45, z=(0, 10kilometers), topology)
+        constants = ThermodynamicConstants()
+
+        # Legal to construct without one (a coupled model binds it later)...
+        radiation = RadiativeTransferModel(grid, AllSkyOptics(), constants; surface_albedo = 0.1)
+        @test isnothing(radiation.surface_properties.surface_temperature)
+
+        # ...but solving before anything is bound fails loudly.
+        @test_throws ArgumentError Breeze.AtmosphereModels._update_radiation!(radiation, nothing)
+    end
+
     @testset "Single column grid with clouds [$(FT)]" for FT in test_float_types()
         Oceananigans.defaults.FloatType = FT
         topology = (Flat, Flat, Bounded)


### PR DESCRIPTION
## Summary

Defaults `surface_temperature = nothing` in all three `RadiativeTransferModel` constructors (gray, clear-sky, all-sky), and adds a clear `ArgumentError` at the first radiation update if none was ever bound.

## Motivation

In a coupled configuration the surface temperature the atmosphere *sees* is the coupled interface's diagnostic skin temperature — not something the user should thread by hand into the RTM constructor. Since the RTM re-reads its stored `surface_temperature` field on every solve, a coupled model (e.g. NumericalEarth's `EarthSystemModel`) can bind the interface temperature field after construction with exact semantics. This PR makes that construction order legal:

```julia
radiation = RadiativeTransferModel(grid, AllSkyOptics(), constants; surface_albedo = 0.18)
model = AtmosphereLandModel(atmosphere, land; radiation)   # binds interfaces.atmosphere_land_interface.temperature
```

Standalone (uncoupled) usage is unchanged — passing `surface_temperature` at construction works exactly as before, and forgetting it now fails loudly at the first solve instead of being impossible to express.

Companion to #791 (terrain support) and #855 (ozone default) in the "minimal RTM construction" series; the NumericalEarth side (the `EarthSystemModel` wiring) lands separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)