### PR TITLE
Rename the static-energy symbol e → s (ρe → ρs) to free e for TKE

### DIFF
--- a/.agents/physics-debugging.md
+++ b/.agents/physics-debugging.md
@@ -6,13 +6,13 @@
 |----------|---------|
 | `T` | Temperature (K) |
 | `θ` | Potential temperature: `θ = T / Π` where `Π = (p/p₀)^κ` |
-| `ρe` | Density × total energy (J/m³) |
+| `ρs` | Density × static energy (J/m³) |
 | `ρθ` | Density × potential temperature (kg·K/m³) |
 
 Before applying forcing: (1) check what variable the paper uses, (2) check working examples,
 (3) check Breeze's prognostic variable, (4) verify units.
 
-**Common mistakes**: Applying T tendency to θ, confusing `ρe` with `ρθ`, forgetting Exner function in T↔θ conversion.
+**Common mistakes**: Applying T tendency to θ, confusing `ρs` with `ρθ`, forgetting Exner function in T↔θ conversion.
 
 ## When a Stable Simulation Becomes Unstable
 
@@ -36,7 +36,7 @@ The instability is NOT pre-existing if the code was stable before your changes.
 
 When implementing from papers using different models (SAM, WRF, MPAS):
 1. Identify the paper's prognostic variables and how forcing is applied.
-2. Identify Breeze's prognostics (`ρθ` or `ρe`).
+2. Identify Breeze's prognostics (`ρθ` or `ρs`).
 3. Derive the transformation (e.g., ∂θ/∂t = ∂T/∂t × 1/Π — can amplify 10× at high altitude!).
 4. Check if the paper's model handles this implicitly (e.g., SAM uses static energy ∝ T).
 

--- a/.claude/skills/new-simulation.md
+++ b/.claude/skills/new-simulation.md
@@ -15,7 +15,7 @@ Set up, run, and visualize a new atmospheric simulation with Breeze.
   boundary conditions, initial conditions, forcing, closure parameters
 - Check parameter tables, figure captions, and coordinate conventions
 - Identify the paper's prognostic variables and how forcing is applied
-- Identify Breeze's prognostics (`ρθ` or `ρe`) and derive any transformations needed
+- Identify Breeze's prognostics (`ρθ` or `ρs`) and derive any transformations needed
 
 **If designing a new case:**
 - Ask the user for the science goal or phenomenon to simulate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ src/
 Breeze uses "formulations" for different equation sets. Currently `AnelasticDynamics` in conservation
 form (all prognostics are densities) with two thermodynamic formulations:
   - `LiquidIcePotentialTemperatureThermodynamics` — prognostic `ρθ`
-  - `StaticEnergyThermodynamics` — prognostic `ρe`
+  - `StaticEnergyThermodynamics` — prognostic `ρs`
 
 Planned: fully compressible formulation, `EntropyThermodynamics` (prognostic `ρη`).
 

--- a/docs/src/anelastic_dynamics.md
+++ b/docs/src/anelastic_dynamics.md
@@ -51,7 +51,7 @@ where ``\phi`` is a nonhydrostatic pressure correction potential defined by the 
 Breeze advances a conservative moist static energy density
 
 ```math
-ρᵣ e ≡ ρᵣ \left ( c^{pm} T + g z - \mathscr{L}^l_r q^l - \mathscr{L}^i_r q^i \right ),
+ρᵣ s ≡ ρᵣ \left ( c^{pm} T + g z - \mathscr{L}^l_r q^l - \mathscr{L}^i_r q^i \right ),
 ```
 
 where ``c^{p m}`` is the mixture heat capacity, ``T`` is temperature, ``g`` is gravitational acceleration,
@@ -63,10 +63,10 @@ and
 According to [Pauluis2008](@citet), the moist static energy obeys
 
 ```math
-\partial_t(ρᵣ e) + \boldsymbol{\nabla \cdot}\, (ρᵣ e \boldsymbol{u}) = - ρᵣ w b + S_e ,
+\partial_t(ρᵣ s) + \boldsymbol{\nabla \cdot}\, (ρᵣ s \boldsymbol{u}) = - ρᵣ w b + S_s ,
 ```
 
-with vertical velocity ``w``, buoyancy ``b`` as above, and ``S_e`` including microphysical and external energy sources/sinks.
+with vertical velocity ``w``, buoyancy ``b`` as above, and ``S_s`` including microphysical and external energy sources/sinks.
 The ``ρᵣ w b`` term is the buoyancy flux that links the energy and momentum budgets in the anelastic limit.
 
 Thermodynamic closures needed for ``R^m``, ``c^{pm}`` and the Exner function ``Π = (pᵣ / p_0)^{R^m / c^{pm}}`` are given in [Thermodynamics](@ref Thermodynamics-section) section.
@@ -96,6 +96,6 @@ In Breeze this projection is implemented as a Fourier-tridiagonal solve in the v
 - ``ρᵣ(z)``, ``pᵣ(z)``: Reference density and pressure satisfying hydrostatic balance for a constant ``θᵣ``.
 - ``α = R^m T / pᵣ``, ``αᵣ = R^d θᵣ / pᵣ``: Specific volume and its reference value.
 - ``b = g (α - αᵣ) / αᵣ``: Buoyancy.
-- ``e``: Moist static energy.
+- ``s``: Moist static energy.
 - ``q^t``: Total specific humidity (vapor + condensates).
 - ``\phi``: Nonhydrostatic pressure correction potential used by the projection.

--- a/docs/src/appendix/notation.md
+++ b/docs/src/appendix/notation.md
@@ -17,7 +17,7 @@ A few notes about the following table:
   a "reference state", which is an adiabatic, hydrostatic solution to the equations of motion. But there is also an
   "energy reference temperature" and "reference latent heat", which are thermodynamic constants required to define
   the internal energy of moist atmospheric constituents.
-* Mapping to AM fields: `ρe` corresponds to `energy_density(model)`, and the moisture density is accessed via `model.moisture_density`.
+* Mapping to AM fields: `ρs` corresponds to `static_energy_density(model)`, and the moisture density is accessed via `model.moisture_density`.
 
 The following table also uses a few conventions that suffuse the source code and which are internalized by wise developers:
 
@@ -25,7 +25,7 @@ The following table also uses a few conventions that suffuse the source code and
 * `q` refers to an instance of  [`MoistureMassFractions`](@ref Breeze.Thermodynamics.MoistureMassFractions)
 * "Reference" quantities use a subscript ``r`` (e.g., ``p_r``, ``\rho_r``).
 * Phase or mixture identifiers (``d``, ``v``, ``m``, and ``t`` for *total*) appear as superscripts (e.g., ``Rᵈ``, ``cᵖᵐ``, ``qᵗ``, ``ρᵗ``), matching usage in the codebase (e.g., `Rᵈ`, `cᵖᵐ`).
-* Momentum and the thermodynamic variable are stored *coupling-density-weighted* (``ρu = ρᵈ u``, and the thermodynamic density ``ρᵡ = ρᵈ χ`` — i.e. ``ρθ = ρᵈ θ`` or ``ρe``). The coupling density is `dynamics_density(dynamics)`: the reference density ``ρᵣ`` for [`AnelasticDynamics`](@ref Breeze.AnelasticEquations.AnelasticDynamics), and the prognostic dry-air density ``ρᵈ`` for [`CompressibleDynamics`](@ref Breeze.CompressibleEquations.CompressibleDynamics). Velocity and ``θ`` are recovered by dividing by the coupling density.
+* Momentum and the thermodynamic variable are stored *coupling-density-weighted* (``ρu = ρᵈ u``, and the thermodynamic density ``ρᵡ = ρᵈ χ`` — i.e. ``ρθ = ρᵈ θ`` or ``ρs``). The coupling density is `dynamics_density(dynamics)`: the reference density ``ρᵣ`` for [`AnelasticDynamics`](@ref Breeze.AnelasticEquations.AnelasticDynamics), and the prognostic dry-air density ``ρᵈ`` for [`CompressibleDynamics`](@ref Breeze.CompressibleEquations.CompressibleDynamics). Velocity and ``θ`` are recovered by dividing by the coupling density.
 * Water/moisture is stored as *partial densities* (`ρqᵛ`, `ρqˡ`, `ρqⁱ`, …; mass per volume) and recovered as **mass fractions** by dividing by the *total* air density ``ρ = ρᵈ + ρᵗ`` (``qˣ = ρˣ/ρ``), where ``ρᵗ = ρqᵛᵉ + Σ ρqᶜ`` is the total condensate density (all phases of the condensable species). The thermodynamics works in mass fractions throughout. The total density (`total_density(dynamics)`) — diagnosed on the compressible core, the reference density on the anelastic core — is also the carrier for scalar/water advection, the equation of state, and buoyancy.
 
 | math symbol                         | code   | property name                       | description                                                                    |
@@ -39,8 +39,9 @@ The following table also uses a few conventions that suffuse the source code and
 | ``\tilde{w}``                  | `w̃`    | `AM.dynamics.contravariant_vertical_velocity` | Contravariant vertical velocity (grid-relative, normal to ``r``-surfaces) |
 | ``\rho \tilde{w}``             | `ρw̃`   | `AM.dynamics.contravariant_vertical_momentum` | Contravariant vertical momentum                                          |
 | ``r``                          | `r`    | `rnode(i, j, k, grid, ℓz)`          | Reference (computational) vertical coordinate of a terrain-following grid; the physical height is ``z(x, y, r)`` (`znode`), matching Oceananigans' `r`/`z` convention |
-| ``ρ e``                             | `ρe`   | `AM.energy_density`                 | Energy density                                                                 |
-| ``ρᵡ``                              | `ρᵡ`   | `thermodynamic_density(formulation)` | Thermodynamic density: the generic coupling-weighted prognostic thermodynamic variable, ``ρᵡ = ρᵈ χ`` — concretely ``ρθ`` for the potential-temperature formulation or ``ρe`` for static energy. The intensive variable is recovered as ``χ = ρᵡ / ρᵈ`` |
+| ``s``                               | `s`    | `static_energy(model)`              | (Liquid-ice) moist static energy, ``s = cᵖᵐ T + g z - ℒˡᵣ qˡ - ℒⁱᵣ qⁱ``; ``e`` is reserved for turbulent kinetic energy |
+| ``ρ s``                             | `ρs`   | `static_energy_density(model)`      | Static energy density, the prognostic thermodynamic variable of `StaticEnergyFormulation` |
+| ``ρᵡ``                              | `ρᵡ`   | `thermodynamic_density(formulation)` | Thermodynamic density: the generic coupling-weighted prognostic thermodynamic variable, ``ρᵡ = ρᵈ χ`` — concretely ``ρθ`` for the potential-temperature formulation or ``ρs`` for static energy. The intensive variable is recovered as ``χ = ρᵡ / ρᵈ`` |
 | ``T``                               | `T`    | `AM.temperature`                    | Temperature                                                                    |
 | ``T⁺``                              | `T⁺`   | `DewpointTemperature(model)`        | Dewpoint temperature                                                           |
 | ``p``                               | `p`    | `AM.pressure`                       | Pressure                                                                       |

--- a/docs/src/compressible_dynamics.md
+++ b/docs/src/compressible_dynamics.md
@@ -27,7 +27,7 @@ p = ρ R^m T ,
 ```
 
 where ``R^m`` is the mixture gas constant. For the potential-temperature thermodynamics the
-prognostic is ``χ = ρ θ`` and ``Π = 0``; for static-energy thermodynamics ``χ = ρ e`` and ``Π``
+prognostic is ``χ = ρ θ`` and ``Π = 0``; for static-energy thermodynamics ``χ = ρ s`` and ``Π``
 encodes pressure work.
 
 ## Time integration options

--- a/docs/src/dycore_equations_algorithms.md
+++ b/docs/src/dycore_equations_algorithms.md
@@ -36,7 +36,7 @@ Breeze supports two concrete choices for ``χ``:
 
 - **Liquid-ice potential temperature density** (``χ = ρ θ^{li}``): The potential temperature is materially conserved under adiabatic motion, so ``Π = 0``. This is the simplest thermodynamic formulation.
 
-- **Static energy density** (``χ = ρ e``): The moist static energy ``e = c^{pm} T + g z - \mathscr{L}^l_r q^l - \mathscr{L}^i_r q^i`` includes gravitational potential energy and latent heat. In this case ``Π \neq 0`` and encodes the pressure work term.
+- **Static energy density** (``χ = ρ s``): The moist static energy ``s = c^{pm} T + g z - \mathscr{L}^l_r q^l - \mathscr{L}^i_r q^i`` includes gravitational potential energy and latent heat. In this case ``Π \neq 0`` and encodes the pressure work term.
 
 The thermodynamic equation couples to the momentum equation through the equation of state (below) and buoyancy.
 
@@ -71,7 +71,7 @@ Thermodynamic relations (mixture gas constant ``R^m``, heat capacity ``c^{pm}``,
 - ``p``: Pressure
 - ``T``: Temperature
 - ``θ``: Potential temperature
-- ``χ``: Thermodynamic prognostic variable (``ρθ`` or ``ρe``)
+- ``χ``: Thermodynamic prognostic variable (``ρθ`` or ``ρs``)
 
 ### Moisture
 - ``q^t``: Total specific humidity (vapor + condensates)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -79,12 +79,12 @@ reference_state = ReferenceState(grid, surface_pressure=p₀, potential_temperat
 dynamics = AnelasticDynamics(reference_state)
 
 Q₀ = 1000 # heat flux in W / m²
-ρe_bcs = FieldBoundaryConditions(bottom=FluxBoundaryCondition(Q₀))
+ρs_bcs = FieldBoundaryConditions(bottom=FluxBoundaryCondition(Q₀))
 ρqᵛ_bcs = FieldBoundaryConditions(bottom=FluxBoundaryCondition(1e-2))
 
 advection = WENO()
 model = AtmosphereModel(grid; advection, dynamics,
-                              boundary_conditions = (ρe=ρe_bcs, ρqᵛ=ρqᵛ_bcs))
+                              boundary_conditions = (ρs=ρs_bcs, ρqᵛ=ρqᵛ_bcs))
 
 Δθ = 2 # ᵒK
 Tₛ = reference_state.potential_temperature # K

--- a/docs/src/microphysics/mixed_phase_saturation_adjustment.md
+++ b/docs/src/microphysics/mixed_phase_saturation_adjustment.md
@@ -105,7 +105,7 @@ fig
   `T ≤ Tʰ` (``λ = 0``, all ice).
 - The moist static energy in Breeze includes both liquid and ice latent heats in mixed-phase conditions:
   ```math
-  e = cᵖᵐ T + g z - ℒˡᵣ qˡ - ℒⁱᵣ qⁱ .
+  s = cᵖᵐ T + g z - ℒˡᵣ qˡ - ℒⁱᵣ qⁱ .
   ```
 
 For details about the saturation adjustment algorithm itself and moist static energy,

--- a/docs/src/microphysics/warm_phase_saturation_adjustment.md
+++ b/docs/src/microphysics/warm_phase_saturation_adjustment.md
@@ -7,19 +7,19 @@ Mixed-phase saturation adjustment is described by [Pressel2015](@citet).
 ## Moist static energy and total moisture mass fraction
 
 The saturation adjustment solver (specific to our anelastic formulation) takes four inputs:
-* moist static energy ``e``,
+* moist static energy ``s``,
 * total moisture mass fraction ``qᵗ``,
 * height ``z``, and
 * reference pressure ``pᵣ``.
 
-Note that moist static energy density ``ρᵣ e`` and moisture density ``ρᵣ qᵗ``
+Note that moist static energy density ``ρᵣ s`` and moisture density ``ρᵣ qᵗ``
 are prognostic variables for [`AtmosphereModel`](@ref) when using [`AnelasticDynamics`](@ref),
 where ``ρᵣ`` is the reference density.
-With warm-phase microphysics, the moist static energy ``e`` is related to temperature ``T``,
+With warm-phase microphysics, the moist static energy ``s`` is related to temperature ``T``,
 height ``z``, and liquid mass fraction ``qˡ`` by
 
 ```math
-e ≡ cᵖᵐ \, T + g z - ℒˡᵣ qˡ ,
+s ≡ cᵖᵐ \, T + g z - ℒˡᵣ qˡ ,
 ```
 
 where ``cᵖᵐ`` is the mixture heat capacity, ``g`` is gravitational acceleration,
@@ -76,7 +76,7 @@ This expression can also be found in paper by [Pressel2015](@citet), equation (3
 We compute the saturation adjustment temperature by solving the nonlinear algebraic equation
 
 ```math
-0 = r(T) ≡ T - \frac{1}{cᵖᵐ} \left [ e - g z + ℒˡᵣ \max(0, qᵗ - qᵛ⁺) \right ] \,
+0 = r(T) ≡ T - \frac{1}{cᵖᵐ} \left [ s - g z + ℒˡᵣ \max(0, qᵗ - qᵛ⁺) \right ] \,
 ```
 
 where ``r`` is the "residual", using a secant method.
@@ -131,7 +131,7 @@ cᵖᵐ = mixture_heat_capacity(q, thermo)
 g = thermo.gravitational_acceleration
 z = 0.0
 ℒˡᵣ = thermo.liquid.reference_latent_heat
-e = cᵖᵐ * T + g * z - ℒˡᵣ * qˡ
+s = cᵖᵐ * T + g * z - ℒˡᵣ * qˡ
 ```
 
 Moist static energy has units ``\mathrm{m^2 / s^2}``, or ``\mathrm{J} / \mathrm{kg}``.
