### PR TITLE
Keep species borrowing in partial-density units

### DIFF
--- a/src/AtmosphereModels/negative_moisture_correction.jl
+++ b/src/AtmosphereModels/negative_moisture_correction.jl
@@ -303,11 +303,11 @@ end
 # scans the tail behind it), which is a few tens of flops for the N ≤ 10 schemes we run.
 @inline function same_level_borrow!(i, j, k, ρ, fields::Tuple{F1, Vararg}, ρqᵛᵉ) where {F1}
     ρq = fields[1]
-    @inbounds q = ρq[i, j, k] / ρ
+    @inbounds mass = ρq[i, j, k]
 
-    deficit = max(0, -q)
-    borrowed = same_level_borrow!(i, j, k, ρ, Base.tail(fields), ρqᵛᵉ, deficit)
-    @inbounds ρq[i, j, k] += ρ * borrowed
+    deficit = max(0, -mass)
+    remaining = borrow_from_lighter_species!(i, j, k, Base.tail(fields), ρqᵛᵉ, deficit)
+    @inbounds ρq[i, j, k] = ifelse(mass < 0, -remaining, mass)
 
     same_level_borrow!(i, j, k, ρ, Base.tail(fields), ρqᵛᵉ)
     return nothing
@@ -316,25 +316,23 @@ end
 # Empty tuple: nothing to do
 @inline same_level_borrow!(i, j, k, ρ, ::Tuple{}, ρqᵛᵉ) = nothing
 
-# With a deficit argument, recurse through the candidate donors for one field.
-@inline function same_level_borrow!(i, j, k, ρ, fields::Tuple{F1, Vararg}, ρqᵛᵉ, deficit) where {F1}
+# Recurse through the candidate donors, returning the unfunded partial density.
+@inline function borrow_from_lighter_species!(i, j, k, fields::Tuple{F1, Vararg}, ρqᵛᵉ, deficit) where {F1}
     ρq_donor = fields[1]
-    @inbounds q_donor = ρq_donor[i, j, k] / ρ
+    @inbounds mass_donor = ρq_donor[i, j, k]
 
-    borrowed = min(deficit, max(0, q_donor))
-    @inbounds ρq_donor[i, j, k] -= ρ * borrowed
+    borrowed = min(deficit, max(0, mass_donor))
+    @inbounds ρq_donor[i, j, k] -= borrowed
 
     remaining_deficit = deficit - borrowed
-    borrowed_from_tail = same_level_borrow!(i, j, k, ρ, Base.tail(fields), ρqᵛᵉ, remaining_deficit)
-
-    return borrowed + borrowed_from_tail
+    return borrow_from_lighter_species!(i, j, k, Base.tail(fields), ρqᵛᵉ, remaining_deficit)
 end
 
-@inline function same_level_borrow!(i, j, k, ρ, ::Tuple{}, ρqᵛᵉ, deficit)
-    @inbounds qᵛ = ρqᵛᵉ[i, j, k] / ρ
-    borrowed = min(deficit, max(0, qᵛ))
-    @inbounds ρqᵛᵉ[i, j, k] -= ρ * borrowed
-    return borrowed
+@inline function borrow_from_lighter_species!(i, j, k, ::Tuple{}, ρqᵛᵉ, deficit)
+    @inbounds vapor_mass = ρqᵛᵉ[i, j, k]
+    borrowed = min(deficit, max(0, vapor_mass))
+    @inbounds ρqᵛᵉ[i, j, k] -= borrowed
+    return deficit - borrowed
 end
 
 #####

--- a/test/species_borrowing_units.jl
+++ b/test/species_borrowing_units.jl
@@ -1,0 +1,67 @@
+include(joinpath(@__DIR__, "setup.jl"))
+
+using Test, Breeze, Oceananigans
+using Oceananigans.Fields: interior
+using Oceananigans.Utils: launch!
+using KernelAbstractions: @kernel, @index
+
+@kernel function _test_species_borrowing!(fields, density)
+    i, j, k = @index(Global, NTuple)
+    Breeze.AtmosphereModels.same_level_borrow!(i, j, k, density,
+                                              fields[1:4], fields[5])
+end
+
+function borrowing_oracle(values)
+    mass = collect(BigFloat.(values))
+    for recipient in 1:length(mass)-1
+        for donor in recipient+1:length(mass)
+            transfer = min(max(0, -mass[recipient]), max(0, mass[donor]))
+            mass[recipient] += transfer
+            mass[donor] -= transfer
+        end
+    end
+    return mass
+end
+
+@testset "Species borrowing in partial-density units" begin
+    for FT in (Float32, Float64)
+        grid = RectilinearGrid(default_arch, FT; size=(2,2,2), extent=(1,1,1))
+        fields = ntuple(_ -> CenterField(grid), 5)
+        # Ordered reservoirs: coating, ice, rain, cloud, vapor [kg/m³]. Include
+        # fully funded roundoff witnesses, multiple donors, insufficient water,
+        # and a backward donor that the configured policy must leave untouched.
+        cases = ((-1.7428903875682522e-9,0,0,0,0.005),
+                 (-6.488883055408995e-24,0,0,0,0.005),
+                 (-0.004,0.001,0.002,0,0.005),
+                 (-0.009,0.001,0,0,0.002),
+                 (0,0,-0.002,0,0.003),
+                 (0,0.001,-0.002,0,0),
+                 (0.0001,0.0002,0.0003,0.0004,0.005),
+                 (0,0.001,0,0,-0.002))
+        for initial in cases
+            values = FT.(initial)
+            expected = borrowing_oracle(values)
+            scale = sum(abs, BigFloat.(values))
+            reference = nothing
+            for density in FT.((0.44961270689964294,0.949273943901062,
+                                1.127671480178833,1e-4,1e4))
+                foreach((field, value) -> set!(field, value), fields, values)
+                launch!(default_arch, grid, :xyz, _test_species_borrowing!, fields, density)
+                actual = map(field -> Array(interior(field))[1], fields)
+                @test all(isfinite, actual)
+                @test abs(sum(BigFloat.(actual)) - sum(BigFloat.(values))) <= 16eps(FT)*scale
+                for n in eachindex(actual)
+                    @test abs(BigFloat(actual[n]) - expected[n]) <= 16eps(FT)*scale
+                    # A fully covered deficit must be exactly zero. A tolerance
+                    # here would hide the negative residual rejected by RT staging.
+                    iszero(expected[n]) && @test iszero(actual[n])
+                    expected[n] >= 0 && @test actual[n] >= 0
+                end
+                reference === nothing || @test actual == reference
+                reference = actual
+                launch!(default_arch, grid, :xyz, _test_species_borrowing!, fields, density)
+                @test map(field -> Array(interior(field))[1], fields) == actual
+            end
+        end
+    end
+end


### PR DESCRIPTION
A fully funded negative moisture reservoir can remain slightly negative after borrowing because partial densities are divided by air density and multiplied back.

Keep transfers in kg m⁻³: `b = min(D, max(m, 0))`, then `m -= b` and `D -= b`. The last fully covering transfer gives exactly zero remaining deficit. Donor order is unchanged, and unfunded deficits remain negative.

The regression checks the negative-roundoff witnesses, conservation against a BigFloat reference, donor ordering, fixed points, and independence from air-density scaling in Float32/Float64.

Validation: CPU `test/species_borrowing_units.jl` (1334 assertions) passed; all five ExplicitImports checks passed. GPU execution was not tested.
