### PR TITLE
Correct the dimensions of the documented P3 effective radius

### DIFF
--- a/src/Microphysics/PredictedParticleProperties/ice_properties.jl
+++ b/src/Microphysics/PredictedParticleProperties/ice_properties.jl
@@ -161,7 +161,7 @@ size distribution. They are used for radiation, radar, and diagnostics.
 
 **Diagnostic integrals:**
 
-- `effective_radius`: Radiation-weighted radius ``r_e = ∫A·N'dD / ∫N'dD``
+- `effective_radius`: Tabulated radiative effective radius [m]
 - `mean_diameter`: Mass-weighted diameter ``D_m = ∫D·m·N'dD / ∫m·N'dD``
 - `mean_density`: Mass-weighted density ``ρ̄ = ∫ρ·m·N'dD / ∫m·N'dD``
 - `reflectivity`: Radar reflectivity ``Z = ∫D^6·N'dD``


### PR DESCRIPTION
The `IceBulkProperties` docstring defined effective radius as `∫A N′ dD / ∫N′ dD`. That expression is mean projected area [m²], not a radius [m].

Describe the field as the tabulated radiative effective radius [m]. This changes documentation only; lookup tables and microphysics calculations are unchanged.

Validation: dimensional review, Julia parsing, and whitespace checks.
