### PR TITLE
Implement checkpointing for `AtmosphereModel`

### DIFF
--- a/src/AnelasticEquations/anelastic_pressure_solver.jl
+++ b/src/AnelasticEquations/anelastic_pressure_solver.jl
@@ -83,7 +83,7 @@ end
 
 function solve_for_anelastic_pressure!(pₙ, solver, ρŨ, Δt)
     compute_anelastic_source_term!(solver, ρŨ, Δt)
-    fill!(solver.storage, 0)
+    fill!(solver.storage, 0)  # workaround for bitwise reproducibility — see Oceananigans #5960
     solve!(pₙ, solver)
     return pₙ
 end

--- a/src/AnelasticEquations/anelastic_pressure_solver.jl
+++ b/src/AnelasticEquations/anelastic_pressure_solver.jl
@@ -83,6 +83,7 @@ end
 
 function solve_for_anelastic_pressure!(pₙ, solver, ρŨ, Δt)
     compute_anelastic_source_term!(solver, ρŨ, Δt)
+    fill!(solver.storage, 0)
     solve!(pₙ, solver)
     return pₙ
 end

--- a/src/AtmosphereModels/AtmosphereModels.jl
+++ b/src/AtmosphereModels/AtmosphereModels.jl
@@ -163,6 +163,7 @@ include("density_weighted_implicit_diffusion.jl")
 include("cell_advection_timescale.jl")
 include("negative_moisture_correction.jl")
 include("update_atmosphere_model_state.jl")
+include("checkpointing.jl")
 include("compute_hydrostatic_pressure.jl")
 
 #####

--- a/src/AtmosphereModels/checkpointing.jl
+++ b/src/AtmosphereModels/checkpointing.jl
@@ -1,0 +1,20 @@
+using Oceananigans: Oceananigans, prognostic_fields, prognostic_state, restore_prognostic_state!
+
+function Oceananigans.prognostic_state(model::AtmosphereModel)
+    return (clock          = prognostic_state(model.clock),
+            particles      = prognostic_state(model.particles),
+            fields         = prognostic_state(prognostic_fields(model)),
+            closure_fields = prognostic_state(model.closure_fields),
+            timestepper    = prognostic_state(model.timestepper))
+end
+
+function Oceananigans.restore_prognostic_state!(restored::AtmosphereModel, from)
+    restore_prognostic_state!(restored.clock, from.clock)
+    restore_prognostic_state!(restored.particles, from.particles)
+    restore_prognostic_state!(prognostic_fields(restored), from.fields)
+    restore_prognostic_state!(restored.closure_fields, from.closure_fields)
+    restore_prognostic_state!(restored.timestepper, from.timestepper)
+    return restored
+end
+
+Oceananigans.restore_prognostic_state!(::AtmosphereModel, ::Nothing) = nothing

