### PR TITLE
Replace `TYPEDEF` -> `TYPEDSIGNATURES` for struct definitions

### DIFF
--- a/src/CompressibleEquations/time_discretizations.jl
+++ b/src/CompressibleEquations/time_discretizations.jl
@@ -379,6 +379,8 @@ convert_acoustic_parameter(::Type{FT}, damping::DirectDivergenceDamping) where F
     DirectDivergenceDamping{FT}(convert(FT, damping.coefficient))
 
 """
+$(TYPEDEF)
+
 Abstract supertype for upper-sponge ramp shapes. A concrete `AbstractRamp`
 is callable as `(ramp)(z, sponge_top, depth)` and returns a value in
 ``[0, 1]``: zero below ``z_{\\rm sponge\\_top} - \\text{depth}``, rising

--- a/src/Microphysics/bulk_microphysics.jl
+++ b/src/Microphysics/bulk_microphysics.jl
@@ -91,7 +91,7 @@ AtmosphereModels.microphysics_model_update!(::NonEquilibriumCloudFormation, mode
 abstract type AbstractCondensateFormation end
 
 """
-$(TYPEDSIGNATURES)
+$(TYPEDEF)
 
 Return a condensate formation model that applies a **constant** phase-change rate.
 

--- a/src/PotentialTemperatureFormulations/PotentialTemperatureFormulations.jl
+++ b/src/PotentialTemperatureFormulations/PotentialTemperatureFormulations.jl
@@ -10,7 +10,7 @@ module PotentialTemperatureFormulations
 
 export LiquidIcePotentialTemperatureFormulation
 
-using DocStringExtensions: TYPEDSIGNATURES
+using DocStringExtensions: TYPEDSIGNATURES, TYPEDEF
 using Adapt: Adapt, adapt
 using KernelAbstractions: @kernel, @index
 

--- a/src/PotentialTemperatureFormulations/potential_temperature_formulation.jl
+++ b/src/PotentialTemperatureFormulations/potential_temperature_formulation.jl
@@ -3,7 +3,7 @@
 #####
 
 """
-$(TYPEDSIGNATURES)
+$(TYPEDEF)
 
 `LiquidIcePotentialTemperatureFormulation` uses liquid-ice potential temperature density `ρθ`
 as the prognostic thermodynamic variable.

--- a/src/StaticEnergyFormulations/StaticEnergyFormulations.jl
+++ b/src/StaticEnergyFormulations/StaticEnergyFormulations.jl
@@ -11,7 +11,7 @@ module StaticEnergyFormulations
 
 export StaticEnergyFormulation
 
-using DocStringExtensions: TYPEDSIGNATURES
+using DocStringExtensions: TYPEDSIGNATURES, TYPEDEF
 using Adapt: Adapt, adapt
 using KernelAbstractions: @kernel, @index
 

--- a/src/StaticEnergyFormulations/static_energy_formulation.jl
+++ b/src/StaticEnergyFormulations/static_energy_formulation.jl
@@ -3,7 +3,7 @@
 #####
 
 """
-$(TYPEDSIGNATURES)
+$(TYPEDEF)
 
 `StaticEnergyFormulation` uses moist static energy density `ρs` as the prognostic thermodynamic variable.
 


### PR DESCRIPTION
Resolves some warnings by `DocumenterCodeBlocks`.