### PR TITLE
[tests] Create `setup.jl` instead of passing `init_code` to `runtests`

### DIFF
--- a/test/acoustic_substepping.jl
+++ b/test/acoustic_substepping.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 #####
 ##### Tests for acoustic substepping in CompressibleDynamics
 #####

--- a/test/adiabatic_balance_set.jl
+++ b/test/adiabatic_balance_set.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 #####
 ##### Tests for `balance_adiabatically!(model, balancer)` / `set!(model; balancer = …)` — in-place
 ##### adiabatic (FV3 na_init) initialization on a memory-sharing, stripped twin

--- a/test/advection_schemes.jl
+++ b/test/advection_schemes.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 using Breeze
 using Oceananigans
 using Test

--- a/test/all_sky_radiative_transfer.jl
+++ b/test/all_sky_radiative_transfer.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 using Breeze
 using Dates
 using GPUArraysCore: @allowscalar

--- a/test/anelastic_pressure_solver_analytic.jl
+++ b/test/anelastic_pressure_solver_analytic.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 using Test
 using Breeze
 using Oceananigans

--- a/test/anelastic_pressure_solver_nonhydrostatic.jl
+++ b/test/anelastic_pressure_solver_nonhydrostatic.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 using Test
 using Breeze
 using Oceananigans

--- a/test/atmosphere_model_callbacks.jl
+++ b/test/atmosphere_model_callbacks.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 using Breeze
 using Oceananigans
 using Oceananigans: UpdateStateCallsite, TendencyCallsite, TimeStepCallsite

--- a/test/atmosphere_model_construction.jl
+++ b/test/atmosphere_model_construction.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 using Breeze
 using Breeze.Thermodynamics: TetensFormula
 using GPUArraysCore: @allowscalar

--- a/test/balance_adiabatically.jl
+++ b/test/balance_adiabatically.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 #####
 ##### Tests for `balance_adiabatically!` (FV3-SHiELD `na_init`).
 #####

--- a/test/boundary_conditions.jl
+++ b/test/boundary_conditions.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 using Test
 using Breeze
 using Oceananigans.BoundaryConditions: BoundaryCondition

--- a/test/clear_sky_radiative_transfer.jl
+++ b/test/clear_sky_radiative_transfer.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 using Breeze
 using Dates
 using GPUArraysCore: @allowscalar

--- a/test/cloud_microphysics_1M.jl
+++ b/test/cloud_microphysics_1M.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 using Breeze
 using Breeze.AtmosphereModels: microphysical_velocities
 using CloudMicrophysics

--- a/test/cloud_microphysics_1M_warm_ice_deposition.jl
+++ b/test/cloud_microphysics_1M_warm_ice_deposition.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 using Breeze
 using CloudMicrophysics
 using CloudMicrophysics.Parameters: CloudIce, CloudLiquid

--- a/test/cloud_microphysics_2M.jl
+++ b/test/cloud_microphysics_2M.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 using Breeze
 using Breeze.AtmosphereModels: microphysical_velocities
 using CloudMicrophysics

--- a/test/compressible_saturation_adjustment.jl
+++ b/test/compressible_saturation_adjustment.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 using Breeze
 using Oceananigans
 using Test

--- a/test/dcmip2016_kessler.jl
+++ b/test/dcmip2016_kessler.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 using Breeze
 using Test
 using Oceananigans

--- a/test/diagnostics.jl
+++ b/test/diagnostics.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 using Test
 using Breeze
 using Breeze.Thermodynamics: dry_air_gas_constant, adiabatic_hydrostatic_pressure,

--- a/test/doctests.jl
+++ b/test/doctests.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 # Loading `Breeze` into `Main` is necessary to work around
 # <https://github.com/JuliaTesting/ParallelTestRunner.jl/issues/68>.
 @eval Main using Breeze

--- a/test/dynamics.jl
+++ b/test/dynamics.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 using Breeze
 using Breeze.Microphysics
 using Oceananigans

--- a/test/forcing_and_boundary_conditions.jl
+++ b/test/forcing_and_boundary_conditions.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 using Breeze
 using Breeze.AtmosphereModels: thermodynamic_density, surface_pressure, standard_pressure
 using Breeze.BoundaryConditions: EnergyFluxBoundaryCondition, FilteredSurfaceVelocities

--- a/test/geostrophic_subsidence_forcings.jl
+++ b/test/geostrophic_subsidence_forcings.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 using Breeze
 using Breeze: ReferenceState, AnelasticDynamics, LiquidIcePotentialTemperatureFormulation,
               GeostrophicForcing, SpecificForcing

