### PR TITLE
Fill the halos the terrain acoustic substep reads horizontally

### DIFF
--- a/src/CompressibleEquations/acoustic_substepping.jl
+++ b/src/CompressibleEquations/acoustic_substepping.jl
@@ -1520,6 +1520,10 @@ function acoustic_rk3_substep_loop!(model::AtmosphereModel, substepper, Δt, β_
         # solve and recovery substitution see a transport-consistent ρθ′★ (issue #897).
         implicit_advection_substep!(model, substepper, advection, Δτ)
 
+        # On terrain `∇ᶻp′`'s slope correction reads ρθ′★ at i±1, j±1, and both writers above
+        # cover interior cells only. Must follow the implicit substep, which rewrites ρθ′★.
+        fill_halo_regions!(substepper.density_potential_temperature_predictor)
+
         launch!(arch, grid, KernelParameters(1:size(grid, 1), 1:size(grid, 2), 1:size(grid, 3) + 1),
                 _build_vertical_rhs!,
                 substepper.vertical_solver_source_term,

--- a/src/CompressibleEquations/terrain_compressible_physics.jl
+++ b/src/CompressibleEquations/terrain_compressible_physics.jl
@@ -502,6 +502,13 @@ function assemble_slow_vertical_momentum_tendency!(substepper::AcousticSubsteppe
         β_stage == 1 ? substepper.final_stage_vertical_pressure_tendency_factor :
         substepper.vertical_pressure_tendency_factor
 
+    # The slope projection below interpolates Gⁿρu, Gⁿρv to (Center, Center, Face), reading
+    # face Nx+1 / Ny+1 — which the tendency kernels, launched over `size(grid)`, never write.
+    # Here rather than at the producer: this is their last writer before the substep loop.
+    # `similar` gives auxiliary BCs, so a Bounded wall face keeps its allocated zero.
+    fill_halo_regions!(Gⁿ.ρu)
+    fill_halo_regions!(Gⁿ.ρv)
+
     launch!(arch, grid, :xyz, _assemble_terrain_slow_vertical_momentum_tendency!,
             substepper.slow_vertical_momentum_tendency,
             Gⁿ.ρu, Gⁿ.ρv, Gⁿ.ρw,

--- a/test/terrain_following_split_explicit.jl
+++ b/test/terrain_following_split_explicit.jl
@@ -584,5 +584,53 @@ const TERRAIN_FORMULATIONS = (LinearDecay(),
         @test isfinite(maximum(abs, model.velocities.v))
     end
 
+    @testset "Terrain acoustic substep fills the horizontally-read halos" begin
+        # Two fields in the terrain acoustic path are written over interior cells and then read
+        # at i±1: the predictor (ρθ)′★ via the `∇ᶻp′` slope correction, and Gⁿρu/Gⁿρv via the
+        # slow-tendency slope projection. Probe: terrain and initial condition invariant under a
+        # shift of Nx/2 cells, so the solution must be too. `mod(x, Lx/2)` on power-of-two
+        # centers makes the shifted arguments bitwise equal, so the invariance is exact.
+        Nx, Nz = 16, 8
+        Lx, Lz = 8192.0, 8192.0
+        half  = Lx / 2
+        shift = Nx ÷ 2
+        θ₀ = 300.0
+
+        z_faces = TerrainFollowingVerticalDiscretization(collect(range(0, Lz, length=Nz+1));
+                                                         formulation = LinearDecay())
+        grid = RectilinearGrid(default_arch; size=(Nx, Nz), halo=(5, 5),
+                               x=(0, Lx), z=z_faces, topology=(Periodic, Flat, Bounded))
+        materialize_terrain!(grid, x -> 300 * sin(2π * mod(x, half) / half))
+
+        dynamics = CompressibleDynamics(SplitExplicitTimeDiscretization(substeps=6);
+                                        reference_potential_temperature = θ₀)
+        model = AtmosphereModel(grid; dynamics)
+
+        # `enforce_mass_conservation` runs a pressure solve that breaks the bitwise invariance.
+        set!(model,
+             ρ = model.dynamics.reference_state.density,
+             θ = (x, z) -> θ₀ + 5 * sin(2π * mod(x, half) / half) * exp(-z / Lz),
+             u = 10.0,
+             enforce_mass_conservation = false)
+
+        time_step!(model, 0.5)
+
+        function shift_asymmetry(field)
+            f = Array(interior(field, :, 1, :))
+            return maximum(abs, f[1:shift, :] - f[shift+1:2shift, :]) / maximum(abs, f)
+        end
+
+        # Correct halos give bitwise invariance; the missing exchanges gave ~1e-4 relative. A
+        # trivial solution divides by zero and fails, so the checks have teeth.
+        @test shift_asymmetry(model.velocities.w) ≤ 1e-12
+        @test shift_asymmetry(model.velocities.u) ≤ 1e-12
+
+        # And the predictor exchange directly: its x halos must hold the periodic wrap, not the
+        # zeros the field was allocated with. Kept too — it pins the mechanism with no tolerance.
+        ρθ★ = model.timestepper.substepper.density_potential_temperature_predictor
+        @test all(ρθ★[0, 1, k] == ρθ★[Nx, 1, k] for k in 1:Nz)
+        @test all(ρθ★[Nx + 1, 1, k] == ρθ★[1, 1, k] for k in 1:Nz)
+    end
+
 end
 end


### PR DESCRIPTION
Two fields in the terrain acoustic path are written over interior cells and then read at `i±1`, so their halos held stale values: zeros on a stage's first substep, and always wrong at an internal partition boundary of a distributed grid.

- **Predictor `(ρθ)′★`** — `_build_vertical_rhs!` reads it through `∇ᶻp′`, whose terrain method adds the slope correction `slopeₓ·∂ₓ(Cᴸ(ρθ)′★) + slopeᵧ·∂ᵧ(Cᴸ(ρθ)′★)`. Both writers cover the interior only, so the exchange goes after `implicit_advection_substep!`. It is unconditional, matching every other fill in the loop: on a height-coordinate grid `∇ᶻp′` is a pure vertical difference, so nothing reads the filled halos and results stay bit-identical.
- **Tendencies `Gⁿρu`, `Gⁿρv`** — `_assemble_terrain_slow_vertical_momentum_tendency!` interpolates them to `(Center, Center, Face)`, reading face `Nx+1`/`Ny+1`, which the tendency kernels never write. Filled at this consumer, not the producer: `Gⁿρu` has three writers per RK3 stage and this is the last point before the substep loop.

## Test

Terrain and initial condition exactly invariant under a shift of `Nx/2` cells, so the discrete solution must be too (`mod(x, Lx/2)` on power-of-two centers makes the shifted arguments bitwise equal).

| | predictor west halo vs. interior wrap | relative shift asymmetry in `w` |
|---|---|---|
| before | `0.0` vs `1.654e-2` | `3.7e-4` |
| after | equal | `0.0` (bitwise) |

All four assertions fail on `main`. Verified: `terrain_following_split_explicit.jl` 516/516, Aqua 34/34, ExplicitImports 5/5, plus `terrain_following_latlon.jl` and `acoustic_substepping_components.jl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
