### PR TITLE
Convert Δt with kernel_time_step in microphysics launch sites

### DIFF
--- a/src/AnelasticEquations/anelastic_pressure_solver.jl
+++ b/src/AnelasticEquations/anelastic_pressure_solver.jl
@@ -91,8 +91,8 @@ function compute_anelastic_source_term!(solver::FourierTridiagonalPoissonSolver,
     rhs = solver.source_term
     arch = architecture(solver)
     grid = solver.grid
-    Δt_FT = kernel_time_step(arch, grid, Δt)
-    launch!(arch, grid, :xyz, _compute_anelastic_source_term!, rhs, grid, ρŨ, Δt_FT)
+    kernel_Δt = kernel_time_step(arch, grid, Δt)
+    launch!(arch, grid, :xyz, _compute_anelastic_source_term!, rhs, grid, ρŨ, kernel_Δt)
     return nothing
 end
 

--- a/src/AnelasticEquations/anelastic_time_stepping.jl
+++ b/src/AnelasticEquations/anelastic_time_stepping.jl
@@ -64,13 +64,13 @@ Update the predictor momentum ``(ρu, ρv, ρw)`` with the non-hydrostatic press
 """
 function AtmosphereModels.make_pressure_correction!(model::AnelasticModel, Δt)
     dynamics = model.dynamics
-    Δt_FT = kernel_time_step(model.architecture, model.grid, Δt)
+    kernel_Δt = kernel_time_step(model.architecture, model.grid, Δt)
 
     launch!(model.architecture, model.grid, :xyz,
             _pressure_correct_momentum!,
             model.momentum,
             model.grid,
-            Δt_FT,
+            kernel_Δt,
             dynamics.pressure_anomaly,  # kinematic pressure p'/ρᵣ
             dynamics.reference_state.density)
 

--- a/src/Microphysics/dcmip2016_kessler.jl
+++ b/src/Microphysics/dcmip2016_kessler.jl
@@ -476,10 +476,10 @@ function AtmosphereModels.microphysics_model_update!(microphysics::DCMIP2016KM, 
     # Microphysical fields
     μ = model.microphysical_fields
 
-    Δt_FT = kernel_time_step(arch, grid, Δt)
+    kernel_Δt = kernel_time_step(arch, grid, Δt)
 
     launch!(arch, grid, :xy, _microphysical_update!,
-            microphysics, grid, Nz, Δt_FT, ρ, p, pˢᵗ, constants, θˡⁱ, ρθˡⁱ, ρqᵛ, μ)
+            microphysics, grid, Nz, kernel_Δt, ρ, p, pˢᵗ, constants, θˡⁱ, ρθˡⁱ, ρqᵛ, μ)
 
     # The kernel mutated prognostic fields in the interior; refill halos and recompute
     # diagnostics and tendencies so the post-update state is consistent for the next step.

--- a/src/Microphysics/dcmip2016_kessler.jl
+++ b/src/Microphysics/dcmip2016_kessler.jl
@@ -14,6 +14,7 @@ using ..Thermodynamics:
 using ..AtmosphereModels:
     dynamics_density,
     dynamics_pressure,
+    kernel_time_step,
     standard_pressure
 
 using ..ParcelModels: ParcelModel
@@ -475,8 +476,10 @@ function AtmosphereModels.microphysics_model_update!(microphysics::DCMIP2016KM, 
     # Microphysical fields
     μ = model.microphysical_fields
 
+    Δt_FT = kernel_time_step(arch, grid, Δt)
+
     launch!(arch, grid, :xy, _microphysical_update!,
-            microphysics, grid, Nz, Δt, ρ, p, pˢᵗ, constants, θˡⁱ, ρθˡⁱ, ρqᵛ, μ)
+            microphysics, grid, Nz, Δt_FT, ρ, p, pˢᵗ, constants, θˡⁱ, ρθˡⁱ, ρqᵛ, μ)
 
     # The kernel mutated prognostic fields in the interior; refill halos and recompute
     # diagnostics and tendencies so the post-update state is consistent for the next step.

--- a/src/Microphysics/instantaneous_precipitation.jl
+++ b/src/Microphysics/instantaneous_precipitation.jl
@@ -128,10 +128,10 @@ function AtmosphereModels.microphysics_model_update!(microphysics::IP, model)
 
     saturation_adjustment = microphysics.saturation_adjustment
 
-    Δt_FT = kernel_time_step(arch, grid, Δt)
+    kernel_Δt = kernel_time_step(arch, grid, Δt)
 
     launch!(arch, grid, :xyz, _instantaneous_precipitation_update!,
-            model.dynamics, saturation_adjustment, constants, pˢᵗ, Δt_FT, ρθˡⁱ, ρqᵛ, μ)
+            model.dynamics, saturation_adjustment, constants, pˢᵗ, kernel_Δt, ρθˡⁱ, ρqᵛ, μ)
 
     # The kernel mutated prognostic fields in the interior only; refill halos and recompute
     # diagnostics and tendencies so the post-update state is consistent for the next step.

--- a/src/Microphysics/instantaneous_precipitation.jl
+++ b/src/Microphysics/instantaneous_precipitation.jl
@@ -9,6 +9,7 @@ using ..Thermodynamics:
 using ..AtmosphereModels:
     AtmosphereModels,
     dynamics_density,
+    kernel_time_step,
     total_density,
     standard_pressure
 
@@ -127,8 +128,10 @@ function AtmosphereModels.microphysics_model_update!(microphysics::IP, model)
 
     saturation_adjustment = microphysics.saturation_adjustment
 
+    Δt_FT = kernel_time_step(arch, grid, Δt)
+
     launch!(arch, grid, :xyz, _instantaneous_precipitation_update!,
-            model.dynamics, saturation_adjustment, constants, pˢᵗ, Δt, ρθˡⁱ, ρqᵛ, μ)
+            model.dynamics, saturation_adjustment, constants, pˢᵗ, Δt_FT, ρθˡⁱ, ρqᵛ, μ)
 
     # The kernel mutated prognostic fields in the interior only; refill halos and recompute
     # diagnostics and tendencies so the post-update state is consistent for the next step.

--- a/src/TimeSteppers/acoustic_runge_kutta_3.jl
+++ b/src/TimeSteppers/acoustic_runge_kutta_3.jl
@@ -162,8 +162,8 @@ end
 
 function scalar_rk3_substep!(model::AtmosphereModel, Δt_stage)
     grid = model.grid
-    Δt_FT = kernel_time_step(grid.architecture, grid, Δt_stage)
-    return scalar_substep!(model, _rk3_substep!, Δt_stage, Δt_FT)
+    kernel_Δt = kernel_time_step(grid.architecture, grid, Δt_stage)
+    return scalar_substep!(model, _rk3_substep!, Δt_stage, kernel_Δt)
 end
 
 @kernel function _rk3_substep!(u, u⁰, G, Δt_stage)

--- a/src/TimeSteppers/ssp_runge_kutta_3.jl
+++ b/src/TimeSteppers/ssp_runge_kutta_3.jl
@@ -115,13 +115,13 @@ function ssp_rk3_substep!(model, Δt, α)
     arch = grid.architecture
     U⁰ = model.timestepper.U⁰
     Gⁿ = model.timestepper.Gⁿ
-    Δt_FT = kernel_time_step(arch, grid, Δt)
+    kernel_Δt = kernel_time_step(arch, grid, Δt)
 
     prognostic = prognostic_fields(model)
     names = keys(prognostic)
 
     for (i, (u, u⁰, G)) in enumerate(zip(prognostic, U⁰, Gⁿ))
-        launch!(arch, grid, :xyz, _ssp_rk3_substep!, u, u⁰, G, Δt_FT, α)
+        launch!(arch, grid, :xyz, _ssp_rk3_substep!, u, u⁰, G, kernel_Δt, α)
 
         # Field index for implicit solver:
         # - indices 1, 2, 3 are momentum (ρu, ρv, ρw)


### PR DESCRIPTION
`AtmosphereModels.kernel_time_step` exists to convert `Δt` to the grid's float type at the launch site, because Metal cannot load Float64 kernel arguments — that is what its own comment says:

**Definition:** https://github.com/NumericalEarth/Breeze.jl/blob/d8545a231e56dfe02f1705f120e9a6596227e045/src/AtmosphereModels/AtmosphereModels.jl#L124-L129

There is no function by this name in Oceananigans, but the *conversion* is an Oceananigans convention — open-coded at each launch site rather than behind a helper, e.g. [`nonhydrostatic_ab2_step.jl#L28`](https://github.com/CliMA/Oceananigans.jl/blob/v0.110.17/src/Models/NonhydrostaticModels/nonhydrostatic_ab2_step.jl#L28) and [`nonhydrostatic_rk3_substep.jl#L34`](https://github.com/CliMA/Oceananigans.jl/blob/v0.110.17/src/Models/NonhydrostaticModels/nonhydrostatic_rk3_substep.jl#L34), both spelled `kernel_Δt = convert(eltype(grid), Δt)`, plus the same in the shallow-water and hydrostatic-free-surface steppers. `kernel_time_step` is Breeze's named version of that convention (with the Reactant override on top), so every Breeze call site is listed below.

Note that some Oceananigans kernels also convert `Δt` *inside* the kernel ([`quasi_adams_bashforth_2.jl#L138`](https://github.com/CliMA/Oceananigans.jl/blob/v0.110.17/src/TimeSteppers/quasi_adams_bashforth_2.jl#L138), [`runge_kutta_3.jl#L198`](https://github.com/CliMA/Oceananigans.jl/blob/v0.110.17/src/TimeSteppers/runge_kutta_3.jl#L198)). That is a useful robustness net but does **not** help on Metal: the Float64 must still be loaded as a kernel argument before it can be converted, which is exactly what Metal cannot do. Only the host-side conversion fixes this.

## Every call site

Reactant override:

- [`ext/BreezeReactantExt/Timesteppers.jl#L15`](https://github.com/NumericalEarth/Breeze.jl/blob/d8545a231e56dfe02f1705f120e9a6596227e045/ext/BreezeReactantExt/Timesteppers.jl#L15) — passes `Δt` through unchanged for `ReactantState`

Already used it (unchanged by this PR):

- [`src/TimeSteppers/acoustic_runge_kutta_3.jl#L165`](https://github.com/NumericalEarth/Breeze.jl/blob/d8545a231e56dfe02f1705f120e9a6596227e045/src/TimeSteppers/acoustic_runge_kutta_3.jl#L165)
- [`src/TimeSteppers/ssp_runge_kutta_3.jl#L118`](https://github.com/NumericalEarth/Breeze.jl/blob/d8545a231e56dfe02f1705f120e9a6596227e045/src/TimeSteppers/ssp_runge_kutta_3.jl#L118)
- [`src/AnelasticEquations/anelastic_time_stepping.jl#L67`](https://github.com/NumericalEarth/Breeze.jl/blob/d8545a231e56dfe02f1705f120e9a6596227e045/src/AnelasticEquations/anelastic_time_stepping.jl#L67)
- [`src/AnelasticEquations/anelastic_pressure_solver.jl#L94`](https://github.com/NumericalEarth/Breeze.jl/blob/d8545a231e56dfe02f1705f120e9a6596227e045/src/AnelasticEquations/anelastic_pressure_solver.jl#L94)

Added by this PR:

- [`src/Microphysics/dcmip2016_kessler.jl#L479`](https://github.com/NumericalEarth/Breeze.jl/blob/d8545a231e56dfe02f1705f120e9a6596227e045/src/Microphysics/dcmip2016_kessler.jl#L479) — feeds [`_microphysical_update!`](https://github.com/NumericalEarth/Breeze.jl/blob/d8545a231e56dfe02f1705f120e9a6596227e045/src/Microphysics/dcmip2016_kessler.jl#L618)
- [`src/Microphysics/instantaneous_precipitation.jl#L131`](https://github.com/NumericalEarth/Breeze.jl/blob/d8545a231e56dfe02f1705f120e9a6596227e045/src/Microphysics/instantaneous_precipitation.jl#L131) — feeds [`_instantaneous_precipitation_update!`](https://github.com/NumericalEarth/Breeze.jl/blob/d8545a231e56dfe02f1705f120e9a6596227e045/src/Microphysics/instantaneous_precipitation.jl#L143)

## The bug

The two microphysics launch sites did not convert: `Δt = model.clock.last_Δt` was passed straight into the kernels.

On a Float32 grid that Float64 argument promotes every expression it touches inside the kernel, including `rʳ^βᵃᶜᶜ` in the accretion factor and the rain-evaporation ventilation powers. Metal.jl device-overrides `^` for Float32 but not for Float64, so the promoted powers compile to genuine doubles and the kernel fails to build with `unsupported use of double value`. On CUDA the same promotion is merely slow rather than fatal, which is why this went unnoticed.

## Verification

- A Float32 moist `AtmosphereModel` (`DCMIP2016KesslerMicrophysics`, `CompressibleDynamics` with `SplitExplicitTimeDiscretization`) now builds and time-steps on Metal. Before this change it failed to compile.
- `test/dcmip2016_kessler.jl` — pass
- `test/instantaneous_precipitation.jl` — pass
- `test/quality_assurance.jl` (ExplicitImports) — pass

## Note

The `ParcelModel` method of `microphysics_model_update!` ([`src/Microphysics/dcmip2016_kessler.jl#L895`](https://github.com/NumericalEarth/Breeze.jl/blob/d8545a231e56dfe02f1705f120e9a6596227e045/src/Microphysics/dcmip2016_kessler.jl#L895)) also uses an unconverted `model.clock.last_Δt`, but that is a scalar host computation with no `launch!`, so it is left alone to keep this focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




## Naming

Second commit renames the converted local from `Δt_FT` to `kernel_Δt`, matching what Oceananigans calls it at its own launch sites ([`nonhydrostatic_ab2_step.jl#L28`](https://github.com/CliMA/Oceananigans.jl/blob/v0.110.17/src/Models/NonhydrostaticModels/nonhydrostatic_ab2_step.jl#L28)). Applied only where the local is genuinely a kernel argument; the `Δt_FT` in `acoustic_substepping.jl` is a host-side substep-count value and keeps its name.

## Open question: could this reuse `clock_convert`?

`kernel_time_step` earns its existence as a *dispatch point* — `Base.convert` cannot be specialized per-architecture, and `BreezeReactantExt` overrides it so `ReactantState` passes Δt through unchanged.

But Oceananigans already has a dispatchable convert with arguably better semantics: [`TimeSteppers.clock_convert`](https://github.com/CliMA/Oceananigans.jl/blob/v0.110.17/src/TimeSteppers/clock.jl#L176), whose Reactant override uses `Reactant.promote_to` to emit a *traced* conversion rather than giving up on converting. Breeze could plausibly use `clock_convert(eltype(grid), Δt)` everywhere and delete both `kernel_time_step` and the Breeze Reactant override — and would then get Float32 in the kernel under Reactant instead of an unconverted Float64.

Not done here: it changes Reactant behavior and wants the Reactant tests to confirm. Flagging for a follow-up.

Conversely, Oceananigans uses `clock_convert` only for adapting the clock ([`clock.jl#L187-L189`](https://github.com/CliMA/Oceananigans.jl/blob/v0.110.17/src/TimeSteppers/clock.jl#L187-L189)) and plain `convert(FT, Δt)` at its own Δt launch sites — the same non-dispatchable form. That may be worth an upstream issue.