--- a/test/gray_radiative_transfer.jl
+++ b/test/gray_radiative_transfer.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 using Breeze
 using Dates
 using GPUArraysCore: @allowscalar

--- a/test/implicit_vertical_advection.jl
+++ b/test/implicit_vertical_advection.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 using Breeze
 using Oceananigans
 using Oceananigans.Advection: AdaptiveVerticallyImplicitDiscretization, needs_implicit_solver,

--- a/test/instantaneous_precipitation.jl
+++ b/test/instantaneous_precipitation.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 using Breeze
 using Oceananigans
 using Test

--- a/test/kinematic_driver.jl
+++ b/test/kinematic_driver.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 using Adapt: adapt
 using Breeze
 using Breeze: PrescribedDensity, PrescribedDynamics, KinematicModel

--- a/test/latitude_longitude_grid.jl
+++ b/test/latitude_longitude_grid.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 #####
 ##### Tests for LatitudeLongitudeGrid + CompressibleDynamics + SphericalCoriolis
 #####
@@ -13,12 +15,6 @@ using Oceananigans
 using Oceananigans.Architectures: architecture
 using Oceananigans.Units
 using Test
-
-# Note: When run through the test runner, test_float_types is defined in the init_code.
-# When run directly, we need to define it.
-if !@isdefined(test_float_types)
-    test_float_types() = (Float64,)
-end
 
 #####
 ##### Helper to build a LatitudeLongitudeGrid for tests

--- a/test/moist_air_buoyancy.jl
+++ b/test/moist_air_buoyancy.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 using Breeze
 using Oceananigans
 using Test

--- a/test/number_concentration.jl
+++ b/test/number_concentration.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 using Test
 using Breeze
 using CloudMicrophysics

--- a/test/open_boundary_momentum.jl
+++ b/test/open_boundary_momentum.jl
@@ -1,6 +1,7 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 using Test
 using Oceananigans
-using Oceananigans.Architectures: CPU
 using Oceananigans.BoundaryConditions: FieldBoundaryConditions, NormalFlowBoundaryCondition,
                                        PeriodicBoundaryCondition, fill_halo_regions!
 using GPUArraysCore: @allowscalar

--- a/test/output_writers.jl
+++ b/test/output_writers.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 using Test
 using Breeze
 using Oceananigans

--- a/test/parcel_dynamics.jl
+++ b/test/parcel_dynamics.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 #####
 ##### Unit tests for ParcelDynamics module
 #####

--- a/test/piecewise_linear_stretching.jl
+++ b/test/piecewise_linear_stretching.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 using Breeze
 using Test
 

--- a/test/polynomial_bulk_coefficients.jl
+++ b/test/polynomial_bulk_coefficients.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 using Test
 using Breeze
 using Breeze.BoundaryConditions

--- a/test/quality_assurance.jl
+++ b/test/quality_assurance.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 using Breeze: Breeze
 using Aqua: Aqua
 using ExplicitImports: ExplicitImports

--- a/test/radiation_scheduling.jl
+++ b/test/radiation_scheduling.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 using Breeze
 using Dates: DateTime, Second
 using GPUArraysCore: @allowscalar

--- a/test/reactant/1m_microphysics_compilation.jl
+++ b/test/reactant/1m_microphysics_compilation.jl
@@ -1,3 +1,5 @@
+include(joinpath(dirname(@__DIR__), "setup.jl"))
+
 #####
 ##### Reactant compilation tests — 1-moment non-equilibrium microphysics
 #####

--- a/test/reactant/advection_diffusion_ad.jl
+++ b/test/reactant/advection_diffusion_ad.jl
@@ -1,3 +1,5 @@
+include(joinpath(dirname(@__DIR__), "setup.jl"))
+
 using Breeze
 using Oceananigans
 using Oceananigans.Architectures: ReactantState

--- a/test/reactant/centered_compilation.jl
+++ b/test/reactant/centered_compilation.jl
@@ -1,3 +1,5 @@
+include(joinpath(dirname(@__DIR__), "setup.jl"))
+
 #####
 ##### Reactant compilation tests — Centered advection
 #####

--- a/test/reactant/lat_lon_compilation.jl
+++ b/test/reactant/lat_lon_compilation.jl
@@ -1,3 +1,5 @@
+include(joinpath(dirname(@__DIR__), "setup.jl"))
+
 #####
 ##### Reactant compilation tests — LatitudeLongitudeGrid (Periodic, Bounded, Bounded)
 #####