@@ -144,7 +144,7 @@ using Breeze.Microphysics: compute_temperature
 microphysics = SaturationAdjustment(equilibrium=WarmPhaseEquilibrium())
 
 q₀ = MoistureMassFractions(qᵗ)
-𝒰 = Breeze.Thermodynamics.StaticEnergyState(e, q₀, z, p)
+𝒰 = Breeze.Thermodynamics.StaticEnergyState(s, q₀, z, p)
 T★ = compute_temperature(𝒰, microphysics, thermo)
 ```
 
@@ -153,7 +153,7 @@ to the temperature in unsaturated conditions,
 
 ```@example microphysics
 cᵖᵐ₁ = mixture_heat_capacity(q₀, thermo)
-T₁ = (e - g * z) / cᵖᵐ₁
+T₁ = (s - g * z) / cᵖᵐ₁
 ```
 
 The difference between ``T₁`` and the solution ``T_\mathrm{eq}`` is
@@ -214,7 +214,7 @@ using Breeze.Thermodynamics: StaticEnergyState
 
 T₀ = 288
 cᵖᵈ = thermo.dry_air.heat_capacity
-e₀ = cᵖᵈ * T₀ # representative value
+s₀ = cᵖᵈ * T₀ # representative value
 z = 0.0
 p = 101325.0
 
@@ -226,7 +226,7 @@ qˡ = zeros(length(qᵗ))
 
 for (i, qᵗⁱ) in enumerate(qᵗ)
     q = MoistureMassFractions(qᵗⁱ)
-    𝒰 = StaticEnergyState(e₀, q, z, p)
+    𝒰 = StaticEnergyState(s₀, q, z, p)
     T[i] = compute_temperature(𝒰, microphysics, thermo)
     qᵛ⁺ = equilibrium_saturation_specific_humidity(T[i], p, qᵗⁱ, thermo, WarmPhaseEquilibrium())
     qˡ[i] = max(0, qᵗⁱ - qᵛ⁺)
@@ -290,8 +290,8 @@ g = thermo.gravitational_acceleration
 for k = 1:grid.Nz
     pᵣ = reference_state.pressure[1, 1, k]
     Tᵣ = θ₀ * (pᵣ / p₀)^(Rᵈ / cᵖᵈ)
-    e₀ = cᵖᵐ * Tᵣ + g * z[k]
-    𝒰 = StaticEnergyState(e₀, q, z[k], pᵣ)
+    s₀ = cᵖᵐ * Tᵣ + g * z[k]
+    𝒰 = StaticEnergyState(s₀, q, z[k], pᵣ)
     T[k] = compute_temperature(𝒰, microphysics, thermo)
 
     # Saturation specific humidity via adjustment formula using T[k], pᵣ, and qᵗ

--- a/docs/src/thermodynamics.md
+++ b/docs/src/thermodynamics.md
@@ -771,7 +771,7 @@ which is equation (37) of [Pressel2015](@citet) and the saturated branch of [`eq
 For moist air, a convenient thermodynamic invariant that couples temperature, composition, and height is the moist static energy (MSE),
 
 ```math
-e ≡ cᵖᵐ \, T + g z - Lˡᵣ \, qˡ - Lⁱᵣ qⁱ .
+s ≡ cᵖᵐ \, T + g z - Lˡᵣ \, qˡ - Lⁱᵣ qⁱ .
 ```
 
 !!! note "The alternative 'frozen moist static energy' variable"
@@ -780,10 +780,10 @@ e ≡ cᵖᵐ \, T + g z - Lˡᵣ \, qˡ - Lⁱᵣ qⁱ .
     models such as the Global System for Atmospheric Modeling (GSAM) [Khairoutdinov2022](@cite) is
 
     ```math
-    ẽ ≡ cᵖᵐ \, T + g z + Lˡᵣ \, qᵛ - Lᶠᵣ qⁱ .
+    s̃ ≡ cᵖᵐ \, T + g z + Lˡᵣ \, qᵛ - Lᶠᵣ qⁱ .
     ```
 
-    ``e`` and ``ẽ`` are not the same, but they obey the same conservation equation provided
+    ``s`` and ``s̃`` are not the same, but they obey the same conservation equation provided
     that total moisture fraction is conserved, or that ``\mathrm{D}qᵗ / \mathrm{D}t = 0``.
 
 ## Liquid-ice potential temperature

--- a/examples/bomex.jl
+++ b/examples/bomex.jl
@@ -162,38 +162,38 @@ qᵉ_drying_forcing = Forcing(drying)
 # A prescribed radiative cooling profile is applied to the thermodynamic equation
 # ([Siebesma2003](@citet); Appendix B, Eq. B3). Below the inversion, radiative cooling
 # of about 2 K/day counteracts the surface heating. We supply the cooling as a specific
-# energy tendency `e` (J/kg/s) so it is consistently applied to the potential temperature
+# energy tendency `s` (J/kg/s) so it is consistently applied to the potential temperature
 # equation (see below).
 
 radiative_cooling = Field{Nothing, Nothing, Center}(grid)
 cᵖᵈ = constants.dry_air.heat_capacity
 dTdt_bomex = AtmosphericProfilesLibrary.Bomex_dTdt(FT)
 set!(radiative_cooling, z -> cᵖᵈ * dTdt_bomex(1, z))
-e_radiation_forcing = Forcing(radiative_cooling)
+s_radiation_forcing = Forcing(radiative_cooling)
 
 # ## Assembling all the forcings
 #
-# Forcings are keyed under specific prognostic names (`u`, `v`, `θ`, `qᵉ`, `e`);
+# Forcings are keyed under specific prognostic names (`u`, `v`, `θ`, `qᵉ`, `s`);
 # Breeze applies the density factor ``ρ`` automatically at kernel time. When
 # multiple forcings act on the same prognostic field — e.g. subsidence and the
 # geostrophic adjustment on the horizontal velocity — they are combined as a
 # tuple, and Breeze sums their contributions.
 #
-# Forcings on `e` and `θ` both contribute to the tendency of `ρθ` in different
+# Forcings on `s` and `θ` both contribute to the tendency of `ρθ` in different
 # ways. The tendency for `ρθ` is written
 #
 # ```math
-# ∂_t (ρ θ) = - \boldsymbol{\nabla \cdot} \, ( ρ \boldsymbol{u} θ ) + ρ F_θ + \frac{ρ F_e}{cᵖᵐ Π} + \cdots
+# ∂_t (ρ θ) = - \boldsymbol{\nabla \cdot} \, ( ρ \boldsymbol{u} θ ) + ρ F_θ + \frac{ρ F_s}{cᵖᵐ Π} + \cdots
 # ```
 #
-# where ``F_e`` denotes the specific energy forcing supplied under `e` and
+# where ``F_s`` denotes the specific energy forcing supplied under `s` and
 # ``F_θ`` denotes the specific potential-temperature forcing supplied under `θ`.
 
 forcing = (; u = (subsidence, geostrophic.u),
              v = (subsidence, geostrophic.v),
              θ = subsidence,
              qᵉ = (subsidence, qᵉ_drying_forcing),
-             e = e_radiation_forcing)
+             s = s_radiation_forcing)
 nothing #hide
 
 # ## Model setup

--- a/examples/cloudy_thermal_bubble.jl
+++ b/examples/cloudy_thermal_bubble.jl
@@ -59,7 +59,7 @@ E = total_energy(model)
 fig = Figure()
 ax = Axis(fig[1, 1], aspect=2, xlabel="x (m)", ylabel="z (m)", title="Initial potential temperature θ (K)")
 hm = heatmap!(ax, θ)
-Colorbar(fig[1, 2], hm, label = "ρe′ (J/kg)")
+Colorbar(fig[1, 2], hm, label = "θ (K)")
 fig
 
 # ## Simulation rising

--- a/examples/dry_thermal_bubble.jl
+++ b/examples/dry_thermal_bubble.jl
@@ -49,9 +49,9 @@ end
 
 set!(model, θ = θᵢ)
 
-ρe = static_energy_density(model)
-ρE = Field(Average(ρe, dims=1))
-ρe′ = Field(ρe - ρE)
+ρs = static_energy_density(model)
+ρS = Field(Average(ρs, dims=1))
+ρs′ = Field(ρs - ρS)
 
 # ## Initial energy perturbation visualization
 #
@@ -59,9 +59,9 @@ set!(model, θ = θᵢ)
 # as expected.
 
 fig = Figure()
-ax = Axis(fig[1, 1], aspect=2, xlabel="x (m)", ylabel="z (m)", title="Initial energy perturbation ρe′ (J / kg)")
-hm = heatmap!(ax, ρe′)
-Colorbar(fig[1, 2], hm, label = "ρe′ (J/kg)")
+ax = Axis(fig[1, 1], aspect=2, xlabel="x (m)", ylabel="z (m)", title="Initial energy perturbation ρs′ (J / kg)")
+hm = heatmap!(ax, ρs′)
+Colorbar(fig[1, 2], hm, label = "ρs′ (J/kg)")
 fig
 
 # ## Simulation rising
@@ -71,12 +71,12 @@ conjure_time_step_wizard!(simulation, cfl=0.7)
 Oceananigans.Diagnostics.erroring_NaNChecker!(simulation)
 
 function progress(sim)
-    ρe = static_energy_density(sim.model)
+    ρs = static_energy_density(sim.model)
     u, v, w = sim.model.velocities
 
