### PR TITLE
Add rrtmgp_context method for Distributed architectures

### DIFF
--- a/ext/BreezeRRTMGPExt/BreezeRRTMGPExt.jl
+++ b/ext/BreezeRRTMGPExt/BreezeRRTMGPExt.jl
@@ -12,6 +12,7 @@ using DocStringExtensions: TYPEDSIGNATURES
 
 # Oceananigans imports
 using Oceananigans.Architectures: architecture, CPU, GPU
+using Oceananigans.DistributedComputations: Distributed, child_architecture
 using Oceananigans.Fields: ZFaceField, CenterField
 
 # RRTMGP imports (external types - cannot modify)
@@ -67,6 +68,9 @@ end
 function rrtmgp_context(arch::GPU)
     return ClimaComms.context(ClimaComms.CUDADevice())
 end
+
+# Radiation is column-local: each rank solves its own columns on its child architecture
+rrtmgp_context(arch::Distributed) = rrtmgp_context(child_architecture(arch))
 
 compute_datetime(dt::AbstractDateTime, epoch) = dt
 compute_datetime(t::Number, epoch::AbstractDateTime) = epoch + Millisecond(round(Int, 1000t))


### PR DESCRIPTION
`RadiativeTransferModel` on a distributed grid currently throws

```
MethodError: no method matching rrtmgp_context(::Distributed{GPU{CUDABackend}, ...})
```

because `rrtmgp_context` only has `CPU`/`GPU` methods. Radiation is column-local — each rank solves its own columns — so the context should simply come from the child architecture:

```julia
rrtmgp_context(arch::Distributed) = rrtmgp_context(child_architecture(arch))
```

Found while validating a 2×A100 `NCCLDistributed` ERA5→Breeze nested downscaling run (the AR case); with this method the all-sky RTM constructs cleanly per rank.

🤖 Generated with [Claude Code](https://claude.com/claude-code)