### PR TITLE
Make materialize_surface_property a public AtmosphereModels hook

### DIFF
--- a/ext/BreezeRRTMGPExt/BreezeRRTMGPExt.jl
+++ b/ext/BreezeRRTMGPExt/BreezeRRTMGPExt.jl
@@ -2,7 +2,7 @@ module BreezeRRTMGPExt
 
 using Breeze
 
-using Breeze.AtmosphereModels: GrayOptics, ClearSkyOptics, AllSkyOptics, ConstantRadiusParticles
+using Breeze.AtmosphereModels: GrayOptics, ClearSkyOptics, AllSkyOptics, ConstantRadiusParticles, materialize_surface_property
 using Breeze.Thermodynamics: ThermodynamicConstants
 using RRTMGP: RRTMGP
 

--- a/ext/BreezeRRTMGPExt/all_sky_radiative_transfer_model.jl
+++ b/ext/BreezeRRTMGPExt/all_sky_radiative_transfer_model.jl
@@ -103,13 +103,13 @@ function AtmosphereModels.RadiativeTransferModel(grid::AbstractGrid,
             throw(ArgumentError(error_msg))
         end
 
-        surface_albedo = materialize_surface_property(surface_albedo, grid)
+        surface_albedo = materialize_surface_property(surface_albedo, grid, solar_position)
         diffuse_surface_albedo = surface_albedo
         direct_surface_albedo = surface_albedo
 
     elseif !isnothing(diffuse_surface_albedo) && !isnothing(direct_surface_albedo)
-        direct_surface_albedo = materialize_surface_property(direct_surface_albedo, grid)
-        diffuse_surface_albedo = materialize_surface_property(diffuse_surface_albedo, grid)
+        direct_surface_albedo = materialize_surface_property(direct_surface_albedo, grid, solar_position)
+        diffuse_surface_albedo = materialize_surface_property(diffuse_surface_albedo, grid, solar_position)
     else
         throw(ArgumentError(error_msg))
     end

--- a/ext/BreezeRRTMGPExt/clear_sky_radiative_transfer_model.jl
+++ b/ext/BreezeRRTMGPExt/clear_sky_radiative_transfer_model.jl
@@ -78,13 +78,13 @@ function AtmosphereModels.RadiativeTransferModel(grid::AbstractGrid,
             throw(ArgumentError(error_msg))
         end
 
-        surface_albedo = materialize_surface_property(surface_albedo, grid)
+        surface_albedo = materialize_surface_property(surface_albedo, grid, solar_position)
         diffuse_surface_albedo = surface_albedo
         direct_surface_albedo = surface_albedo
 
     elseif !isnothing(diffuse_surface_albedo) && !isnothing(direct_surface_albedo)
-        direct_surface_albedo = materialize_surface_property(direct_surface_albedo, grid)
-        diffuse_surface_albedo = materialize_surface_property(diffuse_surface_albedo, grid)
+        direct_surface_albedo = materialize_surface_property(direct_surface_albedo, grid, solar_position)
+        diffuse_surface_albedo = materialize_surface_property(diffuse_surface_albedo, grid, solar_position)
     else
         throw(ArgumentError(error_msg))
     end

--- a/ext/BreezeRRTMGPExt/gray_radiative_transfer_model.jl
+++ b/ext/BreezeRRTMGPExt/gray_radiative_transfer_model.jl
@@ -21,8 +21,6 @@ using Dates: AbstractDateTime, Millisecond
 # Dispatch on background_atmosphere = Nothing for gray radiation
 const GrayRadiativeTransferModel = RadiativeTransferModel{<:Any, <:Any, <:Any, Nothing}
 
-materialize_surface_property(x::Number, grid) = convert(eltype(grid), x)
-materialize_surface_property(x::Field, grid) = x
 
 #####
 ##### Solar position handling: resolve user-facing input into a concrete
@@ -88,13 +86,13 @@ function AtmosphereModels.RadiativeTransferModel(grid::AbstractGrid,
             throw(ArgumentError(error_msg))
         end
 
-        surface_albedo = materialize_surface_property(surface_albedo, grid)
+        surface_albedo = materialize_surface_property(surface_albedo, grid, solar_position)
         diffuse_surface_albedo = surface_albedo
         direct_surface_albedo = surface_albedo
 
     elseif !isnothing(diffuse_surface_albedo) && !isnothing(direct_surface_albedo)
-        direct_surface_albedo = materialize_surface_property(direct_surface_albedo, grid)
-        diffuse_surface_albedo = materialize_surface_property(diffuse_surface_albedo, grid)
+        direct_surface_albedo = materialize_surface_property(direct_surface_albedo, grid, solar_position)
+        diffuse_surface_albedo = materialize_surface_property(diffuse_surface_albedo, grid, solar_position)
     else
         throw(ArgumentError(error_msg))
     end

--- a/src/AtmosphereModels/AtmosphereModels.jl
+++ b/src/AtmosphereModels/AtmosphereModels.jl
@@ -67,6 +67,7 @@ export
     RadiativeTransferModel,
     BackgroundAtmosphere,
     materialize_background_atmosphere,
+    materialize_surface_property,
     GrayOptics,
     ClearSkyOptics,
     AllSkyOptics,

--- a/src/AtmosphereModels/radiation_interface.jl
+++ b/src/AtmosphereModels/radiation_interface.jl
@@ -176,6 +176,19 @@ function RadiativeTransferModel(grid::AbstractGrid, optics, args...; kw...)
 end
 
 """
+    materialize_surface_property(x, grid [, solar_position])
+
+Convert a surface property (albedo, emissivity) to the form the radiative-transfer
+solver stores: a `Number` becomes a grid-eltype scalar and a `Field` passes through.
+Extend the three-argument form for property sources that must be resolved against the
+grid and the solar `epoch` (e.g. an observed-albedo dataset); it falls back to the
+two-argument form.
+"""
+materialize_surface_property(x, grid, solar_position) = materialize_surface_property(x, grid)
+materialize_surface_property(x::Number, grid) = convert(eltype(grid), x)
+materialize_surface_property(x::Oceananigans.Field, grid) = x
+
+"""
 $(TYPEDEF)
 
 Volume mixing ratios (VMR) for radiatively active gases.

--- a/test/unit_tests.jl
+++ b/test/unit_tests.jl
@@ -612,3 +612,32 @@ end
     grid = RectilinearGrid(default_arch; size=4, z=(0, 100), topology=(Flat, Flat, Bounded))
     @test radiation_flux_divergence(1, 1, 1, grid, nothing) == zero(eltype(grid))
 end
+
+#####
+##### materialize_surface_property
+#####
+
+using Breeze.AtmosphereModels: materialize_surface_property
+
+# Extension point: downstream packages materialize property sources against grid + solar position.
+struct TestSurfacePropertySource end
+Breeze.AtmosphereModels.materialize_surface_property(::TestSurfacePropertySource, grid, solar_position) =
+    convert(eltype(grid), 1//2)
+
+@testset "materialize_surface_property [$(FT)]" for FT in test_float_types()
+    Oceananigans.defaults.FloatType = FT
+    grid = RectilinearGrid(default_arch; size=(4, 4, 4), x=(0, 1), y=(0, 1), z=(0, 1))
+
+    x = materialize_surface_property(0.2, grid)
+    @test x isa FT
+    @test x ≈ 0.2
+
+    α = CenterField(grid)
+    @test materialize_surface_property(α, grid) === α
+
+    # The three-argument form falls back to the two-argument form...
+    @test materialize_surface_property(0.2, grid, nothing) === materialize_surface_property(0.2, grid)
+
+    # ...and dispatches to source-specific methods.
+    @test materialize_surface_property(TestSurfacePropertySource(), grid, nothing) == FT(0.5)
+end


### PR DESCRIPTION
## Summary

Hoists `materialize_surface_property` from `BreezeRRTMGPExt` into `AtmosphereModels` (exported, documented) and threads the resolved `solar_position` into the albedo materializations as a third argument, with a two-argument fallback so existing methods are unchanged.

## Motivation

Lets downstream packages pass a *dataset* as a surface property and materialize it against the grid and the solar `epoch`. With NumericalEarth's companion method this becomes:

```julia
RadiativeTransferModel(grid, AllSkyOptics(), constants;
                       solar_position = ApparentSolarPosition(epoch = start_date),
                       surface_albedo = CopernicusAlbedo(),   # CGLS 1 km, dated by the epoch
                       schedule = TimeInterval(1hour))
```

No behavior change for `Number`/`Field` inputs. Part of the "minimal RTM construction" series (#791, #855, #856).

🤖 Generated with [Claude Code](https://claude.com/claude-code)