-    msg = @sprintf("Iter: %d, t: %s, Δt: %s, extrema(ρe): (%.2f, %.2f) J/kg, max|u|: %.2f m/s, max|w|: %.2f m/s",
+    msg = @sprintf("Iter: %d, t: %s, Δt: %s, extrema(ρs): (%.2f, %.2f) J/kg, max|u|: %.2f m/s, max|w|: %.2f m/s",
                    iteration(sim), prettytime(sim), prettytime(sim.Δt),
-                   minimum(ρe), maximum(ρe),
+                   minimum(ρs), maximum(ρs),
                    maximum(abs, u), maximum(abs, w))
 
     @info msg
@@ -88,7 +88,7 @@ add_callback!(simulation, progress, TimeInterval(1minute))
 u, v, w = model.velocities
 T = model.temperature
 
-outputs = merge(model.velocities, model.tracers, (; ρe′, ρe, T))
+outputs = merge(model.velocities, model.tracers, (; ρs′, ρs, T))
 
 filename = "thermal_bubble.jld2"
 writer = JLD2Writer(model, outputs; filename,
@@ -106,31 +106,31 @@ run!(simulation)
 
 @info "Creating visualization..."
 
-ρe′t = FieldTimeSeries(filename, "ρe′")
+ρs′t = FieldTimeSeries(filename, "ρs′")
 wt = FieldTimeSeries(filename, "w")
 
-times = ρe′t.times
-Nt = length(ρe′t)
+times = ρs′t.times
+Nt = length(ρs′t)
 
 fig = Figure(size = (800, 800), fontsize = 12)
-axρ = Axis(fig[1, 1], aspect=2, xlabel="x (m)", ylabel="z (m)", title="Energy perturbation ρe′ (J / kg)")
+axρ = Axis(fig[1, 1], aspect=2, xlabel="x (m)", ylabel="z (m)", title="Energy perturbation ρs′ (J / kg)")
 axw = Axis(fig[2, 1], aspect=2, xlabel="x (m)", ylabel="z (m)", title="Vertical velocity w (m / s)")
 
 n = Observable(Nt)
 
-ρe′n = @lift ρe′t[$n]
+ρs′n = @lift ρs′t[$n]
 wn = @lift wt[$n]
 
 title = @lift "Thermal bubble evolution — t = $(prettytime(times[$n]))"
 fig[0, :] = Label(fig, title, fontsize = 16, tellwidth = false)
 
-ρe′_range = (minimum(ρe′t), maximum(ρe′t))
+ρs′_range = (minimum(ρs′t), maximum(ρs′t))
 w_range = maximum(abs, wt)
 
-hmρ = heatmap!(axρ, ρe′n, colorrange = ρe′_range, colormap = :balance)
+hmρ = heatmap!(axρ, ρs′n, colorrange = ρs′_range, colormap = :balance)
 hmw = heatmap!(axw, wn, colorrange = (-w_range, w_range), colormap = :balance)
 
-Colorbar(fig[1, 2], hmρ, label = "ρe′ (J/kg)", vertical = true)
+Colorbar(fig[1, 2], hmρ, label = "ρs′ (J/kg)", vertical = true)
 Colorbar(fig[2, 2], hmw, label = "w (m/s)", vertical = true)
 
 CairoMakie.record(fig, "thermal_bubble.mp4", 1:Nt; framerate = 12, compression = 23) do nn

--- a/examples/prescribed_sea_surface_temperature.jl
+++ b/examples/prescribed_sea_surface_temperature.jl
@@ -196,7 +196,7 @@ T₀(x) = θ₀ + ΔT / 2 * sign(cos(2π * x / grid.Lx))
 # We complete our specification by using the same polynomial coefficient for
 # sensible and latent heat fluxes. The flux type will be automatically inferred:
 
-ρe_surface_flux = BulkSensibleHeatFlux(coefficient=coef; gustiness=Uᵍ, surface_temperature=T₀, filtered_velocities)
+ρs_surface_flux = BulkSensibleHeatFlux(coefficient=coef; gustiness=Uᵍ, surface_temperature=T₀, filtered_velocities)
 ρqᵉ_surface_flux = BulkVaporFlux(coefficient=coef; gustiness=Uᵍ, surface_temperature=T₀, filtered_velocities)
 
 # We can visualize how the neutral drag coefficient varies with wind speed,
@@ -259,7 +259,7 @@ fig
 
 ρu_bcs = FieldBoundaryConditions(bottom=ρu_surface_flux)
 ρv_bcs = FieldBoundaryConditions(bottom=ρv_surface_flux)
-ρe_bcs = FieldBoundaryConditions(bottom=ρe_surface_flux)
+ρs_bcs = FieldBoundaryConditions(bottom=ρs_surface_flux)
 ρqᵉ_bcs = FieldBoundaryConditions(bottom=ρqᵉ_surface_flux)
 
 # ## Model construction
@@ -269,7 +269,7 @@ fig
 # schemes, microphysics, and boundary conditions.
 
 model = AtmosphereModel(grid; momentum_advection, scalar_advection, microphysics, dynamics,
-                        boundary_conditions = (ρu=ρu_bcs, ρv=ρv_bcs, ρe=ρe_bcs, ρqᵉ=ρqᵉ_bcs))
+                        boundary_conditions = (ρu=ρu_bcs, ρv=ρv_bcs, ρs=ρs_bcs, ρqᵉ=ρqᵉ_bcs))
 
 # ## Initial conditions
 #
@@ -327,8 +327,8 @@ qᵛ = specific_humidity(model)
 τˣ = BoundaryConditionOperation(ρu, :bottom, model)
 
 ## Sensible heat flux 𝒬ᵀ
-ρe = static_energy_density(model)
-𝒬ᵀ = BoundaryConditionOperation(ρe, :bottom, model)
+ρs = static_energy_density(model)
+𝒬ᵀ = BoundaryConditionOperation(ρs, :bottom, model)
 
 ## Latent heat flux: ``𝒬ᵛ = ℒˡ Jᵛ`` (using reference ``θ₀`` for latent heat)
 ρqᵉ = model.moisture_density

--- a/examples/radiative_convection.jl
+++ b/examples/radiative_convection.jl
@@ -168,7 +168,7 @@ microphysics = SaturationAdjustment(equilibrium=WarmPhaseEquilibrium())
 # equilibrium: ozone absorbs shortwave radiation and the coarse upper cells
 # respond strongly. A Newtonian relaxation of temperature toward the initial
 # profile above 8 km keeps the stratosphere anchored without affecting the
-# tropospheric dynamics. We apply this as an energy forcing on `ρe`, which
+# tropospheric dynamics. We apply this as an energy forcing on `ρs`, which
 # Breeze automatically converts to a `ρθ` tendency.
 
 Tᵣ = reference_state.temperature
@@ -189,7 +189,7 @@ end
 sponge = Forcing(stratospheric_relaxation; discrete_form=true,
                  parameters=(; Tᵣ, ρᵣ, cᵖᵈ, τ=τ_sponge))
 
-forcing = (; ρe=sponge)
+forcing = (; ρs=sponge)
 
 # ## Model assembly
 

--- a/examples/rico.jl
+++ b/examples/rico.jl
@@ -80,10 +80,10 @@ T₀ = 299.8    # Sea surface temperature (K)
 # We implement the specified bulk formula with Breeze utilities whose scope
 # currently extends only to constant coefficients (but could expand in the future),
 
-ρe_flux = BulkSensibleHeatFlux(coefficient=Cᵀ, surface_temperature=T₀)
+ρs_flux = BulkSensibleHeatFlux(coefficient=Cᵀ, surface_temperature=T₀)
 ρqᵉ_flux = BulkVaporFlux(coefficient=Cᵛ, surface_temperature=T₀)
 
-ρe_bcs = FieldBoundaryConditions(bottom=ρe_flux)
+ρs_bcs = FieldBoundaryConditions(bottom=ρs_flux)
 ρqᵉ_bcs = FieldBoundaryConditions(bottom=ρqᵉ_flux)
 
 ρu_bcs = FieldBoundaryConditions(bottom=BulkDrag(coefficient=Cᴰ))
@@ -164,7 +164,7 @@ forcing = (; u = (subsidence, geostrophic.u),
              w = sponge,
              qᵉ = (subsidence, qᵉ_large_scale_forcing),
              θ = (subsidence, θ_large_scale_forcing))
-boundary_conditions = (ρe=ρe_bcs, ρqᵉ=ρqᵉ_bcs, ρu=ρu_bcs, ρv=ρv_bcs)
+boundary_conditions = (ρs=ρs_bcs, ρqᵉ=ρqᵉ_bcs, ρu=ρu_bcs, ρv=ρv_bcs)
 nothing #hide
 
 # ## Model setup

--- a/examples/tropical_cyclone_world.jl
+++ b/examples/tropical_cyclone_world.jl
@@ -117,7 +117,7 @@ Uᵍ = 1
 ρu_bcs = FieldBoundaryConditions(bottom = BulkDrag(coefficient = Cᴰ, gustiness = Uᵍ))
 ρv_bcs = FieldBoundaryConditions(bottom = BulkDrag(coefficient = Cᴰ, gustiness = Uᵍ))
 
-ρe_bcs = FieldBoundaryConditions(bottom = BulkSensibleHeatFlux(coefficient = Cᵀ,
+ρs_bcs = FieldBoundaryConditions(bottom = BulkSensibleHeatFlux(coefficient = Cᵀ,
                                                                gustiness = Uᵍ,
                                                                surface_temperature = T₀))
 
@@ -125,7 +125,7 @@ Uᵍ = 1
                                                         gustiness = Uᵍ,
                                                         surface_temperature = T₀))
 
-boundary_conditions = (; ρu=ρu_bcs, ρv=ρv_bcs, ρe=ρe_bcs, ρqᵉ=ρqᵉ_bcs)
+boundary_conditions = (; ρu=ρu_bcs, ρv=ρv_bcs, ρs=ρs_bcs, ρqᵉ=ρqᵉ_bcs)
 nothing #hide
 
 # ## Radiative forcing
@@ -133,21 +133,21 @@ nothing #hide
 # The paper (Eq. 1) prescribes a piecewise radiative tendency: constant cooling
 # at ``Ṫ = 1`` K/day for ``T > T^{ts}`` (troposphere), and Newtonian relaxation toward ``T^{ts}``
 # with timescale ``τ_r = 20`` days for ``T ≤ T^{ts}`` (stratosphere). We apply this as an
-# energy forcing on ``ρe``, so that Breeze handles the conversion to ``ρθ`` tendency.
+# energy forcing on ``ρs``, so that Breeze handles the conversion to ``ρθ`` tendency.
 
 Ṫ  = 1 / day
 τᵣ = 20days
 ρᵣ = reference_state.density
 parameters = (; Tᵗˢ, Ṫ, τᵣ, ρᵣ, cᵖᵈ)
 
-@inline function ρe_forcing_func(i, j, k, grid, clock, model_fields, p)
+@inline function ρs_forcing_func(i, j, k, grid, clock, model_fields, p)
     @inbounds T = model_fields.T[i, j, k]
     @inbounds ρ = p.ρᵣ[i, j, k]
     ∂t_T = ifelse(T > p.Tᵗˢ, -p.Ṫ, (p.Tᵗˢ - T) / p.τᵣ)
     return ρ * p.cᵖᵈ * ∂t_T
 end
 
-ρe_forcing = Forcing(ρe_forcing_func; discrete_form=true, parameters)
+ρs_forcing = Forcing(ρs_forcing_func; discrete_form=true, parameters)
 
 # ## Sponge layer
 #
@@ -157,7 +157,7 @@ end
 sponge_mask = GaussianMask{:z}(center=26kilometers, width=2kilometers)
 ρw_sponge = Relaxation(rate=1/30, mask=sponge_mask)
 
-forcing = (; ρe=ρe_forcing, ρw=ρw_sponge)
+forcing = (; ρs=ρs_forcing, ρw=ρw_sponge)
 nothing #hide
 
 # ## Model
@@ -211,9 +211,9 @@ s = @at (Center, Center, Center) sqrt(u^2 + v^2)
 s₀ = Field(s, indices = (:, :, 1))
 
 ρqᵉ = model.moisture_density
-ρe = static_energy_density(model)
+ρs = static_energy_density(model)
 ℒˡ = Breeze.Thermodynamics.liquid_latent_heat(T₀, constants)
-𝒬ᵀ = BoundaryConditionOperation(ρe, :bottom, model)
+𝒬ᵀ = BoundaryConditionOperation(ρs, :bottom, model)
 Jᵛ = BoundaryConditionOperation(ρqᵉ, :bottom, model)
 𝒬 = Field(𝒬ᵀ + ℒˡ * Jᵛ)
 

--- a/src/AtmosphereModels/Diagnostics/static_energy.jl
+++ b/src/AtmosphereModels/Diagnostics/static_energy.jl
@@ -26,13 +26,13 @@ const StaticEnergy = KernelFunctionOperation{Center, Center, Center, <:Any, <:An
 """
     StaticEnergy(model, flavor=:specific)
 
-Return a `KernelFunctionOperation` representing moist static energy ``e``.
+Return a `KernelFunctionOperation` representing moist static energy ``s``.
 
 Moist static energy is a conserved quantity in adiabatic, frictionless flow that
 combines sensible heat, gravitational potential energy, and latent heat:
 
 ```math
-e = cᵖᵐ T + g z - ℒˡᵣ qˡ - ℒⁱᵣ qⁱ
+s = cᵖᵐ T + g z - ℒˡᵣ qˡ - ℒⁱᵣ qⁱ
 ```
 
 where ``cᵖᵐ`` is the moist air heat capacity, ``T`` is temperature,
@@ -44,7 +44,7 @@ This is the prognostic thermodynamic variable used in `StaticEnergyThermodynamic
 # Arguments
 
 - `model`: An `AtmosphereModel` instance.
-- `flavor`: Either `:specific` (default) to return ``e``, or `:density` to return ``ρ e``.
+- `flavor`: Either `:specific` (default) to return ``s``, or `:density` to return ``ρ s``.
 
 # Examples
 
@@ -55,8 +55,8 @@ grid = RectilinearGrid(size=(1, 1, 8), extent=(1, 1, 1e3))
 model = AtmosphereModel(grid)
 set!(model, θ=300)
 
-e = StaticEnergy(model)
-Field(e)
+s = StaticEnergy(model)
+Field(s)
 
 # output
 1×1×8 Field{Center, Center, Center} on RectilinearGrid on CPU
@@ -110,11 +110,11 @@ function (d::StaticEnergyKernelFunction)(i, j, k, grid)
     qⁱ = q.ice
 
     # Moist static energy
-    e = cᵖᵐ * T + g * z - ℒˡᵣ * qˡ - ℒⁱᵣ * qⁱ
+    s = cᵖᵐ * T + g * z - ℒˡᵣ * qˡ - ℒⁱᵣ * qⁱ
 
     if d.flavor isa Specific
-        return e
+        return s
     elseif d.flavor isa Density
-        return ρᵣ * e
+        return ρᵣ * s
     end
 end

--- a/src/AtmosphereModels/adiabatic_balance.jl
+++ b/src/AtmosphereModels/adiabatic_balance.jl
@@ -197,7 +197,7 @@ $(TYPEDSIGNATURES)
 
 Build a stripped adiabatic twin of `model` that SHARES all field memory (momentum, velocities,
 densities, ρθ, moisture, tracers, temperature, pressure solver, dynamics fields) and steps it in
-place. Every prognostic scalar — momentum, ρθ/ρe, moisture, and tracers — is rewrapped with its
+place. Every prognostic scalar — momentum, ρθ/ρs, moisture, and tracers — is rewrapped with its
 surface fluxes stripped to no-flux (see [`adiabatic_scalar_bcs`](@ref)), sharing the production data
 so no memory is reallocated. The twin's dynamics comes from [`adiabatic_twin_dynamics`](@ref) (per
 `balancer.time_stepping`); microphysics, closure, the implicit diffusion solver, the sponge, and

--- a/src/AtmosphereModels/atmosphere_model.jl
+++ b/src/AtmosphereModels/atmosphere_model.jl
@@ -100,7 +100,7 @@ AtmosphereModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
 │   ├── momentum: Centered(order=2)
 │   ├── ρθ: Centered(order=2)
 │   └── ρqᵛ: Centered(order=2)
-├── forcing: @NamedTuple{ρu::Returns{Float64}, ρv::Returns{Float64}, ρw::Returns{Float64}, ρθ::Returns{Float64}, ρqᵛ::Returns{Float64}, ρe::Returns{Float64}}
+├── forcing: @NamedTuple{ρu::Returns{Float64}, ρv::Returns{Float64}, ρw::Returns{Float64}, ρθ::Returns{Float64}, ρqᵛ::Returns{Float64}, ρs::Returns{Float64}}
 ├── tracers: ()
 ├── coriolis: Nothing
 └── microphysics: Nothing
@@ -180,7 +180,7 @@ function AtmosphereModel(grid;
     preliminary_microphysical_fields = materialize_microphysical_fields(microphysics, grid, field_boundary_conditions)
 
     # Materialize atmosphere-specific boundary conditions (fill in VPT diagnostic,
-    # surface pressure, thermodynamic constants, convert ρe → ρθ for potential temperature formulations)
+    # surface pressure, thermodynamic constants, convert ρs → ρθ for potential temperature formulations)
     p₀ = surface_pressure(dynamics)
     # Pass preliminary microphysical fields for BC materialization; the qᵛ field within
     # provides the specific_prognostic_moisture reference needed by VirtualPotentialTemperature.
@@ -267,7 +267,7 @@ function AtmosphereModel(grid;
                                        velocities, dynamics, formulation, microphysics,
                                        specific_prognostic_moisture)
 
-    # Include thermodynamic density (ρe or ρθ), moisture, microphysical prognostic fields, plus user tracers
+    # Include thermodynamic density (ρs or ρθ), moisture, microphysical prognostic fields, plus user tracers
     closure_thermo_name = thermodynamic_density_name(formulation)
     microphysical_names = prognostic_field_names(microphysics)
     scalar_names = tuple(closure_thermo_name, moisture_name, microphysical_names..., tracer_names...)
@@ -418,10 +418,10 @@ function atmosphere_model_forcing(user_forcings::NamedTuple, prognostic_fields, 
 
     user_forcing_names = keys(user_forcings)
 
-    if :ρe ∈ keys(prognostic_fields)
+    if :ρs ∈ keys(prognostic_fields)
         forcing_fields = prognostic_fields
     else
-        forcing_fields = merge(prognostic_fields, (; ρe=prognostic_fields.ρθ))
+        forcing_fields = merge(prognostic_fields, (; ρs=prognostic_fields.ρθ))
     end
 
     forcing_names = keys(forcing_fields)
@@ -552,8 +552,8 @@ Models.boundary_condition_args(model::AtmosphereModel) = (model.clock, fields(mo
 function total_energy(model)
     u, v, w = model.velocities
     k = @at (Center, Center, Center) (u^2 + v^2 + w^2) / 2 |> Field
-    e = static_energy(model) |> Field
-    return k + e
+    s = static_energy(model) |> Field
+    return k + s
 end
 
 # Check for NaNs in the first prognostic field

--- a/src/AtmosphereModels/forcing_interface.jl
+++ b/src/AtmosphereModels/forcing_interface.jl
@@ -12,7 +12,7 @@
 Regularize boundary conditions for an `AtmosphereModel`. This function is extended
 by the `BoundaryConditions` module to provide atmosphere-specific boundary condition handling.
 
-If `formulation` is `:LiquidIcePotentialTemperature` and `ρe` boundary conditions are provided,
+If `formulation` is `:LiquidIcePotentialTemperature` and `ρs` boundary conditions are provided,
 they are automatically converted to `ρθ` boundary conditions by wrapping flux BCs in
 `EnergyFluxBoundaryCondition`, which divides by the local mixture heat capacity.
 

--- a/src/AtmosphereModels/formulation_interface.jl
+++ b/src/AtmosphereModels/formulation_interface.jl
@@ -17,7 +17,7 @@ complete formulation with all required fields.
 
 Valid symbols:
 - `:LiquidIcePotentialTemperature`, `:θ`, `:ρθ`, `:PotentialTemperature` → `LiquidIcePotentialTemperatureFormulation`
-- `:StaticEnergy`, `:e`, `:ρe` → `StaticEnergyFormulation`
+- `:StaticEnergy`, `:s`, `:ρs` → `StaticEnergyFormulation`
 """
 function materialize_formulation end
 
@@ -81,7 +81,7 @@ additional_thermodynamic_field_names(formulation_name::Symbol) =
 """
     thermodynamic_density_name(formulation)
 
-Return the name of the thermodynamic density field (e.g., `:ρθ`, `:ρe`, `:ρE`).
+Return the name of the thermodynamic density field (e.g., `:ρθ`, `:ρs`, `:ρE`).
 Accepts a `Symbol`, `Val(Symbol)`, or formulation struct.
 """
 function thermodynamic_density_name end
@@ -93,7 +93,7 @@ thermodynamic_density_name(formulation::Symbol) =
     thermodynamic_density(formulation)
 
 Return the thermodynamic density field for the given formulation — the prognostic
-thermodynamic variable in coupling-density-weighted ("flux") form (`ρθ`, `ρe`, `ρE`).
+thermodynamic variable in coupling-density-weighted ("flux") form (`ρθ`, `ρs`, `ρE`).
 
 The weighting density is the dynamics' coupling density (see [`dynamics_density`](@ref)):
 the reference density `ρᵣ` on the anelastic core and the prognostic dry-air density `ρᵈ` on the
@@ -164,7 +164,7 @@ function compute_thermodynamic_tendency! end
 """
     set_thermodynamic_variable!(model, variable_name, value)
 
-Set a thermodynamic variable (e.g., `:θ`, `:T`, `:e`, `:ρθ`, `:ρe`) from the given value.
+Set a thermodynamic variable (e.g., `:θ`, `:T`, `:s`, `:ρθ`, `:ρs`) from the given value.
 Dispatches on the thermodynamic formulation type and variable name.
 """
 function set_thermodynamic_variable! end

--- a/src/AtmosphereModels/set_atmosphere_model.jl
+++ b/src/AtmosphereModels/set_atmosphere_model.jl
@@ -24,7 +24,7 @@ function prioritize_names(names)
     return names
 end
 
-const settable_thermodynamic_variables = (:ρθ, :θ, :ρθˡⁱ, :θˡⁱ, :ρe, :e, :T)
+const settable_thermodynamic_variables = (:ρθ, :θ, :ρθˡⁱ, :θˡⁱ, :ρs, :s, :T)
 function set_thermodynamic_variable! end
 
 #####
@@ -149,10 +149,10 @@ Variables are set via keyword arguments. Supported variables include:
 - `T`: in-situ temperature
 - `θ`: potential temperature
 - `θˡⁱ`: liquid-ice potential temperature
-- `e`: static energy
+- `s`: static energy
 - `ρθ`: potential temperature density
 - `ρθˡⁱ`: liquid-ice potential temperature density
-- `ρe`: static energy density (for `StaticEnergyThermodynamics`)
+- `ρs`: static energy density (for `StaticEnergyThermodynamics`)
 
 **Diagnostic variables** (specific, i.e., per unit mass):
 - `u`, `v`, `w`: velocity components (sets both velocity and momentum)

--- a/src/AtmosphereModels/set_to_mean.jl
+++ b/src/AtmosphereModels/set_to_mean.jl
@@ -115,9 +115,9 @@ end
 Recompute the reference pressure and density profiles from horizontally-averaged
 temperature and moisture mass fractions of the current model state.
 
-When `rescale_densities=true`, density-weighted prognostic fields (ρe, ρqᵗ, ρu,
+When `rescale_densities=true`, density-weighted prognostic fields (ρs, ρqᵗ, ρu,
 etc.) are rescaled by `ρᵣ_new / ρᵣ_old` so that the specific quantities
-(e, qᵗ, u, etc.) are unchanged. When `false` (default), the density-weighted
+(s, qᵗ, u, etc.) are unchanged. When `false` (default), the density-weighted
 fields are left as-is and only diagnostics are recomputed.
 """
 function set_to_mean!(ref::ReferenceState, model; rescale_densities=false)

--- a/src/AtmosphereModels/update_atmosphere_model_state.jl
+++ b/src/AtmosphereModels/update_atmosphere_model_state.jl
@@ -201,7 +201,7 @@ Compute auxiliary model variables:
 
 - thermodynamic variables from the prognostic thermodynamic state,
     * temperature ``T``, possibly involving saturation adjustment
-    * specific thermodynamic variable (``e = ρe / ρ`` or ``θ = ρθ / ρ``)
+    * specific thermodynamic variable (``s = ρs / ρ`` or ``θ = ρθ / ρ``)
     * moisture mass fraction ``qᵗ = ρqᵗ / ρ``
 """
 function compute_auxiliary_variables!(model)

--- a/src/BoundaryConditions/BoundaryConditions.jl
+++ b/src/BoundaryConditions/BoundaryConditions.jl
@@ -154,7 +154,7 @@ This function walks through all boundary conditions and calls
 `materialize_atmosphere_boundary_condition` on each one, allowing specialized handling for
 bulk flux boundary conditions and other atmosphere-specific boundary condition types.
 
-If `formulation` is `:LiquidIcePotentialTemperature` and `ρe` boundary conditions are provided,
+If `formulation` is `:LiquidIcePotentialTemperature` and `ρs` boundary conditions are provided,
 they are automatically converted to `ρθ` boundary conditions using `EnergyFluxBoundaryCondition`.
 """
 function AtmosphereModels.materialize_atmosphere_model_boundary_conditions(boundary_conditions, grid, formulation,
@@ -162,7 +162,7 @@ function AtmosphereModels.materialize_atmosphere_model_boundary_conditions(bound
                                                                            thermodynamic_constants,
                                                                            microphysical_fields, specific_prognostic_moisture, temperature)
 
-    # Convert ρe boundary conditions to ρθ for potential temperature formulations
+    # Convert ρs boundary conditions to ρθ for potential temperature formulations
     boundary_conditions = convert_energy_to_theta_bcs(boundary_conditions, formulation, thermodynamic_constants)
 
     materialized = Dict{Symbol, Any}()
@@ -176,11 +176,11 @@ function AtmosphereModels.materialize_atmosphere_model_boundary_conditions(bound
 end
 
 #####
-##### Convert ρe boundary conditions to ρθ for potential temperature formulations
+##### Convert ρs boundary conditions to ρθ for potential temperature formulations
 #####
 
 const θFormulation = Union{Val{:LiquidIcePotentialTemperature}, Val{:θ}}
-const eFormulation = Union{Val{:StaticEnergy}, Val{:e}, Val{:ρe}}
+const sFormulation = Union{Val{:StaticEnergy}, Val{:s}, Val{:ρs}}
 
 # Check if FieldBoundaryConditions has any non-default values
 has_nondefault_bcs(::Nothing) = false
@@ -197,13 +197,13 @@ function has_nondefault_bcs(fbcs::FieldBoundaryConditions)
     return false
 end
 
-# Validate: error if BOTH ρθ and ρe have non-default BCs
+# Validate: error if BOTH ρθ and ρs have non-default BCs
 function validate_thermodynamic_bcs(bcs)
     has_ρθ = :ρθ ∈ keys(bcs) && has_nondefault_bcs(bcs.ρθ)
-    has_ρe = :ρe ∈ keys(bcs) && has_nondefault_bcs(bcs.ρe)
-    if has_ρθ && has_ρe
-        throw(ArgumentError("Cannot specify boundary conditions on both ρθ and ρe. " *
-                            "Use ρe for energy fluxes or ρθ for potential temperature fluxes, but not both."))
+    has_ρs = :ρs ∈ keys(bcs) && has_nondefault_bcs(bcs.ρs)
+    if has_ρθ && has_ρs
+        throw(ArgumentError("Cannot specify boundary conditions on both ρθ and ρs. " *
+                            "Use ρs for energy fluxes or ρθ for potential temperature fluxes, but not both."))
     end
     return nothing
 end
@@ -214,27 +214,27 @@ function convert_energy_to_theta_bcs(bcs, formulation, constants)
     return bcs
 end
 
-# Convert ρe → ρθ for potential temperature formulations
+# Convert ρs → ρθ for potential temperature formulations
 function convert_energy_to_theta_bcs(bcs, formulation::θFormulation, constants)
     validate_thermodynamic_bcs(bcs)
-    :ρe ∈ keys(bcs) || return bcs
-    has_nondefault_bcs(bcs.ρe) || return bcs
+    :ρs ∈ keys(bcs) || return bcs
+    has_nondefault_bcs(bcs.ρs) || return bcs
 
-    ρe_bcs = set_sensible_heat_formulation_bcs(bcs.ρe, PotentialTemperatureFlux())
-    ρθ_bcs = energy_to_theta_bcs(ρe_bcs)
-    remaining = NamedTuple(k => v for (k, v) in pairs(bcs) if k !== :ρe)
+    ρs_bcs = set_sensible_heat_formulation_bcs(bcs.ρs, PotentialTemperatureFlux())
+    ρθ_bcs = energy_to_theta_bcs(ρs_bcs)
+    remaining = NamedTuple(k => v for (k, v) in pairs(bcs) if k !== :ρs)
     return merge(remaining, (; ρθ=ρθ_bcs))
 end
 
 # Set formulation on BulkSensibleHeatFlux for static energy formulations
-function convert_energy_to_theta_bcs(bcs, formulation::eFormulation, constants)
+function convert_energy_to_theta_bcs(bcs, formulation::sFormulation, constants)
     validate_thermodynamic_bcs(bcs)
-    :ρe ∈ keys(bcs) || return bcs
-    has_nondefault_bcs(bcs.ρe) || return bcs
+    :ρs ∈ keys(bcs) || return bcs
+    has_nondefault_bcs(bcs.ρs) || return bcs
 
-    ρe_bcs = set_sensible_heat_formulation_bcs(bcs.ρe, StaticEnergyFlux())
-    remaining = NamedTuple(k => v for (k, v) in pairs(bcs) if k !== :ρe)
-    return merge(remaining, (; ρe=ρe_bcs))
+    ρs_bcs = set_sensible_heat_formulation_bcs(bcs.ρs, StaticEnergyFlux())
+    remaining = NamedTuple(k => v for (k, v) in pairs(bcs) if k !== :ρs)
+    return merge(remaining, (; ρs=ρs_bcs))
 end
 
 convert_energy_to_theta_bcs(bcs, f::Symbol, c) = convert_energy_to_theta_bcs(bcs, Val(f), c)

--- a/src/BoundaryConditions/bulk_scalar_fluxes.jl
+++ b/src/BoundaryConditions/bulk_scalar_fluxes.jl
@@ -32,7 +32,7 @@ thermodynamic variable appropriate to the formulation:
 
 - For `LiquidIcePotentialTemperatureFormulation`: ``Δϕ = θ - θ₀``, where
   ``θ₀ = T₀ / Π₀`` and ``Π₀ = (p₀ / pˢᵗ)^{Rᵈ / cᵖᵈ}`` (potential temperature flux)
-- For `StaticEnergyFormulation`: ``Δϕ = e - cᵖᵈ T₀`` (static energy flux)
+- For `StaticEnergyFormulation`: ``Δϕ = s - cᵖᵈ T₀`` (static energy flux)
 
 Here ``p₀`` is the actual surface pressure, while ``pˢᵗ`` is the fixed reference pressure
 used to define potential temperature.
@@ -104,9 +104,9 @@ end
     cᵖᵛ = constants.vapor.heat_capacity
     qᵛ = @inbounds fields.qᵛ[i, j, 1]
     cᵖᵐ = (1 - qᵛ) * cᵖᵈ + qᵛ * cᵖᵛ  # no condensate at the surface
-    e₀ = cᵖᵐ * T₀
-    e = @inbounds fields.e[i, j, 1]
-    return e - e₀
+    s₀ = cᵖᵐ * T₀
+    s = @inbounds fields.s[i, j, 1]
+    return s - s₀
 end
 
 @inline function bulk_sensible_heat_difference(i, j, grid, ::StaticEnergyFlux, bf, T₀, fields, fs::FilteredSurfaceScalar)
@@ -115,9 +115,9 @@ end
     cᵖᵛ = constants.vapor.heat_capacity
     qᵛ = @inbounds fields.qᵛ[i, j, 1]
     cᵖᵐ = (1 - qᵛ) * cᵖᵈ + qᵛ * cᵖᵛ  # no condensate at the surface
-    e₀ = cᵖᵐ * T₀
-    e = @inbounds fs.field[i, j, 1]
-    return e - e₀
+    s₀ = cᵖᵐ * T₀
+    s = @inbounds fs.field[i, j, 1]
+    return s - s₀
 end
 
 @inline function OceananigansBC.getbc(bf::BulkSensibleHeatFluxFunction, i::Integer, j::Integer,
@@ -249,7 +249,7 @@ The bulk formula computes
 J = -ρ₀ Cᵀ |U| Δϕ
 ```
 where ``Δϕ`` depends on the thermodynamic formulation: ``Δθ`` for potential
-temperature or ``Δe`` for static energy. The formulation is set automatically
+temperature or ``Δs`` for static energy. The formulation is set automatically
 during model construction.
 
 See [`BulkSensibleHeatFluxFunction`](@ref) for details.
@@ -261,7 +261,7 @@ using Breeze
 
 T₀(x, y) = 290 + 2 * sign(cos(2π * x / 20e3))
 
-ρe_bc = BulkSensibleHeatFlux(coefficient = 1e-3,
+ρs_bc = BulkSensibleHeatFlux(coefficient = 1e-3,
                              gustiness = 0.1,
                              surface_temperature = T₀)
 

--- a/src/BoundaryConditions/filtered_surface_state.jl
+++ b/src/BoundaryConditions/filtered_surface_state.jl
@@ -8,7 +8,7 @@
 #####
 ##### `FilteredSurfaceVelocities` holds the filtered velocity components and the
 ##### filtered virtual potential temperature `θᵥ` used by stability-dependent bulk
-##### coefficients. Per-BC scalar differences (θ, e, qᵛ) are held separately in
+##### coefficients. Per-BC scalar differences (θ, s, qᵛ) are held separately in
 ##### `FilteredSurfaceScalar`.
 #####
 

--- a/src/BoundaryConditions/thermodynamic_variable_bcs.jl
+++ b/src/BoundaryConditions/thermodynamic_variable_bcs.jl
@@ -8,7 +8,7 @@
 
 #####
 ##### EnergyFluxBoundaryConditionFunction: converts energy flux → potential temperature flux
-##### Used when: user specifies ρe BCs but prognostic variable is ρθ
+##### Used when: user specifies ρs BCs but prognostic variable is ρθ
 #####
 
 """
@@ -278,14 +278,14 @@ map_field_boundary_conditions(f, fbcs::FieldBoundaryConditions, args...) =
 ##### Conversion functions: energy ↔ theta boundary conditions
 #####
 
-# Convert ρe BCs → ρθ BCs (for LiquidIcePotentialTemperatureFormulation)
+# Convert ρs BCs → ρθ BCs (for LiquidIcePotentialTemperatureFormulation)
 energy_to_theta_bc(bc) = bc
 energy_to_theta_bc(bc::BulkSensibleHeatFluxBoundaryCondition) = bc
 energy_to_theta_bc(bc::BoundaryCondition{<:Flux}) = EnergyFluxBoundaryCondition(bc.condition)
 
 energy_to_theta_bcs(fbcs::FieldBoundaryConditions) = map_field_boundary_conditions(energy_to_theta_bc, fbcs)
 
-# Convert ρθ BCs → ρe BCs (for diagnostic energy_density with PotentialTemperatureFormulation)
+# Convert ρθ BCs → ρs BCs (for diagnostic energy_density with PotentialTemperatureFormulation)
 theta_to_energy_bc(bc) = bc
 # For EnergyFluxBC, extract the original energy flux
 theta_to_energy_bc(bc::EnergyFluxBCType) = BoundaryCondition(Flux(), bc.condition.condition)

--- a/src/Forcings/specific_forcing.jl
+++ b/src/Forcings/specific_forcing.jl
@@ -34,7 +34,7 @@ via ``ℑxᶠᵃᵃ``, to z-Face for `w` via ``ℑzᵃᵃᶠ``). `ρ` is `ρᵣ(
 the same wrapper handles both.
 
 Users typically supply specific forcings directly through specific-named keys
-(`u`, `v`, `w`, `θ`, `e`, `qᵉ`, `qᵛ`, …) in the `forcing` `NamedTuple` passed to
+(`u`, `v`, `w`, `θ`, `s`, `qᵉ`, `qᵛ`, …) in the `forcing` `NamedTuple` passed to
 [`AtmosphereModel`](@ref Breeze.AtmosphereModels.AtmosphereModel), and the dispatch wraps each entry in `SpecificForcing`
 automatically. The wrapper can also be constructed directly when finer control is needed.
 

--- a/src/ParcelModels/parcel_dynamics.jl
+++ b/src/ParcelModels/parcel_dynamics.jl
@@ -109,7 +109,7 @@ mutable struct ParcelTendencies{FT, GM}
     Gy :: FT
     Gz :: FT
     Gw :: FT
-    Ge :: FT
+    Gs :: FT
     Gqᵗ :: FT
     Gμ :: GM
 end
@@ -239,8 +239,8 @@ function AtmosphereModels.materialize_dynamics(d::ParcelDynamics, grid, bcs, con
     cᵖᵐ = mixture_heat_capacity(q, constants)
     T_default = FT(288.15)
     z_default = zero(FT)
-    e_default = cᵖᵐ * T_default + g * z_default
-    𝒰 = StaticEnergyState(e_default, q, z_default, p₀)
+    s_default = cᵖᵐ * T_default + g * z_default
+    𝒰 = StaticEnergyState(s_default, q, z_default, p₀)
 
     # Microphysics prognostic variables based on the microphysics scheme
     μ = materialize_parcel_microphysics_prognostics(FT, microphysics)
@@ -250,7 +250,7 @@ function AtmosphereModels.materialize_dynamics(d::ParcelDynamics, grid, bcs, con
     w_default = zero(FT)
     qᵗ_default = zero(FT)
     ρqᵗ_default = ρ_default * qᵗ_default
-    ℰ_default = e_default  # static energy for default formulation
+    ℰ_default = s_default  # static energy for default formulation
     ρℰ_default = ρ_default * ℰ_default
     state = ParcelState(zero(FT), zero(FT), z_default, w_default, ρ_default,
                         qᵗ_default, ρqᵗ_default, ℰ_default, ρℰ_default, 𝒰, μ)
@@ -510,10 +510,10 @@ function initialize_parcel_state!(state, z₀, x₀, y₀, model)
     # Compute static energy and thermodynamic state
     q = MoistureMassFractions(qᵗ₀)
     cᵖᵐ = mixture_heat_capacity(q, constants)
-    e = cᵖᵐ * T₀ + g * z₀
-    state.ℰ = e
-    state.ρℰ = ρ₀ * e
-    state.𝒰 = StaticEnergyState(e, q, z₀, p₀)
+    s = cᵖᵐ * T₀ + g * z₀
+    state.ℰ = s
+    state.ρℰ = ρ₀ * s
+    state.𝒰 = StaticEnergyState(s, q, z₀, p₀)
 
     return nothing
 end
@@ -550,9 +550,9 @@ Compute tendencies for the parcel prognostic variables.
 Position tendencies are interpolated from environmental velocity fields.
 Thermodynamic and moisture tendencies come from microphysical sources/sinks.
 
-The parcel model evolves **specific quantities** (e, qᵗ) directly, not
+The parcel model evolves **specific quantities** (s, qᵗ) directly, not
 density-weighted quantities. For adiabatic ascent with no microphysics,
-specific static energy and moisture are exactly conserved (de/dt = dqᵗ/dt = 0).
+specific static energy and moisture are exactly conserved (ds/dt = dqᵗ/dt = 0).
 This is simpler and more accurate than stepping density-weighted quantities.
 """
 function compute_parcel_tendencies!(model::ParcelModel)
@@ -581,7 +581,7 @@ function compute_parcel_tendencies!(model::ParcelModel)
     # Dispatch handles the Nothing case: microphysical_tendency(::Nothing, ...) returns zero,
     # compute_microphysics_prognostic_tendencies(::Nothing, ...) returns nothing/zero NamedTuple
     ℳ = microphysical_state(microphysics, ρ, μ, 𝒰, velocities)
-    tendencies.Ge = microphysical_tendency(microphysics, Val(:e), ρ, ℳ, 𝒰, constants)
+    tendencies.Gs = microphysical_tendency(microphysics, Val(:s), ρ, ℳ, 𝒰, constants)
     tendencies.Gqᵗ = microphysical_tendency(microphysics, Val(:qᵗ), ρ, ℳ, 𝒰, constants)
     tendencies.Gμ = compute_microphysics_prognostic_tendencies(microphysics, ρ, μ, ℳ, 𝒰, constants)
 
@@ -812,8 +812,8 @@ u^{(m)} = (1 - α) u^{(0)} + α \\left[u^{(m-1)} + Δt \\, G^{(m-1)}\\right]
 where ``u^{(0)}`` is the initial state, ``u^{(m-1)}`` is the current state,
 and ``G^{(m-1)}`` is the tendency at the current state.
 
-The parcel model steps specific quantities (e, qᵗ) directly for exact conservation.
-For adiabatic ascent with no microphysics sources, de/dt = dqᵗ/dt = 0, so these
+The parcel model steps specific quantities (s, qᵗ) directly for exact conservation.
+For adiabatic ascent with no microphysics sources, ds/dt = dqᵗ/dt = 0, so these
 quantities remain exactly constant throughout the simulation.
 """
 function ssp_rk3_parcel_substep!(model::ParcelModel, U⁰::ParcelInitialState, Δt, α)
@@ -834,7 +834,7 @@ function ssp_rk3_parcel_substep!(model::ParcelModel, U⁰::ParcelInitialState, �
 
     # Step specific quantities directly (exact conservation for adiabatic)
     state.qᵗ = (1 - α) * U⁰.qᵗ + α * (state.qᵗ + Δt * tendencies.Gqᵗ)
-    state.ℰ = (1 - α) * U⁰.ℰ + α * (state.ℰ + Δt * tendencies.Ge)
+    state.ℰ = (1 - α) * U⁰.ℰ + α * (state.ℰ + Δt * tendencies.Gs)
 
     # Get environmental conditions at new height
     z⁺ = state.z
@@ -872,8 +872,8 @@ Reconstruct a thermodynamic state with a new conserved variable value and update
 """
 function reconstruct_thermodynamic_state end
 
-@inline function reconstruct_thermodynamic_state(𝒰::StaticEnergyState{FT}, e⁺, z⁺, p⁺) where FT
-    return StaticEnergyState{FT}(e⁺, 𝒰.moisture_mass_fractions, z⁺, p⁺)
+@inline function reconstruct_thermodynamic_state(𝒰::StaticEnergyState{FT}, s⁺, z⁺, p⁺) where FT
+    return StaticEnergyState{FT}(s⁺, 𝒰.moisture_mass_fractions, z⁺, p⁺)
 end
 
 @inline function reconstruct_thermodynamic_state(𝒰::LiquidIcePotentialTemperatureState{FT}, θ⁺, z⁺, p⁺) where FT
@@ -931,7 +931,7 @@ function step_parcel_state!(model::ParcelModel, Δt)
 
     # Step specific quantities forward (exact conservation for adiabatic)
     state.qᵗ += Δt * tendencies.Gqᵗ
-    state.ℰ += Δt * tendencies.Ge
+    state.ℰ += Δt * tendencies.Gs
 
     # Get environmental conditions at new height
     z⁺ = state.z

--- a/src/PotentialTemperatureFormulations/potential_temperature_tendency.jl
+++ b/src/PotentialTemperatureFormulations/potential_temperature_tendency.jl
@@ -30,16 +30,16 @@ function AtmosphereModels.static_energy_density(model::PotentialTemperatureModel
     ρθ_bcs = ρθ.boundary_conditions
 
     # Convert θ BCs to energy BCs
-    ρe_bcs = theta_to_energy_bcs(ρθ_bcs)
+    ρs_bcs = theta_to_energy_bcs(ρθ_bcs)
 
     # Regularize the converted BCs (populate microphysics, constants, side)
     loc = (Center(), Center(), Center())
-    ρe_bcs = materialize_atmosphere_field_bcs(ρe_bcs, loc, model.grid, model.dynamics, model.microphysics,
+    ρs_bcs = materialize_atmosphere_field_bcs(ρs_bcs, loc, model.grid, model.dynamics, model.microphysics,
                                               nothing, model.thermodynamic_constants, nothing, nothing, nothing)
 
     # Create the energy density operation and wrap in a Field with proper BCs
-    ρe_op = Diagnostics.StaticEnergy(model, :density)
-    return Field(ρe_op; boundary_conditions=ρe_bcs)
+    ρs_op = Diagnostics.StaticEnergy(model, :density)
+    return Field(ρs_op; boundary_conditions=ρs_bcs)
 end
 
 #####
@@ -53,7 +53,7 @@ function AtmosphereModels.compute_thermodynamic_tendency!(model::PotentialTemper
     ρθ_args = (
         Val(1),
         model.forcing.ρθ,
-        model.forcing.ρe,
+        model.forcing.ρs,
         model.advection.ρθ,
         radiation_flux_divergence(model.radiation),
         common_args...)
@@ -66,7 +66,7 @@ end
 @inline function potential_temperature_tendency(i, j, k, grid,
                                                 id,
                                                 ρθ_forcing,
-                                                ρe_forcing,
+                                                ρs_forcing,
                                                 advection,
                                                 radiation_flux_divergence_field,
                                                 dynamics,
@@ -94,14 +94,14 @@ end
     cᵖᵐ = mixture_heat_capacity(q, constants)
     closure_buoyancy = AtmosphereModelBuoyancy(dynamics, formulation, constants)
 
-    Fρe = ρe_forcing(i, j, k, grid, clock, model_fields)
+    Fρs = ρs_forcing(i, j, k, grid, clock, model_fields)
     div_ℐ = radiation_flux_divergence(i, j, k, grid, radiation_flux_divergence_field)
 
     return ( - div_ρUc(i, j, k, grid, advection, ρ_field, velocities, potential_temperature)
              + c_div_ρU(i, j, k, grid, dynamics, velocities, potential_temperature)
              - ∇_dot_Jᶜ(i, j, k, grid, ρ_field, closure, closure_fields, id, potential_temperature, clock, model_fields, closure_buoyancy)
              + ρθ_forcing(i, j, k, grid, clock, model_fields)
-             + (Fρe + div_ℐ) / (cᵖᵐ * Π)
+             + (Fρs + div_ℐ) / (cᵖᵐ * Π)
     )
 end
 
@@ -121,10 +121,10 @@ function AtmosphereModels.set_thermodynamic_variable!(model::PotentialTemperatur
 end
 
 # Setting from static energy
-function AtmosphereModels.set_thermodynamic_variable!(model::PotentialTemperatureModel, ::Val{:e}, value)
+function AtmosphereModels.set_thermodynamic_variable!(model::PotentialTemperatureModel, ::Val{:s}, value)
     formulation = model.formulation
-    e = model.temperature # scratch space
-    set!(e, value)
+    s = model.temperature # scratch space
+    set!(s, value)
 
     grid = model.grid
     arch = grid.architecture
@@ -133,7 +133,7 @@ function AtmosphereModels.set_thermodynamic_variable!(model::PotentialTemperatur
             formulation.potential_temperature_density,
             formulation.potential_temperature,
             grid,
-            e,
+            s,
             specific_prognostic_moisture(model),
             model.dynamics,
             model.microphysics,
@@ -143,11 +143,11 @@ function AtmosphereModels.set_thermodynamic_variable!(model::PotentialTemperatur
     return nothing
 end
 
-function AtmosphereModels.set_thermodynamic_variable!(model::PotentialTemperatureModel, ::Val{:ρe}, value)
-    ρe = model.temperature # scratch space
-    set!(ρe, value)
+function AtmosphereModels.set_thermodynamic_variable!(model::PotentialTemperatureModel, ::Val{:ρs}, value)
+    ρs = model.temperature # scratch space
+    set!(ρs, value)
     ρ = dynamics_density(model.dynamics)
-    return set_thermodynamic_variable!(model, Val(:e), ρe / ρ)
+    return set_thermodynamic_variable!(model, Val(:s), ρs / ρ)
 end
 
 @kernel function _potential_temperature_from_energy!(potential_temperature_density,
@@ -166,17 +166,17 @@ end
         ρ = total_density(dynamics)[i, j, k]      # total ρ (mass fractions)
         ρᵈ = dynamics_density(dynamics)[i, j, k]  # coupling density ρᵈ (ρθ = ρᵈθ)
         qᵛᵉ = specific_prognostic_moisture[i, j, k]
-        e = specific_energy[i, j, k]
+        s = specific_energy[i, j, k]
     end
 
     z = znode(i, j, k, grid, c, c, c)
     q = grid_moisture_fractions(i, j, k, grid, microphysics, ρ, qᵛᵉ, microphysical_fields)
-    𝒰e₀ = StaticEnergyState(e, q, z, pᵣ)
-    𝒰e₁ = maybe_adjust_thermodynamic_state(𝒰e₀, microphysics, qᵛᵉ, constants)
-    T = temperature(𝒰e₁, constants)
+    𝒰s₀ = StaticEnergyState(s, q, z, pᵣ)
+    𝒰s₁ = maybe_adjust_thermodynamic_state(𝒰s₀, microphysics, qᵛᵉ, constants)
+    T = temperature(𝒰s₁, constants)
 
     pˢᵗ = standard_pressure(dynamics)
-    q₁ = 𝒰e₁.moisture_mass_fractions
+    q₁ = 𝒰s₁.moisture_mass_fractions
     𝒰θ = LiquidIcePotentialTemperatureState(zero(T), q₁, pˢᵗ, pᵣ)
     𝒰θ = with_temperature(𝒰θ, T, constants)
     θ = 𝒰θ.potential_temperature

--- a/src/StaticEnergyFormulations/StaticEnergyFormulations.jl
+++ b/src/StaticEnergyFormulations/StaticEnergyFormulations.jl
@@ -3,7 +3,7 @@
 
 Submodule defining the static energy thermodynamic formulation for atmosphere models.
 
-`StaticEnergyFormulation` uses moist static energy density `ρe` as the prognostic thermodynamic variable.
+`StaticEnergyFormulation` uses moist static energy density `ρs` as the prognostic thermodynamic variable.
 Moist static energy is a conserved quantity in adiabatic, frictionless flow that combines
 sensible heat, gravitational potential energy, and latent heat.
 """
@@ -37,9 +37,9 @@ include("static_energy_tendency.jl")
 
 # Kernel wrapper for launching static_energy_tendency
 # (needs to be defined after static_energy_tendency is defined)
-@kernel function compute_static_energy_tendency!(Gρe, grid, args)
+@kernel function compute_static_energy_tendency!(Gρs, grid, args)
     i, j, k = @index(Global, NTuple)
-    @inbounds Gρe[i, j, k] = static_energy_tendency(i, j, k, grid, args...)
+    @inbounds Gρs[i, j, k] = static_energy_tendency(i, j, k, grid, args...)
 end
 
 end # module

--- a/src/StaticEnergyFormulations/static_energy_formulation.jl
+++ b/src/StaticEnergyFormulations/static_energy_formulation.jl
@@ -5,20 +5,20 @@
 """
 $(TYPEDSIGNATURES)
 
-`StaticEnergyFormulation` uses moist static energy density `ρe` as the prognostic thermodynamic variable.
+`StaticEnergyFormulation` uses moist static energy density `ρs` as the prognostic thermodynamic variable.
 
 Moist static energy is a conserved quantity in adiabatic, frictionless flow that combines
 sensible heat, gravitational potential energy, and latent heat:
 
 ```math
-e = cᵖᵐ T + g z - ℒˡᵣ qˡ - ℒⁱᵣ qⁱ
+s = cᵖᵐ T + g z - ℒˡᵣ qˡ - ℒⁱᵣ qⁱ
 ```
 
 The energy density equation includes a buoyancy flux term following [Pauluis2008](@citet).
 """
 struct StaticEnergyFormulation{E, S}
-    energy_density :: E    # ρe (prognostic)
-    specific_energy :: S   # e = ρe / ρ (diagnostic)
+    energy_density :: E    # ρs (prognostic)
+    specific_energy :: S   # s = ρs / ρ (diagnostic)
 end
 
 Adapt.adapt_structure(to, formulation::StaticEnergyFormulation) =
@@ -34,27 +34,27 @@ end
 ##### Field naming interface
 #####
 
-AtmosphereModels.prognostic_thermodynamic_field_names(::StaticEnergyFormulation) = tuple(:ρe)
-AtmosphereModels.additional_thermodynamic_field_names(::StaticEnergyFormulation) = tuple(:e)
-AtmosphereModels.thermodynamic_density_name(::StaticEnergyFormulation) = :ρe
+AtmosphereModels.prognostic_thermodynamic_field_names(::StaticEnergyFormulation) = tuple(:ρs)
+AtmosphereModels.additional_thermodynamic_field_names(::StaticEnergyFormulation) = tuple(:s)
+AtmosphereModels.thermodynamic_density_name(::StaticEnergyFormulation) = :ρs
 AtmosphereModels.thermodynamic_density(formulation::StaticEnergyFormulation) = formulation.energy_density
-AtmosphereModels.with_thermodynamic_density(f::StaticEnergyFormulation, ρe) =
-    StaticEnergyFormulation(ρe, f.specific_energy)
+AtmosphereModels.with_thermodynamic_density(f::StaticEnergyFormulation, ρs) =
+    StaticEnergyFormulation(ρs, f.specific_energy)
 
-AtmosphereModels.prognostic_thermodynamic_field_names(::Val{:StaticEnergy}) = tuple(:ρe)
-AtmosphereModels.additional_thermodynamic_field_names(::Val{:StaticEnergy}) = tuple(:e)
-AtmosphereModels.thermodynamic_density_name(::Val{:StaticEnergy}) = :ρe
+AtmosphereModels.prognostic_thermodynamic_field_names(::Val{:StaticEnergy}) = tuple(:ρs)
+AtmosphereModels.additional_thermodynamic_field_names(::Val{:StaticEnergy}) = tuple(:s)
+AtmosphereModels.thermodynamic_density_name(::Val{:StaticEnergy}) = :ρs
 
-Oceananigans.fields(formulation::StaticEnergyFormulation) = (; e=formulation.specific_energy)
-Oceananigans.prognostic_fields(formulation::StaticEnergyFormulation) = (; ρe=formulation.energy_density)
+Oceananigans.fields(formulation::StaticEnergyFormulation) = (; s=formulation.specific_energy)
+Oceananigans.prognostic_fields(formulation::StaticEnergyFormulation) = (; ρs=formulation.energy_density)
 
 #####
 ##### Materialization
 #####
 
 function AtmosphereModels.materialize_formulation(::Val{:StaticEnergy}, dynamics, grid, boundary_conditions)
-    energy_density = CenterField(grid, boundary_conditions=boundary_conditions.ρe)
-    specific_energy = CenterField(grid)  # e = ρe / ρ (diagnostic per-mass energy)
+    energy_density = CenterField(grid, boundary_conditions=boundary_conditions.ρs)
+    specific_energy = CenterField(grid)  # s = ρs / ρ (diagnostic per-mass energy)
     return StaticEnergyFormulation(energy_density, specific_energy)
 end
 
@@ -66,8 +66,8 @@ function AtmosphereModels.compute_auxiliary_thermodynamic_variables!(formulation
     ρ = dynamics_density(dynamics)
     @inbounds begin
         ρᵢ = ρ[i, j, k]
-        ρe = formulation.energy_density[i, j, k]
-        formulation.specific_energy[i, j, k] = ρe / ρᵢ
+        ρs = formulation.energy_density[i, j, k]
+        formulation.specific_energy[i, j, k] = ρs / ρᵢ
     end
     return nothing
 end
@@ -87,11 +87,11 @@ function AtmosphereModels.diagnose_thermodynamic_state(i, j, k, grid,
                                                        dynamics,
                                                        q)
 
-    e = @inbounds formulation.specific_energy[i, j, k]
+    s = @inbounds formulation.specific_energy[i, j, k]
     pᵣ = @inbounds dynamics_pressure(dynamics)[i, j, k]
     z = znode(i, j, k, grid, c, c, c)
 
-    return StaticEnergyState(e, q, z, pᵣ)
+    return StaticEnergyState(s, q, z, pᵣ)
 end
 
 #####
@@ -105,8 +105,8 @@ function AtmosphereModels.collect_prognostic_fields(formulation::StaticEnergyFor
                                                     moisture_name,
                                                     microphysical_fields,
                                                     tracers)
-    ρe = formulation.energy_density
-    thermodynamic_variables = merge((ρe=ρe,), NamedTuple{(moisture_name,)}((moisture_density,)))
+    ρs = formulation.energy_density
+    thermodynamic_variables = merge((ρs=ρs,), NamedTuple{(moisture_name,)}((moisture_density,)))
     dynamics_fields = dynamics_prognostic_fields(dynamics)
     return merge(dynamics_fields, momentum, thermodynamic_variables, microphysical_fields, tracers)
 end

--- a/src/StaticEnergyFormulations/static_energy_tendency.jl
+++ b/src/StaticEnergyFormulations/static_energy_tendency.jl
@@ -23,22 +23,22 @@ function AtmosphereModels.compute_thermodynamic_tendency!(model::StaticEnergyMod
     grid = model.grid
     arch = grid.architecture
 
-    ρe_args = (
+    ρs_args = (
         Val(1),
-        model.forcing.ρe,
-        model.advection.ρe,
+        model.forcing.ρs,
+        model.advection.ρs,
         radiation_flux_divergence(model.radiation),
         common_args...,
         model.temperature)
 
-    Gρe = model.timestepper.Gⁿ.ρe
-    launch!(arch, grid, :xyz, compute_static_energy_tendency!, Gρe, grid, ρe_args)
+    Gρs = model.timestepper.Gⁿ.ρs
+    launch!(arch, grid, :xyz, compute_static_energy_tendency!, Gρs, grid, ρs_args)
     return nothing
 end
 
 @inline function static_energy_tendency(i, j, k, grid,
                                         id,
-                                        ρe_forcing,
+                                        ρs_forcing,
                                         advection,
                                         radiation_flux_divergence_field,
                                         dynamics,
@@ -67,7 +67,7 @@ end
              + c_div_ρU(i, j, k, grid, dynamics, velocities, specific_energy)
              - buoyancy_flux
              - ∇_dot_Jᶜ(i, j, k, grid, ρ_field, closure, closure_fields, id, specific_energy, clock, model_fields, closure_buoyancy)
-             + ρe_forcing(i, j, k, grid, clock, model_fields)
+             + ρs_forcing(i, j, k, grid, clock, model_fields)
              + radiation_flux_divergence(i, j, k, grid, radiation_flux_divergence_field))
 end
 
@@ -75,14 +75,14 @@ end
 ##### Set thermodynamic variables
 #####
 
-AtmosphereModels.set_thermodynamic_variable!(model::StaticEnergyModel, ::Val{:ρe}, value) =
+AtmosphereModels.set_thermodynamic_variable!(model::StaticEnergyModel, ::Val{:ρs}, value) =
     set!(model.formulation.energy_density, value)
 
-function AtmosphereModels.set_thermodynamic_variable!(model::StaticEnergyModel, ::Val{:e}, value)
+function AtmosphereModels.set_thermodynamic_variable!(model::StaticEnergyModel, ::Val{:s}, value)
     set!(model.formulation.specific_energy, value)
     ρ = dynamics_density(model.dynamics)
-    e = model.formulation.specific_energy
-    set!(model.formulation.energy_density, ρ * e)
+    s = model.formulation.specific_energy
+    set!(model.formulation.energy_density, ρ * s)
     return nothing
 end
 
@@ -125,7 +125,7 @@ end
     @inbounds begin
         pᵣ = dynamics_pressure(dynamics)[i, j, k]
         ρ = total_density(dynamics)[i, j, k]      # total ρ (mass fractions)
-        ρᵈ = dynamics_density(dynamics)[i, j, k]  # coupling density ρᵈ (ρe = ρᵈe)
+        ρᵈ = dynamics_density(dynamics)[i, j, k]  # coupling density ρᵈ (ρs = ρᵈs)
         qᵛᵉ = specific_prognostic_moisture[i, j, k]
         θ = potential_temperature[i, j, k]
     end
@@ -138,12 +138,12 @@ end
 
     z = znode(i, j, k, grid, c, c, c)
     q₁ = 𝒰θ₁.moisture_mass_fractions
-    𝒰e₀ = StaticEnergyState(zero(T), q₁, z, pᵣ)
-    𝒰e₁ = with_temperature(𝒰e₀, T, constants)
-    e = 𝒰e₁.static_energy
+    𝒰s₀ = StaticEnergyState(zero(T), q₁, z, pᵣ)
+    𝒰s₁ = with_temperature(𝒰s₀, T, constants)
+    s = 𝒰s₁.static_energy
 
-    @inbounds specific_energy[i, j, k] = e
-    @inbounds energy_density[i, j, k] = ρᵈ * e
+    @inbounds specific_energy[i, j, k] = s
+    @inbounds energy_density[i, j, k] = ρᵈ * s
 end
 
 #####
@@ -155,10 +155,10 @@ end
 
 Set the thermodynamic state from temperature ``T``.
 
-The temperature is converted to static energy ``e`` using the relation:
+The temperature is converted to static energy ``s`` using the relation:
 
 ```math
-e = cᵖᵐ T + g z - ℒˡ qˡ - ℒⁱ qⁱ .
+s = cᵖᵐ T + g z - ℒˡ qˡ - ℒⁱ qⁱ .
 ```
 """
 function AtmosphereModels.set_thermodynamic_variable!(model::StaticEnergyModel, ::Val{:T}, value)
@@ -198,7 +198,7 @@ end
     @inbounds begin
         pᵣ = dynamics_pressure(dynamics)[i, j, k]
         ρ = total_density(dynamics)[i, j, k]      # total ρ (mass fractions)
-        ρᵈ = dynamics_density(dynamics)[i, j, k]  # coupling density ρᵈ (ρe = ρᵈe)
+        ρᵈ = dynamics_density(dynamics)[i, j, k]  # coupling density ρᵈ (ρs = ρᵈs)
         qᵛᵉ = specific_prognostic_moisture[i, j, k]
         T = temperature_field[i, j, k]
     end
@@ -211,7 +211,7 @@ end
     𝒰₀ = StaticEnergyState(zero(T), q, z, pᵣ)
     𝒰₁ = with_temperature(𝒰₀, T, constants)
 
-    e = 𝒰₁.static_energy
-    @inbounds specific_energy[i, j, k] = e
-    @inbounds energy_density[i, j, k] = ρᵈ * e
+    s = 𝒰₁.static_energy
+    @inbounds specific_energy[i, j, k] = s
+    @inbounds energy_density[i, j, k] = ρᵈ * s
 end

--- a/src/Thermodynamics/dynamic_states.jl
+++ b/src/Thermodynamics/dynamic_states.jl
@@ -281,7 +281,7 @@ end
     StaticEnergyState{FT}(𝒰.static_energy, q, 𝒰.height, 𝒰.reference_pressure)
 
 @inline function temperature(𝒰::StaticEnergyState, constants::ThermodynamicConstants)
-    e = 𝒰.static_energy
+    s = 𝒰.static_energy
     q = 𝒰.moisture_mass_fractions
     cᵖᵐ = mixture_heat_capacity(q, constants)
 
@@ -293,8 +293,8 @@ end
     qˡ = q.liquid
     qⁱ = q.ice
 
-    # e = cᵖᵐ * T + g * z - ℒˡᵣ * qˡ - ℒⁱᵣ * qⁱ
-    return (e - g * z + ℒˡᵣ * qˡ + ℒⁱᵣ * qⁱ) / cᵖᵐ
+    # s = cᵖᵐ * T + g * z - ℒˡᵣ * qˡ - ℒⁱᵣ * qⁱ
+    return (s - g * z + ℒˡᵣ * qˡ + ℒⁱᵣ * qⁱ) / cᵖᵐ
 end
 
 @inline function with_temperature(𝒰::StaticEnergyState, T, constants)
@@ -307,7 +307,7 @@ end
     qˡ = q.liquid
     qⁱ = q.ice
 
-    e = cᵖᵐ * T + g * z - ℒˡᵣ * qˡ - ℒⁱᵣ * qⁱ
+    s = cᵖᵐ * T + g * z - ℒˡᵣ * qˡ - ℒⁱᵣ * qⁱ
 
-    return StaticEnergyState(e, q, z, 𝒰.reference_pressure)
+    return StaticEnergyState(s, q, z, 𝒰.reference_pressure)
 end

--- a/src/TimeSteppers/ssp_runge_kutta_3.jl
+++ b/src/TimeSteppers/ssp_runge_kutta_3.jl
@@ -125,7 +125,7 @@ function ssp_rk3_substep!(model, Δt, α)
 
         # Field index for implicit solver:
         # - indices 1, 2, 3 are momentum (ρu, ρv, ρw)
-        # - indices 4+ are scalars (ρθ/ρe, ρqᵗ, microphysics, tracers)
+        # - indices 4+ are scalars (ρθ/ρs, ρqᵗ, microphysics, tracers)
         # For scalars, we use Val(i - 3) to get Val(1), Val(2), etc.
         field_index = Val(i - 3)
         advection = field_advection_scheme(model.advection, names[i])

--- a/test/advection_schemes.jl
+++ b/test/advection_schemes.jl
@@ -20,7 +20,7 @@ using Test
         potential_temperature_model = AtmosphereModel(grid; thermodynamic_constants=constants, dynamics,
                                                       formulation=:LiquidIcePotentialTemperature)
 
-        @test static_energy_model.advection.ρe isa Centered
+        @test static_energy_model.advection.ρs isa Centered
         @test potential_temperature_model.advection.ρθ isa Centered
 
         for model in (static_energy_model, potential_temperature_model)
@@ -37,7 +37,7 @@ using Test
         potential_temperature_model= AtmosphereModel(grid; thermodynamic_constants=constants,
                                                      dynamics, formulation=:LiquidIcePotentialTemperature, advection=WENO())
 
-        @test static_energy_model.advection.ρe isa WENO
+        @test static_energy_model.advection.ρs isa WENO
         @test potential_temperature_model.advection.ρθ isa WENO
 
         for model in (static_energy_model, potential_temperature_model)
@@ -52,7 +52,7 @@ using Test
         static_energy_model = AtmosphereModel(grid; dynamics, formulation=:StaticEnergy, kw...)
         potential_temperature_model = AtmosphereModel(grid; dynamics, formulation=:LiquidIcePotentialTemperature, kw...)
 
-        @test static_energy_model.advection.ρe isa Centered
+        @test static_energy_model.advection.ρs isa Centered
         @test potential_temperature_model.advection.ρθ isa Centered
 
         for model in (static_energy_model, potential_temperature_model)
@@ -68,10 +68,10 @@ using Test
         static_energy_model = AtmosphereModel(grid; dynamics, formulation=:StaticEnergy, kw...)
         potential_temperature_model = AtmosphereModel(grid; dynamics, formulation=:LiquidIcePotentialTemperature, kw...)
 
-        @test static_energy_model.advection.ρe isa FluxFormAdvection
-        @test static_energy_model.advection.ρe.x isa WENO
-        @test static_energy_model.advection.ρe.y isa WENO
-        @test static_energy_model.advection.ρe.z isa Centered
+        @test static_energy_model.advection.ρs isa FluxFormAdvection
+        @test static_energy_model.advection.ρs.x isa WENO
+        @test static_energy_model.advection.ρs.y isa WENO
+        @test static_energy_model.advection.ρs.z isa Centered
 
         @test potential_temperature_model.advection.ρθ isa FluxFormAdvection
         @test potential_temperature_model.advection.ρθ.x isa WENO
@@ -93,7 +93,7 @@ using Test
         static_energy_model = AtmosphereModel(grid; dynamics, formulation=:StaticEnergy, kw...)
         potential_temperature_model = AtmosphereModel(grid; dynamics, formulation=:LiquidIcePotentialTemperature, kw...)
 
-        @test static_energy_model.advection.ρe isa UpwindBiased
+        @test static_energy_model.advection.ρs isa UpwindBiased
         @test potential_temperature_model.advection.ρθ isa UpwindBiased
 
         for model in (static_energy_model, potential_temperature_model)
@@ -110,7 +110,7 @@ using Test
         static_energy_model = AtmosphereModel(grid; dynamics, formulation=:StaticEnergy, kw...)
         potential_temperature_model = AtmosphereModel(grid; dynamics, formulation=:LiquidIcePotentialTemperature, kw...)
 
-        @test static_energy_model.advection.ρe isa Centered
+        @test static_energy_model.advection.ρs isa Centered
         @test potential_temperature_model.advection.ρθ isa Centered
 
         for model in (static_energy_model, potential_temperature_model)

--- a/test/atmosphere_model_construction.jl
+++ b/test/atmosphere_model_construction.jl
@@ -40,7 +40,7 @@ end
         @test occursin("thermodynamic_constants: ThermodynamicConstants{$FT}", shown_model)
         @test occursin("forcing: @NamedTuple{", shown_model)
         @test occursin("ρu::Returns{$FT}", shown_model)
-        @test occursin("ρe::Returns{$FT}", shown_model)
+        @test occursin("ρs::Returns{$FT}", shown_model)
 
         uᵍ(z) = -10
         vᵍ(z) = 0
@@ -79,18 +79,18 @@ end
             dynamics = AnelasticDynamics(reference_state)
             model = AtmosphereModel(grid; thermodynamic_constants=constants, dynamics, formulation)
 
-            # Test round-trip consistency: set θ, get ρe; then set ρe, get back θ
+            # Test round-trip consistency: set θ, get ρs; then set ρs, get back θ
             set!(model; θ = θ₀)
 
-            ρe₁ = Field(static_energy_density(model))
-            e₁ = Field(static_energy(model))
+            ρs₁ = Field(static_energy_density(model))
+            s₁ = Field(static_energy(model))
             ρθ₁ = Field(liquid_ice_potential_temperature_density(model))
             θ₁ = Field(liquid_ice_potential_temperature(model))
 
-            set!(model; ρe = ρe₁)
-            @test static_energy(model) ≈ e₁
+            set!(model; ρs = ρs₁)
+            @test static_energy(model) ≈ s₁
             @test liquid_ice_potential_temperature(model) ≈ θ₁
-            @test static_energy_density(model) ≈ ρe₁
+            @test static_energy_density(model) ≈ ρs₁
             @test liquid_ice_potential_temperature_density(model) ≈ ρθ₁
         end
     end

--- a/test/diagnostics.jl
+++ b/test/diagnostics.jl
@@ -132,17 +132,17 @@ end
     set!(model, θ=300, qᵗ=0.01)
 
     # Test StaticEnergy
-    e = StaticEnergy(model)
-    @test e isa Oceananigans.AbstractOperations.KernelFunctionOperation
-    e_field = Field(e)
-    @test all(isfinite.(interior(e_field)))
-    @test all(interior(e_field) .> 0)
+    s = StaticEnergy(model)
+    @test s isa Oceananigans.AbstractOperations.KernelFunctionOperation
+    s_field = Field(s)
+    @test all(isfinite.(interior(s_field)))
+    @test all(interior(s_field) .> 0)
 
     # Test density flavor
-    e_density = StaticEnergy(model, :density)
-    e_density_field = Field(e_density)
-    @test all(isfinite.(interior(e_density_field)))
-    @test all(interior(e_density_field) .> 0)
+    s_density = StaticEnergy(model, :density)
+    s_density_field = Field(s_density)
+    @test all(isfinite.(interior(s_density_field)))
+    @test all(interior(s_density_field) .> 0)
 end
 
 @testset "Relative humidity diagnostics [$(FT)]" for FT in test_float_types()

--- a/test/forcing_and_boundary_conditions.jl
+++ b/test/forcing_and_boundary_conditions.jl
@@ -28,7 +28,7 @@ increment_tolerance(::Type{Float64}) = 1e-10
     # Test a representative subset of forcing types (reduced from 4 to 2)
     forcings = [
         Returns(one(FT)),
-        Forcing(Returns(one(FT)), field_dependencies=(:ρe, :ρqᵛ, :ρu), discrete_form=true),
+        Forcing(Returns(one(FT)), field_dependencies=(:ρs, :ρqᵛ, :ρu), discrete_form=true),
     ]
 
     Δt = convert(FT, 1e-6)
@@ -45,11 +45,11 @@ increment_tolerance(::Type{Float64}) = 1e-10
         time_step!(model, Δt)
         @test maximum(model.momentum.ρv) ≈ Δt
 
-        e_forcing = (; ρe=forcing)
-        model = setup_forcing_model(grid, e_forcing)
-        ρe_before = deepcopy(static_energy_density(model))
+        s_forcing = (; ρs=forcing)
+        model = setup_forcing_model(grid, s_forcing)
+        ρs_before = deepcopy(static_energy_density(model))
         time_step!(model, Δt)
-        @test maximum(static_energy_density(model)) ≈ maximum(ρe_before) + Δt
+        @test maximum(static_energy_density(model)) ≈ maximum(ρs_before) + Δt
     end
 
     @testset "Forcing on non-existing field errors" begin
@@ -345,22 +345,22 @@ end
     @testset "BulkSensibleHeatFlux with StaticEnergyFormulation [$FT]" begin
         bc = BulkSensibleHeatFlux(surface_temperature=T₀, coefficient=Cᴰ, gustiness=gustiness)
 
-        # Test with ρe on static energy formulation
-        ρe_bcs = FieldBoundaryConditions(bottom=bc)
+        # Test with ρs on static energy formulation
+        ρs_bcs = FieldBoundaryConditions(bottom=bc)
         model = AtmosphereModel(grid; formulation=:StaticEnergy,
-                                boundary_conditions=(; ρe=ρe_bcs))
+                                boundary_conditions=(; ρs=ρs_bcs))
         θ₀ = model.dynamics.reference_state.potential_temperature
         set!(model; θ=θ₀, qᵗ=FT(0.01))
         time_step!(model, 1e-6)
         @test true
     end
 
-    @testset "BulkSensibleHeatFlux with ρe auto-converts for θ formulation [$FT]" begin
+    @testset "BulkSensibleHeatFlux with ρs auto-converts for θ formulation [$FT]" begin
         bc = BulkSensibleHeatFlux(surface_temperature=T₀, coefficient=Cᴰ, gustiness=gustiness)
 
-        # ρe BCs with θ formulation: should auto-convert to ρθ
-        ρe_bcs = FieldBoundaryConditions(bottom=bc)
-        model = AtmosphereModel(grid; boundary_conditions=(; ρe=ρe_bcs))
+        # ρs BCs with θ formulation: should auto-convert to ρθ
+        ρs_bcs = FieldBoundaryConditions(bottom=bc)
+        model = AtmosphereModel(grid; boundary_conditions=(; ρs=ρs_bcs))
         θ₀ = model.dynamics.reference_state.potential_temperature
         set!(model; θ=θ₀)
         time_step!(model, 1e-6)
@@ -424,12 +424,12 @@ end
     @testset "Combined bulk boundary conditions with StaticEnergyFormulation [$FT]" begin
         ρu_bcs = FieldBoundaryConditions(bottom=BulkDrag(coefficient=Cᴰ, gustiness=gustiness))
         ρv_bcs = FieldBoundaryConditions(bottom=BulkDrag(coefficient=Cᴰ, gustiness=gustiness))
-        ρe_bcs = FieldBoundaryConditions(bottom=BulkSensibleHeatFlux(surface_temperature=T₀,
+        ρs_bcs = FieldBoundaryConditions(bottom=BulkSensibleHeatFlux(surface_temperature=T₀,
                                                                      coefficient=Cᴰ, gustiness=gustiness))
         ρqᵛ_bcs = FieldBoundaryConditions(bottom=BulkVaporFlux(surface_temperature=T₀,
                                                                coefficient=Cᴰ, gustiness=gustiness))
 
-        boundary_conditions = (; ρu=ρu_bcs, ρv=ρv_bcs, ρe=ρe_bcs, ρqᵛ=ρqᵛ_bcs)
+        boundary_conditions = (; ρu=ρu_bcs, ρv=ρv_bcs, ρs=ρs_bcs, ρqᵛ=ρqᵛ_bcs)
         model = AtmosphereModel(grid; formulation=:StaticEnergy, boundary_conditions)
 
         θ₀ = model.dynamics.reference_state.potential_temperature
@@ -493,7 +493,7 @@ end
     θ₀ = FT(290)
     qᵗ₀ = FT(0.01)
 
-    @testset "Automatic ρe → ρθ conversion [$FT]" begin
+    @testset "Automatic ρs → ρθ conversion [$FT]" begin
         𝒬 = FT(100)  # W/m²
 
         # Test bottom, top, and both together
@@ -502,7 +502,7 @@ end
             FieldBoundaryConditions(top=FluxBoundaryCondition(-𝒬)),
             FieldBoundaryConditions(bottom=FluxBoundaryCondition(𝒬), top=FluxBoundaryCondition(-𝒬))
         ]
-            model = AtmosphereModel(grid; boundary_conditions=(ρe=bcs_config,))
+            model = AtmosphereModel(grid; boundary_conditions=(ρs=bcs_config,))
             set!(model; θ=θ₀, qᵗ=qᵗ₀)
         time_step!(model, FT(1e-6))
         @test true
@@ -528,8 +528,8 @@ end
         grid_1 = RectilinearGrid(default_arch; size=(1, 1, 4), x=(0, 100), y=(0, 100), z=(0, 100))
         𝒬 = FT(1000)
 
-        ρe_bcs = FieldBoundaryConditions(bottom=FluxBoundaryCondition(𝒬))
-        model = AtmosphereModel(grid_1; boundary_conditions=(; ρe=ρe_bcs))
+        ρs_bcs = FieldBoundaryConditions(bottom=FluxBoundaryCondition(𝒬))
+        model = AtmosphereModel(grid_1; boundary_conditions=(; ρs=ρs_bcs))
 
         θ₀_ref = model.dynamics.reference_state.potential_temperature
         set!(model; θ=θ₀_ref, qᵗ=qᵗ₀)
@@ -545,26 +545,26 @@ end
         @test expected_θ_flux ≈ 𝒬 / cᵖᵐ
     end
 
-    @testset "Error when specifying both ρθ and ρe boundary conditions [$FT]" begin
+    @testset "Error when specifying both ρθ and ρs boundary conditions [$FT]" begin
         grid_1 = RectilinearGrid(default_arch; size=(1, 1, 4), x=(0, 100), y=(0, 100), z=(0, 100))
 
         ρθ_bcs = FieldBoundaryConditions(bottom=FluxBoundaryCondition(FT(100)))
-        ρe_bcs = FieldBoundaryConditions(bottom=FluxBoundaryCondition(FT(200)))
+        ρs_bcs = FieldBoundaryConditions(bottom=FluxBoundaryCondition(FT(200)))
 
-        @test_throws ArgumentError AtmosphereModel(grid_1; boundary_conditions=(ρθ=ρθ_bcs, ρe=ρe_bcs))
+        @test_throws ArgumentError AtmosphereModel(grid_1; boundary_conditions=(ρθ=ρθ_bcs, ρs=ρs_bcs))
     end
 
     @testset "static_energy_density returns Field with energy flux BCs [$FT]" begin
         𝒬₀ = FT(500)
 
-        ρe_bcs = FieldBoundaryConditions(bottom=FluxBoundaryCondition(𝒬₀))
-        model = AtmosphereModel(grid; boundary_conditions=(ρe=ρe_bcs,))
+        ρs_bcs = FieldBoundaryConditions(bottom=FluxBoundaryCondition(𝒬₀))
+        model = AtmosphereModel(grid; boundary_conditions=(ρs=ρs_bcs,))
 
         θ₀_ref = model.dynamics.reference_state.potential_temperature
         set!(model; θ=θ₀_ref, qᵗ=qᵗ₀)
 
-        ρe = static_energy_density(model)
-        𝒬_op = BoundaryConditionOperation(ρe, :bottom, model)
+        ρs = static_energy_density(model)
+        𝒬_op = BoundaryConditionOperation(ρs, :bottom, model)
         𝒬_field = Field(𝒬_op)
         compute!(𝒬_field)
         @test all(interior(𝒬_field) .≈ 𝒬₀)
@@ -589,11 +589,11 @@ end
 
     # Test all lateral boundaries at once (more efficient than individual tests)
     @testset "Multiple lateral boundaries [$FT]" begin
-        ρe_bcs = FieldBoundaryConditions(west=FluxBoundaryCondition(𝒬),
+        ρs_bcs = FieldBoundaryConditions(west=FluxBoundaryCondition(𝒬),
                                           east=FluxBoundaryCondition(-𝒬),
                                           south=FluxBoundaryCondition(𝒬/2),
                                           north=FluxBoundaryCondition(-𝒬/2))
-        model = AtmosphereModel(grid; boundary_conditions=(ρe=ρe_bcs,))
+        model = AtmosphereModel(grid; boundary_conditions=(ρs=ρs_bcs,))
         set!(model; θ=θ₀, qᵗ=qᵗ₀)
         time_step!(model, FT(1e-6))
         @test true
@@ -610,14 +610,14 @@ end
 
     @testset "static_energy_density works for lateral EnergyFluxBC [$FT]" begin
         𝒬_west = 200
-        ρe_bcs = FieldBoundaryConditions(west=FluxBoundaryCondition(𝒬_west))
-        model = AtmosphereModel(grid; boundary_conditions=(ρe=ρe_bcs,))
+        ρs_bcs = FieldBoundaryConditions(west=FluxBoundaryCondition(𝒬_west))
+        model = AtmosphereModel(grid; boundary_conditions=(ρs=ρs_bcs,))
 
         θ₀_ref = model.dynamics.reference_state.potential_temperature
         set!(model; θ=θ₀_ref, qᵗ=qᵗ₀)
 
-        ρe = static_energy_density(model)
-        𝒬_op = BoundaryConditionOperation(ρe, :west, model)
+        ρs = static_energy_density(model)
+        𝒬_op = BoundaryConditionOperation(ρs, :west, model)
         𝒬_field = Field(𝒬_op)
         compute!(𝒬_field)
         @test all(interior(𝒬_field) .≈ 𝒬_west)
@@ -652,24 +652,24 @@ end
     end
 
     @testset "convert_energy_to_theta_bcs with Symbol formulation [$FT]" begin
-        bcs = (; ρe=FieldBoundaryConditions(bottom=FluxBoundaryCondition(FT(100))))
+        bcs = (; ρs=FieldBoundaryConditions(bottom=FluxBoundaryCondition(FT(100))))
         constants = ThermodynamicConstants()
 
         result = convert_energy_to_theta_bcs(bcs, :LiquidIcePotentialTemperature, constants)
         @test :ρθ ∈ keys(result)
-        @test :ρe ∉ keys(result)
+        @test :ρs ∉ keys(result)
     end
 
     @testset "theta_to_energy_bcs correctly converts BCs [$FT]" begin
         Jᶿ = FT(0.5)
         ρθ_bcs = FieldBoundaryConditions(bottom=FluxBoundaryCondition(Jᶿ))
-        ρe_bcs = theta_to_energy_bcs(ρθ_bcs)
-        @test ρe_bcs.bottom isa ThetaFluxBCType
+        ρs_bcs = theta_to_energy_bcs(ρθ_bcs)
+        @test ρs_bcs.bottom isa ThetaFluxBCType
 
         𝒬 = FT(500)
         ρθ_bcs_with_energy = FieldBoundaryConditions(bottom=EnergyFluxBoundaryCondition(𝒬))
-        ρe_bcs_extracted = theta_to_energy_bcs(ρθ_bcs_with_energy)
-        @test ρe_bcs_extracted.bottom.condition == 𝒬
+        ρs_bcs_extracted = theta_to_energy_bcs(ρθ_bcs_with_energy)
+        @test ρs_bcs_extracted.bottom.condition == 𝒬
     end
 
     @testset "EnergyFluxBoundaryConditionFunction summary [$FT]" begin
@@ -711,11 +711,11 @@ end
     Δt = FT(1e-6)
 
     # Test a representative subset of boundaries (bottom and west are sufficient for coverage)
-    for ρe_bcs in [
+    for ρs_bcs in [
         FieldBoundaryConditions(bottom=FluxBoundaryCondition(𝒬)),
         FieldBoundaryConditions(west=FluxBoundaryCondition(𝒬)),
     ]
-        model = AtmosphereModel(grid; boundary_conditions=(ρe=ρe_bcs,))
+        model = AtmosphereModel(grid; boundary_conditions=(ρs=ρs_bcs,))
         set!(model; θ=θ₀, qᵗ=qᵗ₀)
 
         ρθ = thermodynamic_density(model.formulation)
@@ -744,8 +744,8 @@ end
     model = AtmosphereModel(grid; boundary_conditions=(ρθ=ρθ_bcs,))
     set!(model; θ=θ₀, qᵗ=qᵗ₀)
 
-    ρe = static_energy_density(model)
-    𝒬_op = BoundaryConditionOperation(ρe, :bottom, model)
+    ρs = static_energy_density(model)
+    𝒬_op = BoundaryConditionOperation(ρs, :bottom, model)
     𝒬_field = Field(𝒬_op)
     compute!(𝒬_field)
 

--- a/test/geostrophic_subsidence_forcings.jl
+++ b/test/geostrophic_subsidence_forcings.jl
@@ -128,7 +128,7 @@ end
     @test ρqᵛ_final < ρqᵛ_initial
 end
 
-@testset "θ → e conversion in StaticEnergy model [$(FT)]" for FT in test_float_types()
+@testset "θ → s conversion in StaticEnergy model [$(FT)]" for FT in test_float_types()
     Oceananigans.defaults.FloatType = FT
     grid = RectilinearGrid(default_arch; size=(4, 4, 4), x=(0, 100), y=(0, 100), z=(0, 100))
     reference_state = ReferenceState(grid)

--- a/test/parcel_dynamics.jl
+++ b/test/parcel_dynamics.jl
@@ -54,15 +54,15 @@ using Test
     qᵗ = FT(0.015)
     q = MoistureMassFractions(qᵗ)
     cᵖᵐ = mixture_heat_capacity(q, constants)
-    e_init = cᵖᵐ * T_init + g * z_init
+    s_init = cᵖᵐ * T_init + g * z_init
 
-    𝒰 = StaticEnergyState(e_init, q, z_init, p_init)
+    𝒰 = StaticEnergyState(s_init, q, z_init, p_init)
     μ = NothingMicrophysicalState(FT)
 
     ρ = FT(1.2)
     ρqᵗ = ρ * qᵗ
-    ρℰ = ρ * e_init
-    parcel = ParcelState(FT(0), FT(0), z_init, FT(0), ρ, qᵗ, ρqᵗ, e_init, ρℰ, 𝒰, μ)
+    ρℰ = ρ * s_init
+    parcel = ParcelState(FT(0), FT(0), z_init, FT(0), ρ, qᵗ, ρqᵗ, s_init, ρℰ, 𝒰, μ)
 
     @test parcel.x == 0
     @test parcel.y == 0
@@ -71,7 +71,7 @@ using Test
     @test parcel.ρ == ρ
     @test parcel.qᵗ == qᵗ
     @test parcel.ρqᵗ == ρqᵗ
-    @test parcel.ℰ == e_init
+    @test parcel.ℰ == s_init
     @test parcel.ρℰ == ρℰ
     @test parcel.𝒰 === 𝒰
     @test parcel.μ === μ
@@ -170,9 +170,9 @@ end
         qᵗ = FT(0.010)
         q = MoistureMassFractions(qᵗ)
         cᵖᵐ = mixture_heat_capacity(q, constants)
-        e_init = cᵖᵐ * T_init + g * z_init
+        s_init = cᵖᵐ * T_init + g * z_init
 
-        𝒰_init = StaticEnergyState(e_init, q, z_init, p_init)
+        𝒰_init = StaticEnergyState(s_init, q, z_init, p_init)
 
         # Adjust to new height
         z_new = FT(1000.0)
@@ -180,7 +180,7 @@ end
         𝒰_new = adjust_adiabatically(𝒰_init, z_new, p_new, constants)
 
         # Static energy should be conserved
-        @test 𝒰_new.static_energy ≈ e_init
+        @test 𝒰_new.static_energy ≈ s_init
         @test 𝒰_new.height == z_new
         @test 𝒰_new.reference_pressure == p_new
 
@@ -230,9 +230,9 @@ end
     # Check tendencies are computed
     tendencies = model.dynamics.timestepper.G
     @test tendencies.Gz ≈ 1.0  # w = 1 m/s
-    # With specific quantity evolution, tendencies for e and qᵗ are zero
+    # With specific quantity evolution, tendencies for s and qᵗ are zero
     # (no microphysical sources) giving exact conservation
-    @test tendencies.Ge ≈ 0.0
+    @test tendencies.Gs ≈ 0.0
     @test tendencies.Gqᵗ ≈ 0.0
 
     # Time step should work
@@ -260,9 +260,9 @@ end
 
     # This tests that the state-based interface exists for SaturationAdjustment
     # Microphysical sources are zero (SaturationAdjustment operates via state adjustment)
-    tendency_e = microphysical_tendency(microphysics, Val(:ρe), ρ_val, ℳ, 𝒰, constants)
+    tendency_s = microphysical_tendency(microphysics, Val(:ρs), ρ_val, ℳ, 𝒰, constants)
     tendency_qt = microphysical_tendency(microphysics, Val(:ρqᵛ), ρ_val, ℳ, 𝒰, constants)
-    @test tendency_e == 0.0
+    @test tendency_s == 0.0
     @test tendency_qt == 0.0
 
     # Compute tendencies (this calls microphysical_tendency internally)
@@ -271,7 +271,7 @@ end
     tendencies = model.dynamics.timestepper.G
     @test tendencies.Gz ≈ 1.0  # w = 1 m/s
     # Tendencies are zero (SaturationAdjustment operates via state adjustment, not tendencies)
-    @test tendencies.Ge ≈ 0.0
+    @test tendencies.Gs ≈ 0.0
     @test tendencies.Gqᵗ ≈ 0.0
 
     # Time step should work
@@ -300,9 +300,9 @@ end
 
     # This tests that the state-based interface exists for DCMIP2016Kessler
     # Microphysical sources are zero (operates via microphysics_model_update!)
-    tendency_e = microphysical_tendency(microphysics, Val(:ρe), ρ_val, ℳ, 𝒰, constants)
+    tendency_s = microphysical_tendency(microphysics, Val(:ρs), ρ_val, ℳ, 𝒰, constants)
     tendency_qt = microphysical_tendency(microphysics, Val(:ρqᵛ), ρ_val, ℳ, 𝒰, constants)
-    @test tendency_e == 0.0
+    @test tendency_s == 0.0
     @test tendency_qt == 0.0
 
     # Compute tendencies (this calls microphysical_tendency internally)
@@ -311,7 +311,7 @@ end
     tendencies = model.dynamics.timestepper.G
     @test tendencies.Gz ≈ 1.0  # w = 1 m/s
     # Tendencies are zero (DCMIP2016Kessler operates via microphysics_model_update!, not tendencies)
-    @test tendencies.Ge ≈ 0.0
+    @test tendencies.Gs ≈ 0.0
     @test tendencies.Gqᵗ ≈ 0.0
 
     # Time step should work
@@ -354,7 +354,7 @@ using Oceananigans: interpolate
     T_initial = temperature(model.dynamics.state.𝒰, constants)
     z_initial = model.dynamics.state.z
     qᵗ_initial = model.dynamics.state.qᵗ
-    e_initial = model.dynamics.state.ℰ
+    s_initial = model.dynamics.state.ℰ
 
     # Run simulation for 20 minutes (parcel rises 1200 m at 1 m/s)
     simulation = Simulation(model; Δt=1.0, stop_time=20minutes, verbose=false)
@@ -362,7 +362,7 @@ using Oceananigans: interpolate
 
     z_final = model.dynamics.state.z
     qᵗ_final = model.dynamics.state.qᵗ
-    e_final = model.dynamics.state.ℰ
+    s_final = model.dynamics.state.ℰ
 
     # Get parcel and environmental temperatures at final height
     T_parcel = temperature(model.dynamics.state.𝒰, constants)
@@ -373,7 +373,7 @@ using Oceananigans: interpolate
     @test abs(T_parcel - T_environment) < 1.0
 
     # Specific static energy should be EXACTLY conserved (specific quantity evolution)
-    @test e_final == e_initial
+    @test s_final == s_initial
 
     # Parcel should have risen to expected height
     @test z_final ≈ 1200.0 atol=1.0
@@ -402,18 +402,18 @@ end
          w = 1)
 
     qᵗ_initial = model.dynamics.state.qᵗ
-    e_initial = model.dynamics.state.ℰ
+    s_initial = model.dynamics.state.ℰ
 
     # Run simulation for 15 minutes
     simulation = Simulation(model; Δt=1.0, stop_time=15minutes, verbose=false)
     run!(simulation)
 
     qᵗ_final = model.dynamics.state.qᵗ
-    e_final = model.dynamics.state.ℰ
+    s_final = model.dynamics.state.ℰ
 
     # Specific quantities should be EXACTLY conserved (specific quantity evolution)
     # Static energy is exactly conserved
-    @test e_final == e_initial
+    @test s_final == s_initial
 
     # Moisture conserved to floating-point precision (minor rounding in RK3)
     @test isapprox(qᵗ_final, qᵗ_initial, rtol=1e-14)

--- a/test/reference_states.jl
+++ b/test/reference_states.jl
@@ -456,7 +456,7 @@ end
     ##### set_to_mean! preserves density-weighted prognostic fields
     #####
     #
-    # Density-weighted prognostic fields (ρe, ρqᵗ, ρu) are left unchanged
+    # Density-weighted prognostic fields (ρs, ρqᵗ, ρu) are left unchanged
     # by set_to_mean!. Only the reference state (ρᵣ, pᵣ, Tᵣ) is updated.
 
     @testset "set_to_mean! preserves density-weighted prognostics" begin
@@ -474,7 +474,7 @@ end
         time_step!(model, 1)  # populates diagnostic fields
 
         # Record density-weighted prognostic fields before set_to_mean!
-        ρe_before  = Array(interior(model.formulation.energy_density))
+        ρs_before  = Array(interior(model.formulation.energy_density))
         ρqᵗ_before = Array(interior(model.moisture_density))
         ρu_before  = Array(interior(model.momentum.ρu))
         ρw_before  = Array(interior(model.momentum.ρw))
@@ -491,12 +491,12 @@ end
         end
 
         # Density-weighted prognostic fields should be unchanged
-        ρe_after  = Array(interior(model.formulation.energy_density))
+        ρs_after  = Array(interior(model.formulation.energy_density))
         ρqᵗ_after = Array(interior(model.moisture_density))
         ρu_after  = Array(interior(model.momentum.ρu))
         ρw_after  = Array(interior(model.momentum.ρw))
 
-        @test ρe_after  ≈ ρe_before
+        @test ρs_after  ≈ ρs_before
         @test ρqᵗ_after ≈ ρqᵗ_before
         @test ρu_after  ≈ ρu_before
         @test ρw_after  ≈ ρw_before

--- a/test/saturation_adjustment.jl
+++ b/test/saturation_adjustment.jl
@@ -54,8 +54,8 @@ test_thermodynamics = (:StaticEnergy, :LiquidIcePotentialTemperature)
 
     q₁ = MoistureMassFractions(qᵗ)
     cᵖᵐ = mixture_heat_capacity(q₁, constants)
-    e₁ = cᵖᵐ * T₁ + g * z
-    𝒰₁ = StaticEnergyState(e₁, q₁, z, pᵣ)
+    s₁ = cᵖᵐ * T₁ + g * z
+    𝒰₁ = StaticEnergyState(s₁, q₁, z, pᵣ)
 
     @test compute_temperature(𝒰₁, microphysics, constants) ≈ T₁ atol=atol
     @test compute_temperature(𝒰₁, nothing, constants) ≈ T₁ atol=atol
@@ -78,13 +78,13 @@ test_thermodynamics = (:StaticEnergy, :LiquidIcePotentialTemperature)
                     q₂ = MoistureMassFractions(qᵛ⁺₂, qˡ₂)
                     cᵖᵐ = mixture_heat_capacity(q₂, constants)
                     ℒˡᵣ = constants.liquid.reference_latent_heat
-                    e₂ = cᵖᵐ * T₂ + g * z - ℒˡᵣ * qˡ₂
+                    s₂ = cᵖᵐ * T₂ + g * z - ℒˡᵣ * qˡ₂
 
-                    𝒰₂ = StaticEnergyState(e₂, q₂, z, pᵣ)
+                    𝒰₂ = StaticEnergyState(s₂, q₂, z, pᵣ)
                     T★ = compute_temperature(𝒰₂, microphysics, constants)
                     @test T★ ≈ T₂ atol=atol
 
-                    set!(model, ρe = ρᵣ * e₂, qᵗ = qᵗ₂)
+                    set!(model, ρs = ρᵣ * s₂, qᵗ = qᵗ₂)
                     T★ = @allowscalar first(model.temperature)
                     qᵛ = @allowscalar first(model.microphysical_fields.qᵛ)
                     qˡ = @allowscalar first(model.microphysical_fields.qˡ)
@@ -156,13 +156,13 @@ end
             qˡ = qᵗ - qᵛ⁺
             q = MoistureMassFractions(qᵛ⁺, qˡ)
             cᵖᵐ = mixture_heat_capacity(q, constants)
-            e = cᵖᵐ * T_warm + g * z - ℒˡᵣ * qˡ
+            s = cᵖᵐ * T_warm + g * z - ℒˡᵣ * qˡ
 
-            𝒰 = StaticEnergyState(e, q, z, pᵣ)
+            𝒰 = StaticEnergyState(s, q, z, pᵣ)
             T★ = compute_temperature(𝒰, microphysics, constants)
             @test T★ ≈ T_warm atol=atol
 
-            set!(model, ρe = ρᵣ * e, qᵗ = qᵗ)
+            set!(model, ρs = ρᵣ * s, qᵗ = qᵗ)
             T★ = @allowscalar first(model.temperature)
             qᵛm = @allowscalar first(model.microphysical_fields.qᵛ)
             qˡm = @allowscalar first(model.microphysical_fields.qˡ)
@@ -184,13 +184,13 @@ end
             qⁱ = qᵗ - qᵛ⁺
             q = MoistureMassFractions(qᵛ⁺, zero(FT), qⁱ)
             cᵖᵐ = mixture_heat_capacity(q, constants)
-            e = cᵖᵐ * T_cold + g * z - ℒⁱᵣ * qⁱ
+            s = cᵖᵐ * T_cold + g * z - ℒⁱᵣ * qⁱ
 
-            𝒰 = StaticEnergyState(e, q, z, pᵣ)
+            𝒰 = StaticEnergyState(s, q, z, pᵣ)
             T★ = compute_temperature(𝒰, microphysics, constants)
             @test T★ ≈ T_cold atol=atol
 
-            set!(model, ρe = ρᵣ * e, qᵗ = qᵗ)
+            set!(model, ρs = ρᵣ * s, qᵗ = qᵗ)
             T★ = @allowscalar first(model.temperature)
             qᵛm = @allowscalar first(model.microphysical_fields.qᵛ)
             qˡm = @allowscalar first(model.microphysical_fields.qˡ)
@@ -219,13 +219,13 @@ end
             @test q.vapor + q.liquid + q.ice ≈ qᵗ
 
             cᵖᵐ = mixture_heat_capacity(q, constants)
-            e = cᵖᵐ * T + g * z - ℒˡᵣ * qˡ - ℒⁱᵣ * qⁱ
+            s = cᵖᵐ * T + g * z - ℒˡᵣ * qˡ - ℒⁱᵣ * qⁱ
 
-            𝒰_unadjusted = StaticEnergyState(e, MoistureMassFractions(qᵗ), z, pᵣ)
+            𝒰_unadjusted = StaticEnergyState(s, MoistureMassFractions(qᵗ), z, pᵣ)
             T★ = compute_temperature(𝒰_unadjusted, microphysics, constants)
             @test T★ ≈ T atol=atol
 
-            set!(model, ρe = ρᵣ * e, qᵗ = qᵗ)
+            set!(model, ρs = ρᵣ * s, qᵗ = qᵗ)
             T★ = @allowscalar first(model.temperature)
             qᵛm = @allowscalar first(model.microphysical_fields.qᵛ)
             qˡm = @allowscalar first(model.microphysical_fields.qˡ)
@@ -261,8 +261,8 @@ end
     qᵗ = FT(0.05)
     q = MoistureMassFractions(qᵗ)
     cᵖᵐ = mixture_heat_capacity(q, constants)
-    e = cᵖᵐ * T_ref + g * z  # energy without condensate correction (all-vapor initial)
-    𝒰₀ = StaticEnergyState(e, q, z, pᵣ)
+    s = cᵖᵐ * T_ref + g * z  # energy without condensate correction (all-vapor initial)
+    𝒰₀ = StaticEnergyState(s, q, z, pᵣ)
 
     𝒰₁ = adjust_thermodynamic_state(𝒰₀, microphysics, constants)
     T★ = compute_temperature(𝒰₁, nothing, constants)

--- a/test/turbulence_closures.jl
+++ b/test/turbulence_closures.jl
@@ -41,12 +41,12 @@ test_thermodynamics = (:StaticEnergy, :LiquidIcePotentialTemperature)
             # Set uniform specific energy for no diffusion
             θ₀ = model.dynamics.reference_state.potential_temperature
             cᵖᵈ = model.thermodynamic_constants.dry_air.heat_capacity
-            e₀ = cᵖᵈ * θ₀
-            set!(model; e=e₀)
-            ρe₀ = deepcopy(static_energy_density(model))
+            s₀ = cᵖᵈ * θ₀
+            set!(model; s=s₀)
+            ρs₀ = deepcopy(static_energy_density(model))
             time_step!(model, 1)
             # Use rtol for implicit solver which may have small numerical effects
-            @test isapprox(static_energy_density(model), ρe₀, rtol=1e-5)
+            @test isapprox(static_energy_density(model), ρs₀, rtol=1e-5)
         end
 
         @testset "Closure flux affects momentum tendency [$formulation, $(FT)]" begin
@@ -115,20 +115,20 @@ test_thermodynamics = (:StaticEnergy, :LiquidIcePotentialTemperature)
             set!(model; θ = θᵢ, ρqᵗ = qᵗᵢ, ρc = ρcᵢ, ρu = Ξ, ρv = Ξ, ρw = Ξ)
 
             # Store initial scalar fields (using copy of data to avoid reference issues)
-            ρe₀ = static_energy_density(model) |> Field |> interior |> Array
+            ρs₀ = static_energy_density(model) |> Field |> interior |> Array
             ρqᵛ₀ = model.moisture_density |> interior |> Array
             ρc₀ = model.tracers.ρc |> interior |> Array
 
             # Take a time step
             time_step!(model, 1)
 
-            ρe₁ = static_energy_density(model) |> Field |> interior |> Array
+            ρs₁ = static_energy_density(model) |> Field |> interior |> Array
             ρqᵛ₁ = model.moisture_density |> interior |> Array
             ρc₁ = model.tracers.ρc |> interior |> Array
 
             # Scalars should change due to diffusion (not advection since advection=nothing)
             # Use explicit maximum difference check instead of ≈ to handle Float32
-            @test maximum(abs, ρe₁ - ρe₀) > 0
+            @test maximum(abs, ρs₁ - ρs₀) > 0
             @test maximum(abs, ρqᵛ₁ - ρqᵛ₀) > 0
             @test maximum(abs, ρc₁ - ρc₀) > 0
         end

--- a/test/unit_tests.jl
+++ b/test/unit_tests.jl
@@ -206,7 +206,7 @@ using Breeze.AtmosphereModels: thermodynamic_density_name, thermodynamic_density
 
     # Boundary conditions needed for materialization (must pass grid to respect topology)
     ccc = (Center(), Center(), Center())
-    boundary_conditions = (ρθ = FieldBoundaryConditions(grid, ccc), ρe = FieldBoundaryConditions(grid, ccc))
+    boundary_conditions = (ρθ = FieldBoundaryConditions(grid, ccc), ρs = FieldBoundaryConditions(grid, ccc))
 
     @testset "LiquidIcePotentialTemperature field naming (Symbol)" begin
         @test prognostic_thermodynamic_field_names(:LiquidIcePotentialTemperature) == (:ρθ,)
@@ -215,9 +215,9 @@ using Breeze.AtmosphereModels: thermodynamic_density_name, thermodynamic_density
     end
 
     @testset "StaticEnergy field naming (Symbol)" begin
-        @test prognostic_thermodynamic_field_names(:StaticEnergy) == (:ρe,)
-        @test additional_thermodynamic_field_names(:StaticEnergy) == (:e,)
-        @test thermodynamic_density_name(:StaticEnergy) == :ρe
+        @test prognostic_thermodynamic_field_names(:StaticEnergy) == (:ρs,)
+        @test additional_thermodynamic_field_names(:StaticEnergy) == (:s,)
+        @test thermodynamic_density_name(:StaticEnergy) == :ρs
     end
 
     @testset "materialize_formulation(:LiquidIcePotentialTemperature)" begin
@@ -242,23 +242,23 @@ using Breeze.AtmosphereModels: thermodynamic_density_name, thermodynamic_density
         @test formulation.specific_energy isa Field
 
         # Test struct methods
-        @test prognostic_thermodynamic_field_names(formulation) == (:ρe,)
-        @test additional_thermodynamic_field_names(formulation) == (:e,)
-        @test thermodynamic_density_name(formulation) == :ρe
+        @test prognostic_thermodynamic_field_names(formulation) == (:ρs,)
+        @test additional_thermodynamic_field_names(formulation) == (:s,)
+        @test thermodynamic_density_name(formulation) == :ρs
         @test thermodynamic_density(formulation) === formulation.energy_density
     end
 
     @testset "Oceananigans.fields and prognostic_fields" begin
         θ_formulation = materialize_formulation(:LiquidIcePotentialTemperature, dynamics, grid, boundary_conditions)
-        e_formulation = materialize_formulation(:StaticEnergy, dynamics, grid, boundary_conditions)
+        s_formulation = materialize_formulation(:StaticEnergy, dynamics, grid, boundary_conditions)
 
         # LiquidIcePotentialTemperature
         @test haskey(Oceananigans.fields(θ_formulation), :θ)
         @test haskey(Oceananigans.prognostic_fields(θ_formulation), :ρθ)
 
         # StaticEnergy
-        @test haskey(Oceananigans.fields(e_formulation), :e)
-        @test haskey(Oceananigans.prognostic_fields(e_formulation), :ρe)
+        @test haskey(Oceananigans.fields(s_formulation), :s)
+        @test haskey(Oceananigans.prognostic_fields(s_formulation), :ρs)
     end
 end
 
@@ -324,10 +324,10 @@ end
         g = thermo.gravitational_acceleration
         ℒˡᵣ = thermo.liquid.reference_latent_heat
         ℒⁱᵣ = thermo.ice.reference_latent_heat
-        e = cᵖᵐ * T + g * z - ℒˡᵣ * qˡ - ℒⁱᵣ * qⁱ
+        s = cᵖᵐ * T + g * z - ℒˡᵣ * qˡ - ℒⁱᵣ * qⁱ
 
         # Test with saturation adjustment
-        𝒰 = StaticEnergyState(e, q, z, p)
+        𝒰 = StaticEnergyState(s, q, z, p)
         T★ = temperature(𝒰, thermo)
         @test T★ ≈ T
     end

--- a/validation/DCMIP2016_TC/dcmip2016_tc.jl
+++ b/validation/DCMIP2016_TC/dcmip2016_tc.jl
@@ -302,11 +302,11 @@ function dcmip2016_tropical_cyclone_simulation(; resolution = 0.25,
     Uᵍ = 1.0
     ρu_bcs  = FieldBoundaryConditions(bottom = BulkDrag(coefficient = Cᴰ, gustiness = Uᵍ, surface_temperature = Ts))
     ρv_bcs  = FieldBoundaryConditions(bottom = BulkDrag(coefficient = Cᴰ, gustiness = Uᵍ, surface_temperature = Ts))
-    ρe_bcs  = FieldBoundaryConditions(bottom = BulkSensibleHeatFlux(coefficient = Cᵀ, gustiness = Uᵍ,
+    ρs_bcs  = FieldBoundaryConditions(bottom = BulkSensibleHeatFlux(coefficient = Cᵀ, gustiness = Uᵍ,
                                                                     surface_temperature = Ts))
     ρqᵛ_bcs = FieldBoundaryConditions(bottom = BulkVaporFlux(coefficient = Cᵀ, gustiness = Uᵍ,
                                                              surface_temperature = Ts))
-    boundary_conditions = (; ρu = ρu_bcs, ρv = ρv_bcs, ρe = ρe_bcs, ρqᵛ = ρqᵛ_bcs)
+    boundary_conditions = (; ρu = ρu_bcs, ρv = ρv_bcs, ρs = ρs_bcs, ρqᵛ = ρqᵛ_bcs)
 
     model = AtmosphereModel(grid; dynamics, coriolis, microphysics, closure, boundary_conditions,
                             thermodynamic_constants = constants,


### PR DESCRIPTION
Renames the static-energy symbol from `e` to `s` throughout Breeze: the prognostic density of `StaticEnergyFormulation` is now `ρs` (was `ρe`) and its diagnostic specific field `s` (was `e`) — in field/NamedTuple keys, `thermodynamic_density_name`, boundary-condition and forcing keys (`ρs`, or the specific alias `s`), `set!(model, ρs = …)` / `set!(model, s = …)`, the `Val{:ρs}`/`Val{:s}` dispatch, the parcel-model tendency `Gs`, kernel and docstring variables, the docs math (`s = cᵖᵐ T + g z − ℒˡᵣ qˡ − ℒⁱᵣ qⁱ`), the notation table, examples, tests, the DCMIP2016 validation script and the agent docs.

The motivation is to free `e`/`ρe` for turbulent kinetic energy: the TKE closure of #875 will carry the tracer `ρe` (as CATKE carries `e`), which would otherwise collide with the static-energy prognostic and its `set!`/forcing aliases. `s` is the meteorological static-energy letter (dry static energy `s = cₚT + gz`; Breeze's form is Betts' liquid–ice static energy); lowercase `s`/`ρs` were unused in the notation table and in `src/`.

English names are unchanged (`static_energy`, `static_energy_density`, `StaticEnergyFormulation`, `specific_energy`, `EnergyFluxBoundaryCondition`, …), as are the `𝒬`/`Jᶿ` energy-flux helpers. **Breaking** for user scripts that key boundary conditions, forcings or `set!` by `ρe`/`e`: use `ρs`/`s`. Existing output and checkpoint files will be inconsistent.

One incidental fix: `examples/cloudy_thermal_bubble.jl` labelled a θ heatmap "ρe′ (J/kg)"; it now says "θ (K)".

Verified on CPU: `forcing_and_boundary_conditions`, `unit_tests`, `atmosphere_model_construction`, `saturation_adjustment`, `reference_states`, `advection_schemes`, `set_atmosphere_model`, `parcel_dynamics`, `quality_assurance`, `turbulence_closures`, `diagnostics`, `geostrophic_subsidence_forcings` and the doctests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)