### PR TITLE
[docs] Cap compat with AtmosphericProfilesLibrary

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -25,7 +25,7 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Breeze = {path = ".."}
 
 [compat]
-AtmosphericProfilesLibrary = "0.1.7"
+AtmosphericProfilesLibrary = "0.1.7 - 0.1.8"
 CUDA = "5, 6.0"
 CairoMakie = "0.15"
 Documenter = "1 - 1.17, 1.19"


### PR DESCRIPTION
In the [RICO example](https://numericalearth.github.io/BreezeDocumentation/dev/literated/rico/) we currently see
```
Precompiling packages...
Info Given ClimaInterpolationsCUDAExt was explicitly requested, output will be shown live
ERROR: LoadError: UndefVarError: `Adapt` not defined in `CUDA`
Suggestion: check for spelling errors or missing imports.
Hint: Adapt is loaded but not imported in the active module Main.
Stacktrace:
  [1] include(mapexpr::Function, mod::Module, _path::String)
    @ Base ./Base.jl:307
  [2] top-level scope
    @ /usr/local/share/julia/packages/ClimaInterpolations/3axGJ/ext/ClimaInterpolationsCUDAExt.jl:31
  [3] include(mod::Module, _path::String)
    @ Base ./Base.jl:306
  [4] include_package_for_output(pkg::Base.PkgId, input::String, depot_path::Vector{String}, dl_load_path::Vector{String}, load_path::Vector{String}, concrete_deps::Vector{Pair{Base.PkgId, UInt128}}, source::Nothing)
    @ Base ./loading.jl:3028
  [5] top-level scope
    @ stdin:5
  [6] eval(m::Module, e::Any)
    @ Core ./boot.jl:489
  [7] include_string(mapexpr::typeof(identity), mod::Module, code::String, filename::String)
    @ Base ./loading.jl:2874
  [8] include_string
    @ ./loading.jl:2884 [inlined]
  [9] exec_options(opts::Base.JLOptions)
    @ Base ./client.jl:315
 [10] _start()
    @ Base ./client.jl:550
in expression starting at /usr/local/share/julia/packages/ClimaInterpolations/3axGJ/ext/cuda/interpolation1d.jl:82
in expression starting at /usr/local/share/julia/packages/ClimaInterpolations/3axGJ/ext/cuda/interpolation1d.jl:82
in expression starting at /usr/local/share/julia/packages/ClimaInterpolations/3axGJ/ext/ClimaInterpolationsCUDAExt.jl:1
in expression starting at stdin:5
              ✗ ClimaInterpolations → ClimaInterpolationsCUDAExt
  0 dependencies successfully precompiled in 10 seconds. 104 already precompiled.
```
which isn't exactly very user-friendly.  This happens because [`ClimaInterpolations.jl@v0.1.2`](https://github.com/CliMA/ClimaInterpolations.jl/releases/tag/v0.1.2) [broke the CUDA extension](https://github.com/CliMA/ClimaInterpolations.jl/issues/31).  Good news is that we don't need that package, that's only brought in by `AtmosphericProfilesLibrary`, which until v0.1.8 didn't even require `ClimaInterpolations` at all, so as a temporary solution until https://github.com/CliMA/ClimaInterpolations.jl/issues/31 is resolved we cap `AtmosphericProfilesLibrary` to a version which doesn't require  `ClimaInterpolations`.