### PR TITLE
[docs] Fix rendering of func name in monospace

### DIFF
--- a/docs/src/developer/microphysics/fused_example.md
+++ b/docs/src/developer/microphysics/fused_example.md
@@ -68,7 +68,7 @@ end
 In the per-name walkthrough each prognostic gets its own `microphysical_tendency`
 method. The liquid and ice methods each call `saturation_specific_humidity`
 independently, and the vapor method delegates back into the liquid and ice methods —
-so a given ``saturation_specific_humidity`` is computed twice and the vapor method
+so a given `saturation_specific_humidity` is computed twice and the vapor method
 re-invokes both other dispatches. The structure scales poorly: each new prognostic adds
 another redundant pass.
 


### PR DESCRIPTION
This is [how this is rendered currently](https://numericalearth.github.io/BreezeDocumentation/dev/developer/microphysics/fused_example/#Bundling-Tendencies)
<img width="850" height="237" alt="image" src="https://github.com/user-attachments/assets/e64cabf2-8ca1-48f9-a2ee-3707fbb3bf19" />
