### PR TITLE
Evaluate the SSP RK3 third-stage tendency at tⁿ + Δt/2

### DIFF
--- a/src/ParcelModels/parcel_dynamics.jl
+++ b/src/ParcelModels/parcel_dynamics.jl
@@ -5,7 +5,7 @@ using Oceananigans.Architectures: on_architecture
 using Oceananigans.BoundaryConditions: fill_halo_regions!
 using Oceananigans.Fields: ZeroField, set!, interpolate
 using Oceananigans.TimeSteppers: TimeSteppers, tick_stage!
-using Oceananigans.Utils: launch!
+using Oceananigans.Utils: launch!, time_difference_seconds
 
 using KernelAbstractions: @kernel, @index
 
@@ -1074,23 +1074,32 @@ function TimeSteppers.time_step!(model::AtmosphereModel{<:ParcelDynamics, <:Any,
     state = dynamics.state
     U⁰ = ts.U⁰
 
+    # Stage abscissae, as in the field-model stepper: cₘ = αₘ (cₘ₋₁ + 1) with c₀ = 0, so
+    # u^(1) sits at tⁿ + Δt and u^(2) at tⁿ + Δt/2.
+    c¹ = ts.α¹              # = 1
+    c² = ts.α² * (c¹ + 1)   # = 1/2
+
+    # Compute the next time step a priori to reduce floating point error accumulation
+    tⁿ⁺¹ = model.clock.time + Δt
+
     # Store initial state for SSP RK3 stages
     store_initial_parcel_state!(U⁰, state)
 
     # Stage 1: u^(1) = u^(0) + Δt * G(u^(0))
     ssp_rk3_parcel_substep!(model, U⁰, Δt, ts.α¹)
-    tick_stage!(model.clock, Δt)
+    tick_stage!(model.clock, c¹ * Δt)
 
     # Stage 2: u^(2) = 3/4 u^(0) + 1/4 (u^(1) + Δt * G(u^(1)))
     ssp_rk3_parcel_substep!(model, U⁰, Δt, ts.α²)
-    # Don't tick - still at t + Δt for time-dependent forcing
+
+    # Back to tⁿ + Δt/2, the abscissa of u^(2); `corrected_Δt` below restores the Δt/2.
+    tick_stage!(model.clock, (c² - c¹) * Δt)
 
     # Stage 3: u^(3) = 1/3 u^(0) + 2/3 (u^(2) + Δt * G(u^(2)))
     ssp_rk3_parcel_substep!(model, U⁰, Δt, ts.α³)
 
     # Final clock update (adjust for floating point error)
-    tⁿ⁺¹ = model.clock.time + Δt * (1 - ts.α¹)  # Already advanced by α¹ * Δt in stage 1
-    corrected_Δt = tⁿ⁺¹ - model.clock.time
+    corrected_Δt = time_difference_seconds(tⁿ⁺¹, model.clock.time)
     tick_stage!(model.clock, corrected_Δt, Δt)
 
     # Apply microphysics model update AFTER all RK3 stages and clock update

--- a/src/TimeSteppers/ssp_runge_kutta_3.jl
+++ b/src/TimeSteppers/ssp_runge_kutta_3.jl
@@ -201,6 +201,10 @@ u^{(3)} &= \\frac{1}{3} u^{(0)} + \\frac{2}{3} u^{(2)} + \\frac{2}{3} Δt \\, G(
 ```
 
 where ``G`` above is the right-hand-side, e.g., ``∂u/∂t = G(u)``.
+
+The tendencies are evaluated at the Butcher abscissae ``c = (0, 1, 1/2)``: ``u^{(2)}``
+approximates the solution at the *midpoint* of the step, so the clock steps back by ``Δt/2``
+after the second stage. This keeps third-order accuracy for a time-dependent right-hand side.
 """
 function OceananigansTimeSteppers.time_step!(model::AtmosphereModel{<:Any, <:Any, <:Any, <:SSPRungeKutta3}, Δt; callbacks=[])
 
@@ -211,6 +215,14 @@ function OceananigansTimeSteppers.time_step!(model::AtmosphereModel{<:Any, <:Any
     α¹ = ts.α¹
     α² = ts.α²
     α³ = ts.α³
+
+    # Stage abscissae: a Shu-Osher stage u^(m) = (1 - α) u^(0) + α (u^(m-1) + Δt G) has
+    # Butcher row sum cₘ = αₘ (cₘ₋₁ + 1), so u^(1) sits at tⁿ + Δt but u^(2) sits at
+    # tⁿ + Δt/2. Evaluating G(u^(2)) at tⁿ + Δt instead breaks the order conditions
+    # (Σbᵢcᵢ = 5/6 ≠ 1/2) and leaves `clock.stage` stuck at 2, so per-stage work keyed on
+    # `(iteration, stage)`, such as the filtered surface state, skips the third stage.
+    c¹ = α¹              # = 1
+    c² = α² * (c¹ + 1)   # = 1/2
 
     # Compute the next time step a priori to reduce floating point error accumulation
     tⁿ⁺¹ = model.clock.time + Δt
@@ -229,7 +241,7 @@ function OceananigansTimeSteppers.time_step!(model::AtmosphereModel{<:Any, <:Any
     compute_pressure_correction!(model, Δt)
     make_pressure_correction!(model, Δt)
 
-    tick_stage!(model.clock, Δt)
+    tick_stage!(model.clock, c¹ * Δt)
     update_state!(model, callbacks; compute_tendencies = true)
 
     #
@@ -243,7 +255,8 @@ function OceananigansTimeSteppers.time_step!(model::AtmosphereModel{<:Any, <:Any
     compute_pressure_correction!(model, α² * Δt)
     make_pressure_correction!(model, α² * Δt)
 
-    # Don't tick - still at t + Δt for time-dependent forcing
+    # Back to tⁿ + Δt/2, the abscissa of u^(2); `corrected_Δt` below restores the Δt/2.
+    tick_stage!(model.clock, (c² - c¹) * Δt)
     update_state!(model, callbacks; compute_tendencies = true)
 
     #

--- a/test/runge_kutta_stage_times.jl
+++ b/test/runge_kutta_stage_times.jl
@@ -72,7 +72,9 @@ end
 end
 
 @testset "Parcel SSP RK3 clock bookkeeping" begin
-    grid = RectilinearGrid(default_arch; size=10, z=(0, 1000), topology=(Flat, Flat, Bounded))
+    # The parcel stepper interpolates the environment at the parcel position on the host,
+    # so it runs on the CPU like the other parcel tests.
+    grid = RectilinearGrid(CPU(); size=10, z=(0, 1000), topology=(Flat, Flat, Bounded))
     model = AtmosphereModel(grid; dynamics=ParcelDynamics())
 
     T(z) = 288.0 - 0.0065 * z

--- a/test/runge_kutta_stage_times.jl
+++ b/test/runge_kutta_stage_times.jl
@@ -1,0 +1,91 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
+using Breeze
+using Breeze.AtmosphereModels: dynamics_density
+using Breeze.ParcelModels: ParcelDynamics
+using Oceananigans
+using Oceananigans: UpdateStateCallsite
+using Oceananigans.Fields: interior
+using Oceananigans.TimeSteppers: time_step!
+using Test
+
+#####
+##### Stage abscissae of the SSP RK3 stepper
+#####
+##### Shu-Osher has Butcher abscissae c = (0, 1, 1/2): u^(2) approximates the solution at
+##### tⁿ + Δt/2, so the third stage's tendency belongs at the midpoint. At tⁿ + Δt instead the
+##### order conditions fail (Σbᵢcᵢ = 5/6 ≠ 1/2) and the scheme drops to first order for a
+##### right-hand side that depends explicitly on time.
+#####
+
+"""
+Step a model whose only active tendency is a forcing `F(t)` on a spatially uniform tracer,
+and return the resulting tracer concentration.
+
+Every spatial operator vanishes for a uniform tracer, so `∂ₜ(ρ c) = ρ F(t)` exactly and one
+step returns the Runge-Kutta quadrature of `F` over `[0, Δt]`, abscissae included.
+"""
+function stepped_tracer_quadrature(grid, F, Δt)
+    model = AtmosphereModel(grid; tracers = (:c,), forcing = (; c = F))
+    ρ = Array(interior(dynamics_density(model.dynamics)))
+    time_step!(model, Δt)
+    ρc = Array(interior(model.tracers.c))
+    return ρc[1, 1, 1] / ρ[1, 1, 1]
+end
+
+@testset "SSP RK3 stage abscissae [$(FT)]" for FT in test_float_types()
+    Oceananigans.defaults.FloatType = FT
+    grid = RectilinearGrid(default_arch; size=(2, 2, 2), x=(0, 1), y=(0, 1), z=(0, 1))
+    Δt = FT(1//2)
+    rtol = FT === Float64 ? 1e-12 : 1e-5
+
+    # b = (1/6, 1/6, 2/3) at c = (0, 1, 1/2) is Simpson's rule, exact for cubics. At c₃ = 1
+    # the same weights integrate F = t to 5Δt²/6 instead of Δt²/2.
+    @testset "quadrature of a time-only forcing" begin
+        for (F, exact) in (((x, y, z, t) -> t,   Δt^2 / 2),
+                           ((x, y, z, t) -> t^2, Δt^3 / 3),
+                           ((x, y, z, t) -> t^3, Δt^4 / 4))
+            @test isapprox(stepped_tracer_quadrature(grid, F, Δt), exact; rtol)
+        end
+    end
+
+    # Each `update_state!` builds the tendency its stage consumes, so the clock it sees is
+    # that stage's abscissa. The trace also pins `clock.stage`, the key per-stage work such
+    # as the filtered surface state deduplicates on: it must reach 3.
+    @testset "clock time and stage at each tendency evaluation" begin
+        model = AtmosphereModel(grid)
+        trace = Tuple{Float64, Int}[]
+        record_clock(m) = (push!(trace, (m.clock.time, m.clock.stage)); nothing)
+
+        simulation = Simulation(model; Δt, stop_iteration=1, verbose=false)
+        add_callback!(simulation, record_clock, IterationInterval(1); callsite = UpdateStateCallsite())
+        run!(simulation)
+
+        # (tⁿ, stage 1) from the pre-step preparation, the two interior abscissae, then
+        # (tⁿ⁺¹, stage 1) for the next step's first stage.
+        half_Δt = Float64(Δt) / 2
+        @test trace == [(0.0, 1), (Float64(Δt), 2), (half_Δt, 3), (Float64(Δt), 1)]
+        @test model.clock.time == Δt
+        @test model.clock.iteration == 1
+        @test model.clock.stage == 1
+    end
+end
+
+@testset "Parcel SSP RK3 clock bookkeeping" begin
+    grid = RectilinearGrid(default_arch; size=10, z=(0, 1000), topology=(Flat, Flat, Bounded))
+    model = AtmosphereModel(grid; dynamics=ParcelDynamics())
+
+    T(z) = 288.0 - 0.0065 * z
+    p(z) = 101325.0 * exp(-z / 8500)
+    ρ(z) = p(z) / (287.0 * T(z))
+    set!(model, T=T, p=p, ρ=ρ, z=0.0, w=1.0)
+
+    # The parcel stepper ticks to the same abscissae and closes each step on tⁿ⁺¹ exactly.
+    Δt = 0.5
+    for iteration in 1:4
+        time_step!(model, Δt)
+        @test model.clock.time == iteration * Δt
+        @test model.clock.iteration == iteration
+        @test model.clock.stage == 1
+    end
+end


### PR DESCRIPTION
The SSP RK3 stepper evaluated its third-stage tendency at the wrong time.

## The bug

Written in Butcher form, Shu-Osher SSP RK3 is

```
u⁽¹⁾ = u⁰ + Δt k₁,                          k₁ = G(tⁿ, u⁰)
u⁽²⁾ = u⁰ + ¼Δt k₁ + ¼Δt k₂,                k₂ = G(tⁿ + Δt, u⁽¹⁾)
uⁿ⁺¹ = u⁰ + Δt(⅙k₁ + ⅙k₂ + ⅔k₃),            k₃ = G(tⁿ + ½Δt, u⁽²⁾)
```

with abscissae `c = (0, 1, 1/2)` and weights `b = (1/6, 1/6, 2/3)`. The row sum
`c₃ = a₃₁ + a₃₂ = 1/2` says `u⁽²⁾` approximates the solution at the *midpoint* of
the step, not at its end.

The stepper ticked the clock to `tⁿ + Δt` after the first stage and then deliberately
left it there:

```julia
# Don't tick - still at t + Δt for time-dependent forcing
update_state!(model, callbacks; compute_tendencies = true)
```

so `G(u⁽²⁾)` was built with `clock.time == tⁿ + Δt`, i.e. at `c₃ = 1`. The same
pattern was in `ParcelModels`. The Wicker-Skamarock stepper in
`acoustic_runge_kutta_3.jl` was already correct, ticking to `Δt/3` and then `Δt/2`.

## Why it matters

Two independent consequences.

**Order reduction.** `c₃ = 1` breaks the second- *and* third-order conditions
(`Σbᵢcᵢ = 5/6 ≠ 1/2`, `Σbᵢcᵢ² = 5/6 ≠ 1/3`), costing two orders. An autonomous
right-hand side is unaffected — advection, pressure gradient, Coriolis, buoyancy and
diffusion never read the clock, so the tendency is bit-identical either way. Anything
that *does* read it loses accuracy: `Forcing` functions, time-dependent boundary
conditions, and `FieldTimeSeries` interpolation. The error is not confined to the
forced variable; it enters the momentum and scalar tendencies and spreads to every
prognostic field through the coupling, so all fields drop to first order. The leading
term is `Δt² ∂ₜG / 3` per step, so the relevant ratio is `Δt/τ_forcing`: small for a
slowly varying forcing, real when the forcing timescale approaches the step.

**`clock.stage` never reached 3.** `tick_stage!` also increments the stage counter, so
the stage sequence was 1, 2, 2 instead of 1, 2, 3. Per-stage work deduplicated on
`(iteration, stage)` — the filtered surface state behind the bulk-flux boundary
conditions (`filtered_surface_state.jl:345,355`, `update_boundary_conditions.jl:67`) —
saw a repeated key and returned early, so the third stage computed its surface fluxes
from the second stage's filtered state. This one needs no explicit time dependence
anywhere to bite.

## The fix

Derive the abscissae from the Shu-Osher coefficients (`cₘ = αₘ(cₘ₋₁ + 1)`, giving
`c = (0, 1, 1/2)`) and tick the clock to each one, as the acoustic stepper does. The
second-stage tick is `(c² - c¹)Δt = -Δt/2`; the existing end-of-step
`corrected_Δt = time_difference_seconds(tⁿ⁺¹, clock.time)` then supplies the remaining
`+Δt/2`, so the step still closes on `tⁿ⁺¹` exactly.

`ParcelModels` gets the same treatment. Its final tick was
`tⁿ⁺¹ = clock.time + Δt(1 - α¹)` with `α¹ = 1`, a no-op that only worked because the
clock happened to already sit at `tⁿ + Δt`; it now snapshots `tⁿ⁺¹` before the first
tick and closes on it via `time_difference_seconds`, like the field stepper. Parcel
tendencies never read the clock, so that change is bookkeeping only.

## Tests

New `test/runge_kutta_stage_times.jl`.

The main check exploits the fact that every spatial operator vanishes for a spatially
uniform tracer — flux-form advection collapses to `c ∇·(ρu)`, which anelastic
continuity kills, and diffusion sees no gradient — so a uniform tracer under a
time-only forcing obeys `∂ₜ(ρc) = ρF(t)` exactly and one step returns the scheme's
quadrature of `F` over `[0, Δt]`, abscissae included. With `b = (1/6, 1/6, 2/3)` at
`c = (0, 1, 1/2)` that combination is Simpson's rule, exact for cubics, so `F = t`,
`t²` and `t³` must integrate exactly. A second testset records `(clock.time,
clock.stage)` at each `UpdateStateCallsite` firing, pinning both the abscissae and the
stage counter.

Both discriminate sharply. Stashing the fix and rerunning:

| | before | after | exact |
|---|---|---|---|
| `(time, stage)` trace | `(0,1) (½,2) (½,2) (½,1)` | `(0,1) (½,2) (¼,3) (½,1)` | |
| `∫F` for `F = t` | `5Δt²/6` | `Δt²/2` | `Δt²/2` |
| `∫F` for `F = t²` | `5Δt³/6` | `Δt³/3` | `Δt³/3` |

The pre-fix values are exactly the `5/6` factor predicted by `Σbᵢcᵢ = 5/6` at `c₃ = 1`.

## Notes

- **Behavior change beyond the abscissa.** With `clock.stage` now reaching 3, per-stage
  work keyed on `(iteration, stage)` runs three times per step instead of two, so the
  filtered surface state advances its exponential filter once per stage. That is what
  the code intends — `test/polynomial_bulk_coefficients.jl:953` already assumes "3 RK3
  stages (each with ε)" in its own comment. `filter_timescale` defaults to `Inf` (a
  no-op), so only configurations that opt into finite filtering are affected, and their
  effective filter timescale shifts from `τ/2` to `τ/3`.
- Separately, that filter applies `clock.last_Δt` (the *full* step) on each of its
  per-stage applications, which over-relaxes relative to the "updated each time step"
  claim in its docstring. Pre-existing, and present for the acoustic stepper too; left
  alone here, worth its own issue.
- CPU-verified: `runge_kutta_stage_times`, `parcel_dynamics`,
  `polynomial_bulk_coefficients`, `wall_fluxes`, `forcing_and_boundary_conditions`,
  `specific_forcing`, `atmosphere_model_callbacks`, `dynamics` and `quality_assurance`
  pass, 690 tests. No GPU available on the development machine, so the CUDA paths rely
  on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
