### PR TITLE
Revert "[docs] Cap compat with AtmosphericProfilesLibrary"

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -25,7 +25,7 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Breeze = {path = ".."}
 
 [compat]
-AtmosphericProfilesLibrary = "0.1.7 - 0.1.8"
+AtmosphericProfilesLibrary = "0.1.7"
 CUDA = "5, 6.0"
 CairoMakie = "0.15"
 CloudMicrophysics = "0.38, 0.39"


### PR DESCRIPTION
Previous bug in ClimaInterpolations.jl should have been fixed by https://github.com/CliMA/ClimaInterpolations.jl/pull/32.

Reverts NumericalEarth/Breeze.jl#972.