--- a/src/CompressibleEquations/acoustic_substepping.jl
+++ b/src/CompressibleEquations/acoustic_substepping.jl
@@ -1616,3 +1616,16 @@ function acoustic_rk3_substep_loop!(model::AtmosphereModel, substepper, Δt, β_
 
     return nothing
 end
+
+Oceananigans.prognostic_state(substepper::AcousticSubstepper) =
+    (time_averaged_velocities = Oceananigans.prognostic_state(substepper.time_averaged_velocities),
+     time_averaged_vertical_velocity_cache = Oceananigans.prognostic_state(substepper.time_averaged_vertical_velocity_cache))
+
+function Oceananigans.restore_prognostic_state!(restored::AcousticSubstepper, from)
+    Oceananigans.restore_prognostic_state!(restored.time_averaged_velocities, from.time_averaged_velocities)
+    Oceananigans.restore_prognostic_state!(restored.time_averaged_vertical_velocity_cache,
+                                           from.time_averaged_vertical_velocity_cache)
+    return restored
+end
+
+Oceananigans.restore_prognostic_state!(substepper::AcousticSubstepper, ::Nothing) = substepper

--- a/src/TimeSteppers/acoustic_runge_kutta_3.jl
+++ b/src/TimeSteppers/acoustic_runge_kutta_3.jl
@@ -361,3 +361,13 @@ function AtmosphereModels.transport_velocities(model::AtmosphereModel{<:TerrainC
             v = sub.time_averaged_velocities.v,
             w = sub.time_averaged_velocities.w)
 end
+
+Oceananigans.prognostic_state(timestepper::AcousticRungeKutta3) =
+    (substepper = Oceananigans.prognostic_state(timestepper.substepper),)
+
+function Oceananigans.restore_prognostic_state!(restored::AcousticRungeKutta3, from)
+    Oceananigans.restore_prognostic_state!(restored.substepper, from.substepper)
+    return restored
+end
+
+Oceananigans.restore_prognostic_state!(timestepper::AcousticRungeKutta3, ::Nothing) = timestepper

--- a/src/TimeSteppers/ssp_runge_kutta_3.jl
+++ b/src/TimeSteppers/ssp_runge_kutta_3.jl
@@ -281,3 +281,6 @@ function OceananigansTimeSteppers.time_step!(model::AtmosphereModel{<:Any, <:Any
 
     return nothing
 end
+
+Oceananigans.prognostic_state(::SSPRungeKutta3) = nothing
+Oceananigans.restore_prognostic_state!(timestepper::SSPRungeKutta3, ::Nothing) = timestepper

--- a/src/TurbulenceClosures/tke_based_turbulence_closure.jl
+++ b/src/TurbulenceClosures/tke_based_turbulence_closure.jl
@@ -538,3 +538,6 @@ function Base.show(io::IO, closure::TKEBasedTurbulenceClosure)
               "├── minimum_tke: ", prettysummary(closure.minimum_tke), '\n',
               "└── negative_tke_damping_time_scale: ", prettysummary(closure.negative_tke_damping_time_scale))
 end
+
+Oceananigans.prognostic_state(::TKEClosureFields) = nothing
+Oceananigans.restore_prognostic_state!(closure_fields::TKEClosureFields, ::Nothing) = closure_fields

--- a/src/TurbulenceClosures/tke_based_turbulence_closure.jl
+++ b/src/TurbulenceClosures/tke_based_turbulence_closure.jl
@@ -539,5 +539,7 @@ function Base.show(io::IO, closure::TKEBasedTurbulenceClosure)
               "└── negative_tke_damping_time_scale: ", prettysummary(closure.negative_tke_damping_time_scale))
 end
 
+# Kᵘ, Kᶜ, Kᵉ and Lᵉ are recomputed exactly by update_state! from the prognostic state alone
+# but this may change in the future if the closure becomes dependent on the previous state.
 Oceananigans.prognostic_state(::TKEClosureFields) = nothing
 Oceananigans.restore_prognostic_state!(closure_fields::TKEClosureFields, ::Nothing) = closure_fields

--- a/test/checkpointing.jl
+++ b/test/checkpointing.jl
@@ -1,0 +1,128 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
+using Breeze
+using CloudMicrophysics
+using Oceananigans
+using Test
+
+BreezeCloudMicrophysicsExt = Base.get_extension(Breeze, :BreezeCloudMicrophysicsExt)
+using .BreezeCloudMicrophysicsExt: OneMomentCloudMicrophysics, TwoMomentCloudMicrophysics
+
+const NSPIN = 6
+const NRESTART = 4
+const Δt = 0.4
+
+function test_grid(FT)
+    Oceananigans.defaults.FloatType = FT
+    return RectilinearGrid(default_arch; size=(8, 8, 8), halo=(5, 5, 5),
+                           x=(0, 1_000), y=(0, 1_000), z=(0, 1_000),
+                           topology=(Periodic, Periodic, Bounded))
+end
+
+θᵢ(x, y, z) = 300 + 2 * sin(2π * x / 1_000) * cos(2π * y / 1_000) * exp(-z / 500)
+uᵢ(x, y, z) = 0.5 * cos(2π * x / 1_000) * sin(2π * z / 1_000)
+
+function anelastic_model(FT; microphysics=nothing, closure=nothing)
+    grid = test_grid(FT)
+    constants = ThermodynamicConstants()
+    reference_state = ReferenceState(grid, constants, surface_pressure=101325, potential_temperature=300)
+    dynamics = AnelasticDynamics(reference_state)
+    model = AtmosphereModel(grid; thermodynamic_constants=constants, dynamics, microphysics, closure)
+    set!(model; θ=θᵢ, qᵗ=0.015, u=uᵢ)
+    return model
+end
+
+function compressible_model(FT; time_discretization=ExplicitTimeStepping(), microphysics=nothing, closure=nothing)
+    grid = test_grid(FT)
+    dynamics = CompressibleDynamics(time_discretization; reference_potential_temperature=300)
+    model = AtmosphereModel(grid; dynamics, microphysics, closure)
+    set!(model; ρ=model.dynamics.reference_state.density, θ=θᵢ, qᵗ=0.015, u=uᵢ)
+    return model
+end
+
+snapshot(model) = Dict(string(name) => Array(interior(field))
+                       for (name, field) in pairs(Oceananigans.prognostic_fields(model)))
+
+function run_continuously(build)
+    model = build()
+    simulation = Simulation(model; Δt, stop_iteration=NSPIN + NRESTART, verbose=false)
+    run!(simulation)
+    return snapshot(model)
+end
+
+function run_with_restart(build, dir)
+    model = build()
+    simulation = Simulation(model; Δt, stop_iteration=NSPIN, verbose=false)
+    simulation.output_writers[:checkpointer] = Checkpointer(model; schedule=IterationInterval(NSPIN), dir)
+    run!(simulation)
+
+    checkpoint = joinpath(dir, "checkpoint_iteration$(NSPIN).jld2")
+    @test isfile(checkpoint)
+
+    model = build()
+    simulation = Simulation(model; Δt, stop_iteration=NSPIN + NRESTART, verbose=false)
+    run!(simulation, pickup=checkpoint)
+    return snapshot(model)
+end
+
+function test_bitwise_restart(build)
+    continuous = run_continuously(build)
+    restarted = mktempdir(dir -> run_with_restart(build, dir))
+
+    @test issetequal(keys(continuous), keys(restarted))
+    for name in sort(collect(keys(continuous)))
+        @testset let field = name
+            @test maximum(abs, continuous[name] - restarted[name]) == 0
+        end
+    end
+end
+
+@testset "Checkpoint restart [$FT]" for FT in test_float_types()
+    @testset "Anelastic dynamics" begin
+        @testset "no microphysics, no closure" begin
+            test_bitwise_restart(() -> anelastic_model(FT))
+        end
+
+        @testset "equilibrium microphysics" begin
+            test_bitwise_restart(() -> anelastic_model(FT; microphysics=SaturationAdjustment()))
+        end
+
+        @testset "equilibrium microphysics with precipitation" begin
+            test_bitwise_restart(() -> anelastic_model(FT; microphysics=InstantaneousPrecipitation()))
+        end
+
+        @testset "non-equilibrium microphysics, two species" begin
+            test_bitwise_restart(() -> anelastic_model(FT; microphysics=OneMomentCloudMicrophysics()))
+        end
+
+        @testset "non-equilibrium microphysics, five species" begin
+            test_bitwise_restart(() -> anelastic_model(FT; microphysics=TwoMomentCloudMicrophysics()))
+        end
+
+        @testset "Smagorinsky closure" begin
+            test_bitwise_restart(() -> anelastic_model(FT; closure=SmagorinskyLilly()))
+        end
+
+        @testset "prognostic TKE closure" begin
+            test_bitwise_restart(() -> anelastic_model(FT; closure=TKEBasedTurbulenceClosure()))
+        end
+    end
+
+    @testset "Compressible dynamics" begin
+        @testset "explicit, no microphysics, no closure" begin
+            test_bitwise_restart(() -> compressible_model(FT))
+        end
+
+        @testset "split-explicit, no microphysics, no closure" begin
+            test_bitwise_restart(() -> compressible_model(FT; time_discretization=SplitExplicitTimeDiscretization()))
+        end
+
+        @testset "non-equilibrium microphysics, two species" begin
+            test_bitwise_restart(() -> compressible_model(FT; microphysics=OneMomentCloudMicrophysics()))
+        end
+
+        @testset "prognostic TKE closure" begin
+            test_bitwise_restart(() -> compressible_model(FT; closure=TKEBasedTurbulenceClosure()))
+        end
+    end
+end


### PR DESCRIPTION
Closes #443. Supersedes #529.

`AtmosphereModel` now implements Oceananigans' `prognostic_state` /
`restore_prognostic_state!` protocol, so the stock `Checkpointer` and
`run!(simulation; pickup=...)` work with no Breeze-specific machinery. Neither
method existed before, so `Checkpointer` fell through Oceananigans' untyped
fallback and pickup threw.

Restarts are bitwise, on CPU and on GPU. Getting there also required pinning the
null-space component of the anelastic pressure solve, whose underlying cause is
upstream and is reported in CliMA/Oceananigans.jl#5960. That one line is a
workaround, not a requirement: with it reverted and the fix proposed in #5960
applied, the tests below still pass on CPU and on a T4, so it can be dropped
once upstream lands.

`test/checkpointing.jl` requires exact equality between a continuous run and a
checkpoint/restart run, across both dynamics (compressible in explicit and
split-explicit form), equilibrium and non-equilibrium microphysics at two and
five prognostic species, and the closure-free, diagnostic-closure and
prognostic-closure cases. The checkpointed field set changes with each of those
knobs. 92 assertions, all exact rather than approximate — an approximate
comparison passes on a contaminated restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
