### PR TITLE
Thread boundary-condition args through the auxiliary halo fills

### DIFF
--- a/src/AtmosphereModels/update_atmosphere_model_state.jl
+++ b/src/AtmosphereModels/update_atmosphere_model_state.jl
@@ -240,7 +240,7 @@ function compute_auxiliary_thermodynamic_variables!(model::AtmosphereModel)
             model.moisture_density)
 
     fill_halo_regions!(model.temperature)
-    fill_halo_regions!(model.microphysical_fields)
+    fill_halo_regions!(model.microphysical_fields, boundary_condition_args(model)...)
     fill_halo_regions!(model.formulation)
 
     return nothing

--- a/src/CompressibleEquations/CompressibleEquations.jl
+++ b/src/CompressibleEquations/CompressibleEquations.jl
@@ -60,6 +60,7 @@ using Oceananigans.Grids: rnode, znode
 using Oceananigans.Operators: ℑxᶜᵃᵃ, ℑxᶠᵃᵃ, ℑyᵃᶜᵃ, ℑyᵃᶠᵃ, ℑzᵃᵃᶜ, ℑzᵃᵃᶠ,
                                 ∂zᶜᶜᶜ, ∂zᶜᶜᶠ
 using Oceananigans.BoundaryConditions: fill_halo_regions!
+using Oceananigans.Models: boundary_condition_args
 using Oceananigans.Operators: divᶜᶜᶜ
 using Oceananigans.Utils: prettysummary, launch!, KernelParameters
 

