### PR TITLE
Declare transport bounds in each microphysical quantity’s units

### DIFF
--- a/src/AtmosphereModels/AtmosphereModels.jl
+++ b/src/AtmosphereModels/AtmosphereModels.jl
@@ -88,6 +88,7 @@ export
 
     # Microphysics interface
     prognostic_field_names,
+    microphysical_transport_bounds,
 
     # Diagnostics (re-exported from Diagnostics submodule)
     PotentialTemperature,

--- a/src/AtmosphereModels/microphysics_interface.jl
+++ b/src/AtmosphereModels/microphysics_interface.jl
@@ -883,3 +883,12 @@ based on cloud properties.
 """
 @inline cloud_ice_effective_radius(i, j, k, grid, effective_radius_model::ConstantRadiusParticles, args...) =
     effective_radius_model.radius
+
+"""
+$(TYPEDSIGNATURES)
+
+Return bounds on the specific quantity transported for prognostic `name`, or `nothing`
+for an unbounded quantity. Independent mass fractions default to `(0, 1)`.
+"""
+microphysical_transport_bounds(microphysics, name::Symbol) =
+    ifelse(name in condensate_field_names(microphysics), (0, 1), nothing)

--- a/src/Microphysics/PredictedParticleProperties/p3_microphysical_state.jl
+++ b/src/Microphysics/PredictedParticleProperties/p3_microphysical_state.jl
@@ -955,3 +955,10 @@ end
 @inline p3_tendency_component(result::P3TendencyResult, ::Val{:ρsᵛ⁺ˡ}) = result.tendency_ρsᵛ⁺ˡ
 @inline p3_tendency_component(result::P3TendencyResult, ::Val{:ρqᵛ})  = result.tendency_ρqᵛ
 @inline p3_tendency_component(result::P3TendencyResult, ::Val{:ρnᵃ})  = result.tendency_ρnᵃ
+
+function AM.microphysical_transport_bounds(p3::P3, name::Symbol)
+    name in AM.prognostic_field_names(p3) || throw(ArgumentError("Unknown P3 prognostic $name"))
+    name === :ρsᵛ⁺ˡ && return nothing
+    name in (:ρqᶜˡ, :ρqʳ, :ρqⁱ, :ρqᶠ, :ρqʷⁱ) && return (0, 1)
+    return (0, Inf)
+end

--- a/test/predicted_particle_properties_integration.jl
+++ b/test/predicted_particle_properties_integration.jl
@@ -701,3 +701,15 @@ using Oceananigans.TimeSteppers: update_state!
         @test all(isfinite, Array(interior(model.moisture_density)))
     end
 end
+
+@testset "P3 transport bounds distinguish fractions, number and volume" begin
+    p3 = Breeze.PredictedParticlePropertiesMicrophysics(; predict_supersaturation=true)
+    bounds(name) = Breeze.AtmosphereModels.microphysical_transport_bounds(p3, name)
+    for name in (:ρqᶜˡ, :ρqʳ, :ρqⁱ, :ρqᶠ, :ρqʷⁱ)
+        @test bounds(name) == (0, 1)
+    end
+    for name in (:ρnʳ, :ρnⁱ, :ρbᶠ)
+        @test bounds(name) == (0, Inf)
+    end
+    @test isnothing(bounds(:ρsᵛ⁺ˡ))
+end


### PR DESCRIPTION
Nested transport needs bounds for each specific quantity. A common `[0,1]` interval incorrectly treats P3 number and volume moments as mass fractions.

Add `microphysical_transport_bounds`: mass fractions use `[0,1]`; particle number [kg⁻¹] and rime volume [m³ kg⁻¹] use `[0,∞)`; signed supersaturation is unbounded. Rime mass remains a fraction but is not an independent water reservoir.

This declares the scheme-owned bounds; the companion NumericalEarth PR applies them to nested WENO reconstruction. The regression extends the existing P3 integration test file.

Validation: CPU new transport-bounds testset in `test/predicted_particle_properties_integration.jl` (9 assertions) passed; all five ExplicitImports checks passed. GPU execution was not tested.