--- a/test/reactant/weno_compilation_setup.jl
+++ b/test/reactant/weno_compilation_setup.jl
@@ -1,3 +1,5 @@
+include(joinpath(dirname(@__DIR__), "setup.jl"))
+
 #####
 ##### Reactant compilation tests — WENO advection
 #####

--- a/test/reference_states.jl
+++ b/test/reference_states.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 #####
 ##### Tests for ReferenceState, compute_reference_state!, and related functions
 #####

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,5 @@
 import Breeze
 using ParallelTestRunner: find_tests, parse_args, filter_tests!, runtests, available_memory
-using Test
 
 # Start with autodiscovered tests
 testsuite = find_tests(@__DIR__)
@@ -10,7 +9,7 @@ args = parse_args(ARGS)
 
 const REACTANT_COMPAT = VERSION < v"1.13-" && Base.JLOptions().check_bounds != 1
 
-# These aren't test files, they are only used as a setup for other files.
+# These aren't test files, they are only used as setup for other tests.
 delete!(testsuite, "setup")
 delete!(testsuite, "reactant/weno_compilation_setup")
 
@@ -34,7 +33,6 @@ if Sys.isapple() && get(ENV, "GITHUB_ACTIONS", "false") == "true"
     # currently available memory (with a ~20% margin), with a lower bound of 1700 MiB.
     max_rss_memory = max(1_700, round(Int, available_memory() / 2 ^ 20 / 2  * 0.8))
     ENV["JULIA_TEST_MAXRSS_MB"] = string(max_rss_memory)
-    @info "JULIA_TEST_MAXRSS_MB set to $(max_rss_memory)"
 end
 
 runtests(Breeze, args; testsuite)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,8 @@ args = parse_args(ARGS)
 
 const REACTANT_COMPAT = VERSION < v"1.13-" && Base.JLOptions().check_bounds != 1
 
-# This isn't a test file, it's only used as a setup for other files.
+# These aren't test files, they are only used as a setup for other files.
+delete!(testsuite, "setup")
 delete!(testsuite, "reactant/weno_compilation_setup")
 
 if filter_tests!(testsuite, args)
@@ -25,30 +26,6 @@ if filter_tests!(testsuite, args)
     end
 end
 
-const init_code = quote
-    import CUDA
-    using Oceananigans.Architectures: CPU, GPU
-
-    if get(ENV, "BREEZE_ENSURE_CUDA_FUNCTIONAL", "") == "true"
-        CUDA.functional() || error("CUDA is not functional but we expect it to be, make sure it's set up correctly")
-    end
-
-    const default_arch = CUDA.functional() ? GPU() : CPU()
-
-    # Float type helpers for tests
-    # Default: Float64 only. Set BREEZE_TEST_FLOAT32=true to also test Float32.
-    function test_float_types()
-        if get(ENV, "BREEZE_TEST_FLOAT32", "false") == "true"
-            return (Float32, Float64)
-        else
-            return (Float64,)
-        end
-    end
-
-    # Returns both Float32 and Float64 for tests that need both precision levels
-    all_float_types() = (Float32, Float64)
-end
-
 if Sys.isapple() && get(ENV, "GITHUB_ACTIONS", "false") == "true"
     GC.gc(true); GC.gc(false); GC.gc(true)
     # macOS runners have little memory compared to the other runners, let's set a more
@@ -60,4 +37,4 @@ if Sys.isapple() && get(ENV, "GITHUB_ACTIONS", "false") == "true"
     @info "JULIA_TEST_MAXRSS_MB set to $(max_rss_memory)"
 end
 
-runtests(Breeze, args; testsuite, init_code)
+runtests(Breeze, args; testsuite)

--- a/test/saturation_adjustment.jl
+++ b/test/saturation_adjustment.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 using Breeze
 using GPUArraysCore: @allowscalar
 using Oceananigans

--- a/test/set_atmosphere_model.jl
+++ b/test/set_atmosphere_model.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 using Breeze
 using GPUArraysCore: @allowscalar
 using Oceananigans

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -1,0 +1,21 @@
+import CUDA
+using Oceananigans.Architectures: CPU, GPU
+
+if get(ENV, "BREEZE_ENSURE_CUDA_FUNCTIONAL", "") == "true"
+    CUDA.functional() || error("CUDA is not functional but we expect it to be, make sure it's set up correctly")
+end
+
+const default_arch = CUDA.functional() ? GPU() : CPU()
+
+# Float type helpers for tests
+# Default: Float64 only. Set BREEZE_TEST_FLOAT32=true to also test Float32.
+function test_float_types()
+    if get(ENV, "BREEZE_TEST_FLOAT32", "false") == "true"
+        return (Float32, Float64)
+    else
+        return (Float64,)
+    end
+end
+
+# Returns both Float32 and Float64 for tests that need both precision levels
+all_float_types() = (Float32, Float64)