--- a/src/CompressibleEquations/compressible_time_stepping.jl
+++ b/src/CompressibleEquations/compressible_time_stepping.jl
@@ -374,9 +374,11 @@ function AtmosphereModels.compute_auxiliary_dynamics_variables!(model::Compressi
     dynamics = model.dynamics
 
     # Ensure halos are filled (may have been async from update_state!)
-    # These fields are needed for pressure computation via equation of state
-    fill_halo_regions!(dynamics.dry_density)
-    fill_halo_regions!(prognostic_fields(model.formulation))
+    # These fields are needed for pressure computation via equation of state.
+    # The boundary-condition args must be threaded: without them a time-dependent
+    # boundary condition is evaluated with no clock.
+    fill_halo_regions!(dynamics.dry_density, boundary_condition_args(model)...)
+    fill_halo_regions!(prognostic_fields(model.formulation), boundary_condition_args(model)...)
 
     launch!(arch, grid, :xyz,
             _compute_temperature_and_pressure!,

--- a/src/CompressibleEquations/terrain_compressible_physics.jl
+++ b/src/CompressibleEquations/terrain_compressible_physics.jl
@@ -699,9 +699,10 @@ function compute_terrain_temperature_and_pressure!(model::TerrainCompressibleMod
     arch = architecture(grid)
     dynamics = model.dynamics
 
-    # Ensure halos are filled
-    fill_halo_regions!(dynamics.dry_density)
-    fill_halo_regions!(prognostic_fields(model.formulation))
+    # Ensure halos are filled. The boundary-condition args must be threaded: without
+    # them a time-dependent boundary condition is evaluated with no clock.
+    fill_halo_regions!(dynamics.dry_density, boundary_condition_args(model)...)
+    fill_halo_regions!(prognostic_fields(model.formulation), boundary_condition_args(model)...)
 
     # Compute temperature and pressure (same as non-terrain CompressibleModel)
     launch!(arch, grid, :xyz,

--- a/test/forcing_and_boundary_conditions.jl
+++ b/test/forcing_and_boundary_conditions.jl
@@ -3,11 +3,14 @@ include(joinpath(@__DIR__, "setup.jl"))
 using Breeze
 using Breeze.AtmosphereModels: thermodynamic_density, surface_pressure, standard_pressure
 using Breeze.BoundaryConditions: EnergyFluxBoundaryCondition, FilteredSurfaceVelocities
-using Breeze.Thermodynamics: potential_temperature_from_temperature
+using Breeze.CompressibleEquations: TerrainCompressibleModel
+using Breeze.Microphysics: DCMIP2016KesslerMicrophysics
+using Breeze.Thermodynamics: potential_temperature_from_temperature, TetensFormula
 using GPUArraysCore: @allowscalar
 using Oceananigans: Oceananigans
 using Oceananigans.BoundaryConditions: BoundaryCondition
 using Oceananigans.Fields: location
+using Oceananigans.Operators: ℑxᶠᵃᵃ
 using Oceananigans.TimeSteppers: compute_flux_bc_tendencies!, update_state!
 using Test
 
@@ -195,6 +198,146 @@ end
     @test model.clock.iteration == 1
     @test @allowscalar(model.momentum.ρu[1, 1, 1]) ≈ FT(1.5)
     @test !any(isnan, parent(model.momentum.ρu))
+end
+
+@testset "Time-dependent Value BC on density and ρθ [$FT]" for FT in test_float_types()
+    # Regression test: the auxiliary-variable halo fills inside `update_state!`
+    # (`compute_auxiliary_dynamics_variables!`, `compute_terrain_temperature_and_pressure!`)
+    # refilled the dry density and the formulation prognostics without threading
+    # `model.clock`/`fields(model)`, re-evaluating a time-dependent lateral BC with no
+    # clock and clobbering the correctly-timed halo `compute_velocities!` had just used.
+    Oceananigans.defaults.FloatType = FT
+    grid = RectilinearGrid(default_arch; size=(8, 8, 4),
+                           x=(0, 1000), y=(0, 1000), z=(0, 200),
+                           topology=(Bounded, Bounded, Bounded))
+    dynamics = CompressibleDynamics(SplitExplicitTimeDiscretization();
+                                    reference_potential_temperature=FT(300),
+                                    surface_pressure=FT(1e5))
+
+    ρ₀ = FT(1.2)
+    θ₀ = FT(300)
+    U  = FT(5)
+    parameters = (; ρ₀, θ₀)
+
+    # The prescribed wall density grows linearly in time, so the expected halo value at
+    # any clock time is analytic and no reference run is needed.
+    @inline ρᵈ_west(y, z, t, p) = p.ρ₀ * (1 + t)
+    @inline ρθ_west(y, z, t, p) = p.ρ₀ * (1 + t) * p.θ₀
+
+    boundary_conditions = (ρᵈ = FieldBoundaryConditions(west = ValueBoundaryCondition(ρᵈ_west; parameters)),
+                           ρθ = FieldBoundaryConditions(west = ValueBoundaryCondition(ρθ_west; parameters)),
+                           ρu = FieldBoundaryConditions(west = NormalFlowBoundaryCondition(ρ₀ * U)))
+
+    model = AtmosphereModel(grid; dynamics, boundary_conditions)
+
+    # Write the dry density directly: `set!(model; ρ=...)` refills the ρᵈ halo without a
+    # clock, which a continuous boundary condition cannot be evaluated with.
+    set!(model.dynamics.dry_density, ρ₀)
+    set!(model; θ=θ₀)
+
+    t★ = FT(3)
+    model.clock.time = t★
+    update_state!(model)
+
+    ρᵈ = model.dynamics.dry_density
+    ρθ = thermodynamic_density(model.formulation)
+
+    # A `Value` BC prescribes the boundary-face value, so the west halo satisfies
+    # ℑxᶠᵃᵃ(ρ) = ρ_wall(t) at i = 1 — with t the current clock time, not 0.
+    ρᵈ_boundary = @allowscalar ℑxᶠᵃᵃ(1, 1, 1, grid, ρᵈ)
+    ρθ_boundary = @allowscalar ℑxᶠᵃᵃ(1, 1, 1, grid, ρθ)
+    @test ρᵈ_boundary ≈ ρ₀ * (1 + t★)      # a stale halo would hold ρ₀
+    @test ρθ_boundary ≈ ρ₀ * (1 + t★) * θ₀ # a stale halo would hold ρ₀ θ₀
+
+    # `_compute_velocities!` sets u = ρu / ℑxᶠᵃᵃ(ρᵈ) over 1:Nx+1, so the west boundary
+    # face satisfies ρu = ℑxᶠᵃᵃ(ρᵈ) u unless the density halo is refilled behind it.
+    ρu_boundary = @allowscalar model.momentum.ρu[1, 1, 1]
+    u_boundary = @allowscalar model.velocities.u[1, 1, 1]
+    @test ρu_boundary ≈ u_boundary * ρᵈ_boundary
+end
+
+@testset "Time-dependent Value BC on density and ρθ over terrain [$FT]" for FT in test_float_types()
+    # Regression test for the terrain-following twin of the fill above:
+    # `compute_terrain_temperature_and_pressure!` refilled the dry density and the
+    # formulation prognostics without threading `model.clock`/`fields(model)`.
+    Oceananigans.defaults.FloatType = FT
+    Lx = Ly = FT(1000)
+    Lz = FT(200)
+    Nz = 4
+    z_faces = TerrainFollowingVerticalDiscretization(collect(range(0, Lz, length=Nz+1));
+                                                     formulation = LinearDecay())
+    grid = RectilinearGrid(default_arch; size=(8, 8, Nz),
+                           x=(0, Lx), y=(0, Ly), z=z_faces,
+                           topology=(Bounded, Bounded, Bounded))
+    materialize_terrain!(grid, (x, y) -> 20 * sin(2π * x / Lx) * sin(2π * y / Ly))
+    dynamics = CompressibleDynamics(SplitExplicitTimeDiscretization();
+                                    reference_potential_temperature=FT(300),
+                                    surface_pressure=FT(1e5))
+
+    ρ₀ = FT(1.2)
+    θ₀ = FT(300)
+    U  = FT(5)
+    parameters = (; ρ₀, θ₀)
+
+    @inline ρᵈ_west_terrain(y, z, t, p) = p.ρ₀ * (1 + t)
+    @inline ρθ_west_terrain(y, z, t, p) = p.ρ₀ * (1 + t) * p.θ₀
+
+    boundary_conditions = (ρᵈ = FieldBoundaryConditions(west = ValueBoundaryCondition(ρᵈ_west_terrain; parameters)),
+                           ρθ = FieldBoundaryConditions(west = ValueBoundaryCondition(ρθ_west_terrain; parameters)),
+                           ρu = FieldBoundaryConditions(west = NormalFlowBoundaryCondition(ρ₀ * U)))
+
+    model = AtmosphereModel(grid; dynamics, boundary_conditions)
+
+    # The terrain fill is only reached through `compute_terrain_temperature_and_pressure!`.
+    @test model isa TerrainCompressibleModel
+
+    # Write the dry density directly: `set!(model; ρ=...)` still refills the ρᵈ halo without
+    # a clock inside the density reconciliation (`reconcile_densities!`).
+    set!(model.dynamics.dry_density, ρ₀)
+    set!(model; θ=θ₀)
+
+    t★ = FT(3)
+    model.clock.time = t★
+    update_state!(model)
+
+    ρᵈ = model.dynamics.dry_density
+    ρθ = thermodynamic_density(model.formulation)
+
+    @test @allowscalar(ℑxᶠᵃᵃ(1, 1, 1, grid, ρᵈ)) ≈ ρ₀ * (1 + t★)      # a stale halo would hold ρ₀
+    @test @allowscalar(ℑxᶠᵃᵃ(1, 1, 1, grid, ρθ)) ≈ ρ₀ * (1 + t★) * θ₀ # a stale halo would hold ρ₀ θ₀
+end
+
+@testset "Time-dependent Value BC on a microphysical prognostic [$FT]" for FT in test_float_types()
+    # Regression test: `compute_auxiliary_thermodynamic_variables!` refilled the
+    # microphysical fields without threading `model.clock`/`fields(model)`, so a
+    # time-dependent BC on a prognostic moment could not be evaluated at all.
+    Oceananigans.defaults.FloatType = FT
+    grid = RectilinearGrid(default_arch; size=(8, 8, 4),
+                           x=(0, 1000), y=(0, 1000), z=(0, 200),
+                           topology=(Bounded, Bounded, Bounded))
+    dynamics = CompressibleDynamics(SplitExplicitTimeDiscretization();
+                                    reference_potential_temperature=FT(300),
+                                    surface_pressure=FT(1e5))
+
+    # DCMIP2016 Kessler is the scheme whose prognostic moments (ρqᶜˡ, ρqʳ) carry user
+    # boundary conditions; it requires Tetens saturation vapor pressure.
+    constants = ThermodynamicConstants(FT; saturation_vapor_pressure = TetensFormula(FT))
+    microphysics = DCMIP2016KesslerMicrophysics(FT)
+
+    ρqʳ₀ = FT(1e-3)
+    @inline ρqʳ_west(y, z, t, p) = p.ρqʳ₀ * (1 + t)
+    boundary_conditions = (; ρqʳ = FieldBoundaryConditions(west = ValueBoundaryCondition(ρqʳ_west; parameters=(; ρqʳ₀))))
+
+    model = AtmosphereModel(grid; dynamics, microphysics, boundary_conditions,
+                            thermodynamic_constants = constants)
+    set!(model; ρ=FT(1.2), θ=FT(300))
+
+    t★ = FT(3)
+    model.clock.time = t★
+    update_state!(model)
+
+    ρqʳ = model.microphysical_fields.ρqʳ
+    @test @allowscalar(ℑxᶠᵃᵃ(1, 1, 1, grid, ρqʳ)) ≈ ρqʳ₀ * (1 + t★) # a stale halo would hold ρqʳ₀
 end
 
 @testset "Bulk boundary conditions [$FT]" for FT in test_float_types()


### PR DESCRIPTION
Three `fill_halo_regions!` calls inside `update_state!` refill halos of fields that may carry user boundary conditions without passing the boundary-condition args, so `getbc` is reached with no clock:

| function | file | fields refilled |
|---|---|---|
| `compute_auxiliary_dynamics_variables!` | `src/CompressibleEquations/compressible_time_stepping.jl:378-379` | dry density, formulation prognostics |
| `compute_terrain_temperature_and_pressure!` | `src/CompressibleEquations/terrain_compressible_physics.jl:703-704` | dry density, formulation prognostics |
| `compute_auxiliary_thermodynamic_variables!` | `src/AtmosphereModels/update_atmosphere_model_state.jl:243` | microphysical prognostics |

For a time-dependent boundary condition this is a `MethodError` — `ContinuousBoundaryFunction` is not callable without the clock. A compressible model carrying a continuous `Value` condition on the dry density, on the thermodynamic prognostic, or on a prognostic microphysical moment therefore cannot be stepped at all. A condition type that tolerates a missing clock is worse off: it is evaluated at the wrong time, without complaint.

The ordering is what makes the first two reachable. Within a single `update_state!`:

```
fill_halo_regions!(prognostic_fields(model), boundary_condition_args(model)..., async = true)
compute_auxiliary_variables!(model)
  ├─ compute_velocities!                        fills density + momentum halos WITH args,
  │                                             then sets u = ρu / ℑxᶠᵃᵃ(ρᵈ) over 1:Nx+1
  ├─ compute_auxiliary_thermodynamic_variables! ← site 3 (microphysical prognostics)
  └─ compute_auxiliary_dynamics_variables!      ← site 1, or site 2 for a TerrainCompressibleModel
                                                refills density + formulation prognostics
                                                WITHOUT args, then computes T and p
```

The velocity has therefore already been diagnosed from a correctly-timed density halo by the time that halo is overwritten with one evaluated at the wrong time, so `ρu = ℑxᶠᵃᵃ(ρᵈ) u` no longer holds at the boundary face — an identity `_compute_velocities!` establishes by construction over `1:Nx+1`. Sites 1 and 2 are alternatives by dispatch, never both.

Site 3 is the same defect on the prognostic microphysical moments. It does not touch the density and is independent of that identity.

The refill exists because the fill at the top of `update_state!` is `async = true`, so the equation-of-state kernel cannot assume it has landed. For the *formulation prognostics* that is real work — nothing else fills `ρθ` synchronously. For the *density* it is redundant with the synchronous fill `compute_velocities!` performs immediately above, and dropping it there may be preferable to threading the args; see the discussion below.

#742 fixed this class at three sites, `compute_velocities!` among them. These run afterward and undo it.

`boundary_condition_args` moves to a module-level import in `CompressibleEquations`: `compressible_time_stepping.jl` is included before `acoustic_substepping.jl`, which held the only existing import, so relying on it would depend on include order.

### Tests

Three regression tests in `test/forcing_and_boundary_conditions.jl`, each verified to fail without the corresponding fix **and to land on its own call site**:

| test | stashed failure lands on |
|---|---|
| `Time-dependent Value BC on density and ρθ` | `compressible_time_stepping.jl:378` |
| `Time-dependent Value BC on density and ρθ over terrain` | `terrain_compressible_physics.jl:703` |
| `Time-dependent Value BC on a microphysical prognostic` | `update_atmosphere_model_state.jl:243` |

Each uses a continuous `Value` condition linear in time, so the expected halo value at a given clock time is analytic and no reference run is needed. The first also asserts the `ρu = ℑxᶠᵃᵃ(ρᵈ) u` identity at the boundary face. The microphysics test uses `DCMIP2016KesslerMicrophysics`, the only scheme whose `prognostic_field_names` is non-empty *and* whose field materialization threads user boundary conditions.

`test/forcing_and_boundary_conditions.jl` goes from 83 to 87 passing; `quality_assurance.jl` (Aqua, ExplicitImports, No Core.Box) passes unchanged.

### Not fixed here

A related group of unguarded fills sits on the `set!` path — `reconcile_densities!` (`compressible_time_stepping.jl:165, 186`), `establish_relative_humidity_densities!` (`:218`), and `set_potential_temperature_hydrostatically_balanced_density!` (`set_to_mean.jl:352`) — and `nudge_initial_fields!` (`adiabatic_balance.jl:83`) fills the prognostics the same way. `set!` with a continuous condition on the dry density therefore still fails.

Those are not reachable from `update_state!`, and threading them piecemeal cannot be demonstrated by a passing test until all are done, so they are left for a follow-up.
