### PR TITLE
[examples] Compress all JLD2 files

### DIFF
--- a/examples/acoustic_wave.jl
+++ b/examples/acoustic_wave.jl
@@ -155,6 +155,7 @@ outputs = (; ρ′, u′, w, U, R, W²)
 
 simulation.output_writers[:jld2] = JLD2Writer(model, outputs; filename,
                                               schedule = TimeInterval(0.01),
+                                              jld2_kw = Dict(:compress => true),
                                               overwrite_existing = true)
 
 run!(simulation)

--- a/examples/baroclinic_wave.jl
+++ b/examples/baroclinic_wave.jl
@@ -303,6 +303,7 @@ for k in (1, 16)
     ow = JLD2Writer(model, outputs; filename,
                     indices = (:, :, k),
                     schedule = TimeInterval(6hours),
+                    jld2_kw = Dict(:compress => true),
                     overwrite_existing = true)
 
     simulation.output_writers[Symbol(filename)] = ow

--- a/examples/bomex.jl
+++ b/examples/bomex.jl
@@ -280,6 +280,7 @@ avg_outputs = NamedTuple(name => Average(outputs[name], dims=(1, 2)) for name in
 filename = "bomex.jld2"
 simulation.output_writers[:averages] = JLD2Writer(model, avg_outputs; filename,
                                                   schedule = AveragedTimeInterval(1hour),
+                                                  jld2_kw = Dict(:compress => true),
                                                   overwrite_existing = true)
 
 # Output horizontal slices at z = 600 m for animation
@@ -300,6 +301,7 @@ slice_outputs = (
 simulation.output_writers[:slices] = JLD2Writer(model, slice_outputs;
                                                 filename = "bomex_slices.jld2",
                                                 schedule = TimeInterval(30seconds),
+                                                jld2_kw = Dict(:compress => true),
                                                 overwrite_existing = true)
 
 @info "Running BOMEX simulation..."

--- a/examples/boussinesq_bomex.jl
+++ b/examples/boussinesq_bomex.jl
@@ -271,6 +271,7 @@ averages_filename = string("bomex_averages_", Nx, "_", Ny, "_", Nz, ".jld2")
 
 ow = JLD2Writer(model, outputs; filename,
                 schedule = TimeInterval(1minutes),
+                jld2_kw = Dict(:compress => true),
                 overwrite_existing = true)
 
 simulation.output_writers[:jld2] = ow
@@ -278,6 +279,7 @@ simulation.output_writers[:jld2] = ow
 averages_ow = JLD2Writer(model, averaged_outputs;
                          filename = averages_filename,
                          schedule = TimeInterval(1minutes),
+                         jld2_kw = Dict(:compress => true),
                          overwrite_existing = true)
 
 simulation.output_writers[:avg] = averages_ow

--- a/examples/cloudy_kelvin_helmholtz.jl
+++ b/examples/cloudy_kelvin_helmholtz.jl
@@ -190,6 +190,7 @@ filename = "wave_clouds.jld2"
 
 output_writer = JLD2Writer(model, outputs; filename,
                            schedule = TimeInterval(4),
+                           jld2_kw = Dict(:compress => true),
                            overwrite_existing = true)
 
 simulation.output_writers[:fields] = output_writer

--- a/examples/cloudy_thermal_bubble.jl
+++ b/examples/cloudy_thermal_bubble.jl
@@ -85,6 +85,7 @@ outputs = (; θ, w)
 filename = "dry_thermal_bubble.jld2"
 writer = JLD2Writer(model, outputs; filename,
                     schedule = TimeInterval(10seconds),
+                    jld2_kw = Dict(:compress => true),
                     overwrite_existing = true)
 
 simulation.output_writers[:jld2] = writer
@@ -218,6 +219,7 @@ moist_outputs = (; θ, w, qˡ′)
 moist_filename = "cloudy_thermal_bubble.jld2"
 moist_writer = JLD2Writer(moist_model, moist_outputs; filename=moist_filename,
                           schedule = TimeInterval(10seconds),
+                          jld2_kw = Dict(:compress => true),
                           overwrite_existing = true)
 
 moist_simulation.output_writers[:jld2] = moist_writer
@@ -321,6 +323,7 @@ precip_outputs = (; θ=θ_precip, w=w_precip, qᶜˡ=qᶜˡ_precip, qʳ=qʳ_prec
 precip_filename = "precipitating_thermal_bubble.jld2"
 precip_writer = JLD2Writer(precip_model, precip_outputs; filename=precip_filename,
                            schedule = TimeInterval(30seconds),
+                           jld2_kw = Dict(:compress => true),
                            overwrite_existing = true)
 
 precip_simulation.output_writers[:jld2] = precip_writer

--- a/examples/dry_thermal_bubble.jl
+++ b/examples/dry_thermal_bubble.jl
@@ -93,6 +93,7 @@ outputs = merge(model.velocities, model.tracers, (; ρe′, ρe, T))
 filename = "thermal_bubble.jld2"
 writer = JLD2Writer(model, outputs; filename,
                     schedule = TimeInterval(10seconds),
+                    jld2_kw = Dict(:compress => true),
                     overwrite_existing = true)
 
 simulation.output_writers[:jld2] = writer

--- a/examples/inertia_gravity_wave.jl
+++ b/examples/inertia_gravity_wave.jl
@@ -203,6 +203,7 @@ for (key, model) in models
     sim.output_writers[:jld2] = JLD2Writer(model, outputs;
                                            filename = "igw_$(key).jld2",
                                            schedule = TimeInterval(100),
+                                           jld2_kw = Dict(:compress => true),
                                            overwrite_existing = true)
     simulations[key] = sim
 end

--- a/examples/neutral_atmospheric_boundary_layer.jl
+++ b/examples/neutral_atmospheric_boundary_layer.jl
@@ -228,6 +228,7 @@ avg_output_interval = 10minutes
 simulation.output_writers[:averages] = JLD2Writer(model, merge(avg_outputs, avg_∂z_outputs);
                                                   filename = avg_filename,
                                                   schedule = AveragedTimeInterval(avg_output_interval),
+                                                  jld2_kw = Dict(:compress => true),
                                                   overwrite_existing = true)
 
 # ### Instantaneous slices for animation
@@ -259,6 +260,7 @@ slice_outputs = (
 simulation.output_writers[:slices] = JLD2Writer(model, slice_outputs;
                                                 filename = "abl_slices.jld2",
                                                 schedule = TimeInterval(5minutes),
+                                                jld2_kw = Dict(:compress => true),
                                                 overwrite_existing = true)
 
 # ### Go time

--- a/examples/prescribed_sea_surface_temperature.jl
+++ b/examples/prescribed_sea_surface_temperature.jl
@@ -386,6 +386,7 @@ outputs = (; s, ξ, T, θ, qˡ, qᵛ⁺, qᵛ, τˣ, 𝒬ᵀ, 𝒬ᵛ, Σ𝒬=�
 ow = JLD2Writer(model, outputs;
                 filename = output_filename,
                 schedule = TimeInterval(2minutes),
+                jld2_kw = Dict(:compress => true),
                 overwrite_existing = true)
 
 simulation.output_writers[:jld2] = ow

--- a/examples/radiative_convection.jl
+++ b/examples/radiative_convection.jl
@@ -323,12 +323,14 @@ slices_filename = filename * "_slices.jld2"
 simulation.output_writers[:averages] = JLD2Writer(model, avg_outputs;
                                                   filename = averages_filename,
                                                   schedule = AveragedTimeInterval(1hour),
+                                                  jld2_kw = Dict(:compress => true),
                                                   overwrite_existing = true)
 
 slice_outputs = (; w, qᵛ, T)
 simulation.output_writers[:slices] = JLD2Writer(model, slice_outputs;
                                                 filename = slices_filename,
                                                 schedule = TimeInterval(10minutes),
+                                                jld2_kw = Dict(:compress => true),
                                                 overwrite_existing = true)
 
 @info "Starting simulation..."

--- a/examples/rico.jl
+++ b/examples/rico.jl
@@ -284,6 +284,7 @@ averaged_outputs = NamedTuple(name => Average(outputs[name], dims=(1, 2)) for na
 filename = "rico.jld2"
 simulation.output_writers[:averages] = JLD2Writer(model, averaged_outputs; filename,
                                                   schedule = AveragedTimeInterval(2hour),
+                                                  jld2_kw = Dict(:compress => true),
                                                   overwrite_existing = true)
 
 # For an animation, we also output slices,
@@ -309,6 +310,7 @@ filename = "rico_slices.jld2"
 output_interval = 20seconds
 simulation.output_writers[:slices] = JLD2Writer(model, slice_outputs; filename,
                                                 schedule = TimeInterval(output_interval),
+                                                jld2_kw = Dict(:compress => true),
                                                 overwrite_existing = true)
 
 # We're finally ready to run this thing,

--- a/examples/splitting_supercell.jl
+++ b/examples/splitting_supercell.jl
@@ -366,7 +366,8 @@ function run_simulation(model, label)
 
     slices_filename = "splitting_supercell_$(label)_slices.jld2"
     simulation.output_writers[:slices] = JLD2Writer(model, slice_outputs;
-        filename=slices_filename, schedule=TimeInterval(2minutes), overwrite_existing=true)
+        filename=slices_filename, schedule=TimeInterval(2minutes), overwrite_existing=true,
+        jld2_kw = Dict(:compress => true))
 
     run!(simulation)
     wall_seconds = simulation.run_wall_time

--- a/examples/tropical_cyclone_with_rainband.jl
+++ b/examples/tropical_cyclone_with_rainband.jl
@@ -547,6 +547,7 @@ outputs = (; w, vθ, θ)
 ow = JLD2Writer(model, outputs;
                 filename = output_filename,
                 schedule = TimeInterval(1hour),
+                jld2_kw = Dict(:compress => true),
                 overwrite_existing = true)
 
 simulation.output_writers[:fields] = ow

--- a/examples/tropical_cyclone_world.jl
+++ b/examples/tropical_cyclone_world.jl
@@ -263,6 +263,7 @@ simulation.output_writers[:profiles] = JLD2Writer(model, avg_outputs;
                                                   filename = "tc_world_profiles.jld2",
                                                   schedule = TimeInterval(1day),
                                                   init = save_parameters,
+                                                  jld2_kw = Dict(:compress => true),
                                                   overwrite_existing = true)
 
 # Surface fields for tracking TC development.
@@ -272,6 +273,7 @@ simulation.output_writers[:surface] = JLD2Writer(model, surface_outputs;
                                                  filename = "tc_world_surface.jld2",
                                                  indices = (:, :, 1),
                                                  schedule = TimeInterval(30minutes),
+                                                 jld2_kw = Dict(:compress => true),
                                                  overwrite_existing = true)
 
 # ## Run

--- a/examples/two_dimension_mountain_wave.jl
+++ b/examples/two_dimension_mountain_wave.jl
@@ -322,6 +322,7 @@ outputs = (; w, contravariant_w)
 simulation.output_writers[:jld2] = JLD2Writer(model, outputs;
                                               filename,
                                               schedule = TimeInterval(2minutes),
+                                              jld2_kw = Dict(:compress => true),
                                               overwrite_existing = true)
 
 run!(simulation)


### PR DESCRIPTION
Along the same lines of #885.  For the `dry_thermal_bubble.jl` example, the output file goes from 66 MiB to 31 MiB.  I'm hoping we get similar saving for the other examples as well.