### PR TITLE
[benchmarking] Fix import of `SpecifiedTimes`

### DIFF
--- a/benchmarking/src/BreezeBenchmarks.jl
+++ b/benchmarking/src/BreezeBenchmarks.jl
@@ -25,7 +25,7 @@ using Oceananigans.Architectures: GPU, ReactantState
 using Oceananigans.Units
 using Oceananigans.TimeSteppers: time_step!
 using Oceananigans.OutputWriters: JLD2Writer, IterationInterval, TimeInterval, write_output!
-using Oceananigans.Simulations: SpecifiedTimes
+using Oceananigans.Utils: SpecifiedTimes
 
 using Breeze
 


### PR DESCRIPTION
Before https://github.com/CliMA/Oceananigans.jl/pull/5856, `SpecifiedTimes` was accidentally accessible from `Oceananigans.Simulations` even though it originally coming from the `Utils` submodule, and never actually used, nor re-exported, in `Simulations`