--- a/test/solvers.jl
+++ b/test/solvers.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 using Breeze
 using Test
 

--- a/test/specific_forcing.jl
+++ b/test/specific_forcing.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 using Breeze
 using Breeze: SpecificForcing
 using Breeze.AtmosphereModels: is_density_tendency_forcing

--- a/test/substepper_rest_state.jl
+++ b/test/substepper_rest_state.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 #####
 ##### Rest-atmosphere validation tests for the acoustic substepper.
 #####

--- a/test/substepper_structural.jl
+++ b/test/substepper_structural.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 #####
 ##### Structural correctness tests for the acoustic substepper.
 #####

--- a/test/terrain_following_latlon.jl
+++ b/test/terrain_following_latlon.jl
@@ -1,11 +1,6 @@
-using Breeze
-using Oceananigans.Architectures: CPU
+include(joinpath(@__DIR__, "setup.jl"))
 
-# Run under `default_arch` when the test runner provides it (which routes to
-# GPU when CUDA is functional, matching project convention); otherwise fall
-# back to CPU() so this file can also be included directly with
-# `julia --project=. test/<this file>.jl` during development.
-@isdefined(default_arch) || (default_arch = CPU())
+using Breeze
 
 using CUDA: @allowscalar
 

--- a/test/terrain_following_metrics.jl
+++ b/test/terrain_following_metrics.jl
@@ -1,12 +1,7 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 using Breeze
 using Breeze.AtmosphereModels: x_pressure_gradient
-using Oceananigans.Architectures: CPU
-
-# Run under `default_arch` when the test runner provides it (which routes to
-# GPU when CUDA is functional, matching project convention); otherwise fall
-# back to CPU() so this file can also be included directly with
-# `julia --project=. test/<this file>.jl` during development.
-@isdefined(default_arch) || (default_arch = CPU())
 
 using CUDA: @allowscalar
 

--- a/test/terrain_following_reference_state.jl
+++ b/test/terrain_following_reference_state.jl
@@ -1,11 +1,6 @@
-using Breeze
-using Oceananigans.Architectures: CPU
+include(joinpath(@__DIR__, "setup.jl"))
 
-# Run under `default_arch` when the test runner provides it (which routes to
-# GPU when CUDA is functional, matching project convention); otherwise fall
-# back to CPU() so this file can also be included directly with
-# `julia --project=. test/<this file>.jl` during development.
-@isdefined(default_arch) || (default_arch = CPU())
+using Breeze
 
 using CUDA: @allowscalar
 

--- a/test/terrain_following_split_explicit.jl
+++ b/test/terrain_following_split_explicit.jl
@@ -1,12 +1,7 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 using Breeze
 using Breeze.AtmosphereModels: transport_velocities
-using Oceananigans.Architectures: CPU
-
-# Run under `default_arch` when the test runner provides it (which routes to
-# GPU when CUDA is functional, matching project convention); otherwise fall
-# back to CPU() so this file can also be included directly with
-# `julia --project=. test/<this file>.jl` during development.
-@isdefined(default_arch) || (default_arch = CPU())
 
 using CUDA: @allowscalar
 

--- a/test/tracer_dynamics.jl
+++ b/test/tracer_dynamics.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 using Breeze
 using Oceananigans
 using Test

--- a/test/turbulence_closures.jl
+++ b/test/turbulence_closures.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 using Breeze
 using Oceananigans
 using Test

--- a/test/unit_tests.jl
+++ b/test/unit_tests.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 #####
 ##### Consolidated unit tests for fast-running tests
 #####

--- a/test/vertical_diffusion.jl
+++ b/test/vertical_diffusion.jl
@@ -1,3 +1,5 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
 using Breeze
 using Oceananigans
 using Test


### PR DESCRIPTION
The `init_code` argument to `ParallelTestRunner.runtests` saves lots of `include`s, but it has a couple of drawbacks:

* static analysis tools like JETLS would find undefined variables/functions everywhere (because they're coming from the magic `init_code`
* AI-assisted tools ***love*** running tests with just `julia --project=test test/file.jl`, which would break down because of the same undefined variables/functions as the point above.  I suspect this is the reason why in a few places there are things like https://github.com/NumericalEarth/Breeze.jl/blob/43738af817105d57a7ccc56abda1cfcdce570c72/test/terrain_following_latlon.jl#L4-L8