### PR TITLE
Validate DCMIP2016 Kessler requires Tetens saturation constants

### DIFF
--- a/src/AtmosphereModels/atmosphere_model.jl
+++ b/src/AtmosphereModels/atmosphere_model.jl
@@ -140,6 +140,9 @@ function AtmosphereModel(grid;
     # Validate that velocity boundary conditions are only provided for dynamics that support them
     validate_velocity_boundary_conditions(dynamics, boundary_conditions)
 
+    # Validate that the microphysics scheme is compatible with the thermodynamic constants
+    validate_microphysics(microphysics, thermodynamic_constants)
+
     if !(advection isa DefaultValue)
         # TODO: check that tracer+momentum advection were not independently set.
         scalar_advection = momentum_advection = advection

--- a/src/AtmosphereModels/microphysics_interface.jl
+++ b/src/AtmosphereModels/microphysics_interface.jl
@@ -690,6 +690,18 @@ microphysics_model_update!(microphysics::Nothing, model) = nothing
 """
 $(TYPEDSIGNATURES)
 
+Validate that `microphysics` is compatible with the model's `thermodynamic_constants`.
+
+Defaults to a no-op. Schemes that require a particular thermodynamic formulation (for
+example a specific saturation vapor pressure formula) extend this method to throw a clear
+`ArgumentError` at model construction, rather than failing later inside a kernel — where the
+failure surfaces as an opaque dynamic `getproperty` / GPU compilation error.
+"""
+validate_microphysics(microphysics, thermodynamic_constants) = nothing
+
+"""
+$(TYPEDSIGNATURES)
+
 Adjust the thermodynamic `state` according to the `scheme`.
 For example, if `scheme isa SaturationAdjustment`, then this function
 will adjust and return a new thermodynamic state given the specifications

--- a/src/Microphysics/dcmip2016_kessler.jl
+++ b/src/Microphysics/dcmip2016_kessler.jl
@@ -6,6 +6,7 @@ using ..Thermodynamics:
     mixture_heat_capacity,
     saturation_specific_humidity,
     temperature,
+    TetensFormulaThermodynamicConstants,
     total_mixing_ratio,
     total_specific_moisture,
     with_moisture
@@ -184,6 +185,24 @@ function DCMIP2016KesslerMicrophysics(FT = Oceananigans.defaults.FloatType;
 end
 
 const DCMIP2016KM = DCMIP2016KesslerMicrophysics
+
+# The DCMIP2016 Kessler saturation adjustment reads the liquid coefficient and temperature
+# offset of the Tetens formula (see `saturation_adjustment_coefficient` and the kernel), so it
+# requires thermodynamic constants built with a `TetensFormula` saturation vapor pressure. With
+# other formulations (e.g. the default `ClausiusClapeyron`) those fields are absent and the
+# scheme would fail inside the kernel — an opaque `getproperty` error on the CPU and a GPU
+# compilation failure. Validate at model construction to give a clear, early error instead.
+function AtmosphereModels.validate_microphysics(::DCMIP2016KM, thermodynamic_constants)
+    if !(thermodynamic_constants isa TetensFormulaThermodynamicConstants)
+        svp = thermodynamic_constants.saturation_vapor_pressure
+        throw(ArgumentError(string(
+            "DCMIP2016KesslerMicrophysics requires `thermodynamic_constants` with a `TetensFormula` ",
+            "saturation vapor pressure formulation, but got `", summary(svp), "`. ",
+            "Construct the model with, e.g., ",
+            "`thermodynamic_constants = ThermodynamicConstants(FT; saturation_vapor_pressure = TetensFormula(FT))`.")))
+    end
+    return nothing
+end
 
 """
 $(TYPEDSIGNATURES)
@@ -466,7 +485,12 @@ function AtmosphereModels.microphysics_model_update!(microphysics::DCMIP2016KM, 
     return nothing
 end
 
-function saturation_adjustment_coefficient(T_DCMIP2016, constants)
+# Constrained to `TetensFormulaThermodynamicConstants`: the coefficient `a` is the liquid
+# coefficient of the Tetens formula, which only exists for those constants. The annotation
+# makes the dependence explicit to the compiler (and to static analysis like JETLS), so an
+# incompatible formulation fails as a clear `MethodError` rather than a dynamic `getproperty`
+# inside the GPU kernel. `validate_microphysics` catches the mismatch earlier still.
+@inline function saturation_adjustment_coefficient(T_DCMIP2016, constants::TetensFormulaThermodynamicConstants)
     a = constants.saturation_vapor_pressure.liquid_coefficient
     ℒˡᵣ = constants.liquid.reference_latent_heat
     cᵖᵈ = constants.dry_air.heat_capacity

--- a/test/dcmip2016_kessler.jl
+++ b/test/dcmip2016_kessler.jl
@@ -398,3 +398,19 @@ end
     @test qᶜˡ_breeze ≈ qᶜˡ_ref rtol=1e-12
     @test qʳ_breeze ≈ qʳ_ref rtol=1e-12
 end
+
+@testset "Thermodynamic constants validation" begin
+    FT = Float64
+    grid = RectilinearGrid(CPU(), size=(1, 1, 4), extent=(1, 1, 1))
+    microphysics = DCMIP2016KesslerMicrophysics(FT)
+
+    # DCMIP2016 Kessler requires Tetens saturation vapor pressure. The default constants use
+    # ClausiusClapeyron, which lacks the Tetens coefficients the scheme reads — this should be
+    # rejected at construction with a clear error, not fail later inside the kernel (issue #858).
+    @test_throws ArgumentError AtmosphereModel(grid; microphysics)
+
+    # Constructing with Tetens constants succeeds.
+    tetens_constants = ThermodynamicConstants(FT; saturation_vapor_pressure = TetensFormula(FT))
+    model = AtmosphereModel(grid; microphysics, thermodynamic_constants=tetens_constants)
+    @test model.microphysics isa DCMIP2016KesslerMicrophysics
+end


### PR DESCRIPTION
Closes #858.

## Problem

`DCMIP2016KesslerMicrophysics` reads Tetens-only fields from the model's thermodynamic constants — `constants.saturation_vapor_pressure.liquid_coefficient` (in `saturation_adjustment_coefficient`) and `.liquid_temperature_offset` (in the update kernel). With the default `ClausiusClapeyron` constants those fields don't exist, so the untyped code degraded to a dynamic `getproperty` that only failed at the first time step:

- **CPU:** a `FieldError`.
- **GPU:** the `jl_f_getfield` `check_ir` compilation failure reported in #858.

The scheme silently accepted incompatible constants until then.

## Fix

Following the discussion on the issue (type-constrain to Tetens **and** validate at construction for friendliness):

1. **Early, clear construction-time error.** New `validate_microphysics(microphysics, thermodynamic_constants)` interface hook (default no-op), called from the `AtmosphereModel` constructor. `DCMIP2016KesslerMicrophysics` extends it to throw a descriptive `ArgumentError` — naming the actual formulation and showing how to pass `TetensFormula` — when the constants are not `TetensFormulaThermodynamicConstants`.

2. **Type constraint.** `saturation_adjustment_coefficient` is now constrained to `TetensFormulaThermodynamicConstants` (and marked `@inline`, since it is called from the kernel). This makes the Tetens dependence visible to the compiler and to static analysis such as JETLS — as @giordano noted, the fully-untyped signature is why static analysis missed it — turning the opaque dynamic `getproperty` into a clear `MethodError` as a backstop.

3. **Test.** Added a "Thermodynamic constants validation" testset: default (Clausius–Clapeyron) constants → `@test_throws ArgumentError`; Tetens constants → constructs fine.

This makes the failure early and clear (the accepted status-quo behavior); it does not add general non-Tetens support, which the thread agreed should be a follow-up.

## Verification

- `dcmip2016_kessler`: 14/14 pass (incl. the 2 new tests)
- `parcel_dynamics`: 112/112 pass (exercises the constructor validation via `ParcelDynamics` + DCMIP2016)
- All existing DCMIP2016 usages (examples + tests) already pass Tetens constants, so nothing else is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)