### PR TITLE
[CI] Set `JULIA_CPU_TARGET` for GitHub-hosted x86-64 jobs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -115,7 +115,7 @@ jobs:
         run: |
           # Pool of GitHub-hosted runners can have several different ISAs, try to
           # target all of them, with safe fallbacks.
-          echo "JULIA_CPU_TARGET=generic;haswell,-xsaveopt,clone_all;znver3,-rdrnd,base(1);x86-64-v4,-rdrnd,base(1)" | tee -a "${GITHUB_ENV}"
+          echo "JULIA_CPU_TARGET=generic;haswell,-xsaveopt,clone_all;x86-64-v4,-rdrnd,base(1)" | tee -a "${GITHUB_ENV}"
       - name: Show versioninfo
         run: |
           julia --compile=min -O0 -e 'using InteractiveUtils; versioninfo()'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -115,7 +115,7 @@ jobs:
         run: |
           # Pool of GitHub-hosted runners can have several different ISAs, try to
           # target all of them, with safe fallbacks.
-          echo "JULIA_CPU_TARGET=generic;haswell,-xsaveopt,clone_all;znver3,-rdrnd,base(1);znver4,-rdrnd,base(1);sapphirerapids,-rdrnd,base(1)" | tee -a "${GITHUB_ENV}"
+          echo "JULIA_CPU_TARGET=generic;haswell,-xsaveopt,clone_all;znver3,-rdrnd,base(1);x86-64-v4,-rdrnd,base(1)" | tee -a "${GITHUB_ENV}"
       - name: Show versioninfo
         run: |
           julia --compile=min -O0 -e 'using InteractiveUtils; versioninfo()'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -109,6 +109,13 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
+      - name: Set JULIA_CPU_TARGET
+        if: ${{ runner.environment == 'github-hosted' && runner.arch == 'X64' }}
+        shell: bash
+        run: |
+          # Pool of GitHub-hosted runners can have several different ISAs, try to
+          # target all of them, with safe fallbacks.
+          echo "JULIA_CPU_TARGET=generic;haswell,-xsaveopt,clone_all;znver3,-rdrnd,base(1);znver4,-rdrnd,base(1);sapphirerapids,-rdrnd,base(1)" | tee -a "${GITHUB_ENV}"
       - name: Show versioninfo
         if: ${{ startsWith(matrix.os, 'aws-linux-nvidia-gpu-') }}
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -117,7 +117,6 @@ jobs:
           # target all of them, with safe fallbacks.
           echo "JULIA_CPU_TARGET=generic;haswell,-xsaveopt,clone_all;znver3,-rdrnd,base(1);znver4,-rdrnd,base(1);sapphirerapids,-rdrnd,base(1)" | tee -a "${GITHUB_ENV}"
       - name: Show versioninfo
-        if: ${{ startsWith(matrix.os, 'aws-linux-nvidia-gpu-') }}
         run: |
           julia --compile=min -O0 -e 'using InteractiveUtils; versioninfo()'
       - name: "Cache Julia depot"


### PR DESCRIPTION
Similar to what was done in https://github.com/NumericalEarth/NumericalEarth.jl/pull/663.  Let's see if this helps with Windows jobs often re-precompiling the entire environment for unclear reasons.